### PR TITLE
Add docker.attach

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -197,7 +197,6 @@ class Client(requests.Session):
 
     def attach(self, container):
         params = {
-            'stdin': 1,
             'stdout': 1,
             'stderr': 1,
             'stream': 1


### PR DESCRIPTION
Adds the attach command

Usage:

```
for chunk in docker.Client().attach(container):
  print chunk
```

Probably not 100% correct as there may be content in the buffer and I suppose we should do something with stdin. But a good start 
