### PR TITLE
Python 3 compatibility: relative imports

### DIFF
--- a/docker/__init__.py
+++ b/docker/__init__.py
@@ -1,1 +1,1 @@
-from client import Client
+from .client import Client


### PR DESCRIPTION
In Python 3, this kind of import doesn't work any more. Relative imports have
to be explicit, as in this commit.
