### PR TITLE
Make docker-py compatible with python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 build
 dist
 *.egg-info
+*.egg/
 *.pyc
+*.swp
 
+.tox

--- a/docker/client.py
+++ b/docker/client.py
@@ -1,8 +1,13 @@
 import json
 import logging
 import re
+import six
 import shlex
-from StringIO import StringIO
+
+if six.PY3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 import requests
 from requests.exceptions import HTTPError
@@ -43,7 +48,7 @@ class Client(requests.Session):
     def _container_config(self, image, command, hostname=None, user=None,
         detach=False, stdin_open=False, tty=False, mem_limit=0, ports=None,
         environment=None, dns=None, volumes=None, volumes_from=None):
-        if isinstance(command, basestring):
+        if isinstance(command, six.string_types):
             command = shlex.split(command)
         return {
             'Hostname':     hostname,
@@ -68,7 +73,7 @@ class Client(requests.Session):
         # so we do this disgusting thing here.
         data2 = {}
         if data is not None:
-            for k, v in data.iteritems():
+            for k, v in six.iteritems(data):
                 if v is not None:
                     data2[k] = v
 
@@ -180,7 +185,7 @@ class Client(requests.Session):
             'repo': repository,
             'tag': tag
         }
-        if type(src) == str or type(src) == unicode:
+        if isinstance(src, six.string_types):
             params['fromSrc'] = src
             return self._result(self.post(u, None, params=params))
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='0.0.5',
     description="Python client for Docker.",
     packages=['docker'],
-    install_requires=['requests'] + test_requirements,
+    install_requires=['requests', 'six'] + test_requirements,
     zip_safe=False,
     classifiers=['Development Status :: 3 - Alpha',
                  'Environment :: Other Environment',

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,5 @@
+import six
 import unittest
-import time
 
 import docker
 
@@ -66,7 +66,7 @@ class TestImages(BaseTestCase):
 class TestImageIds(BaseTestCase):
     def runTest(self):
         res1 = self.client.images(quiet=True)
-        self.assertEqual(type(res1[0]), unicode)
+        self.assertEqual(type(res1[0]), six.text_type)
 
 class TestListContainers(BaseTestCase):
     def runTest(self):
@@ -230,7 +230,7 @@ class TestPull(BaseTestCase):
         self.assertIn('Images', info)
         img_count = info['Images']
         res = self.client.pull('joffrey/test001')
-        self.assertEqual(type(res), unicode)
+        self.assertEqual(type(res), six.text_type)
         self.assertEqual(img_count + 2, self.client.info()['Images'])
         img_info = self.client.inspect_image('joffrey/test001')
         self.assertIn('id', img_info)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26, py27, py32, py33
+[testenv]
+commands =
+    {envpython} setup.py install
+    {envpython} tests/test.py


### PR DESCRIPTION
I've been playing with docker-py in a project of mine that is running under python 3.3 and I got a couple of exceptions. This PR adds `six` to make the code compatible with python 3.3. Since there were only a few places that needed changing I thought about not using `six` but working aroudn it. Especially for `iteritems` in line 76 this seemed quiet impractical and I think `six` is the right fit. Let me know if you think this is sensible or needs to be changed. 
