### PR TITLE
Fixed bug by which c.port('<id>', <port>) would fail

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -241,7 +241,7 @@ class Client(requests.Session):
     def port(self, container, private_port):
         res = self.get(self._url("/containers/{0}/json".format(container)))
         json_ = res.json()
-        return json_['NetworkSettings']['PortMapping'][private_port]
+        return json_['NetworkSettings']['PortMapping'][str(private_port)]
 
     def pull(self, repository, tag=None, registry=None):
         if repository.count(":") == 1:


### PR DESCRIPTION
e.g. 
c.port('e087bc23f8d5', 80)

would fail

and 
c.port('e087bc23f8d5', '80') would work. I now inserted str() so it should always work.
