### PR TITLE
Fixed python26 shlex split of unicode strings.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -34,7 +34,7 @@ class UnixHTTPConnection(httplib.HTTPConnection, object):
     def _extract_path(self, url):
         #remove the base_url entirely..
         return url.replace(self.base_url, "")
-        
+
     def request(self, method, url, **kwargs):
         url = self._extract_path(self.unix_socket)
         super(UnixHTTPConnection, self).request(method, url, **kwargs)
@@ -101,7 +101,7 @@ class Client(requests.Session):
         detach=False, stdin_open=False, tty=False, mem_limit=0, ports=None,
         environment=None, dns=None, volumes=None, volumes_from=None):
         if isinstance(command, six.string_types):
-            command = shlex.split(command)
+            command = shlex.split(str(command))
         return {
             'Hostname':     hostname,
             'PortSpecs':    ports,


### PR DESCRIPTION
```
Python 2.6.6 (r266:84292, Sep 11 2012, 08:34:23)
[GCC 4.4.6 20120305 (Red Hat 4.4.6-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import shlex
>>> cmd = u"/bin/bash echo 'Hello World'"
>>> shlex.split(cmd)
['/\x00\x00\x00b\x00\x00\x00i\x00\x00\x00n\x00\x00\x00/\x00\x00\x00b\x00\x00\x00a\x00\x00\x00s\x00\x00\x00h\x00\x00\x00',
'\x00\x00\x00e\x00\x00\x00c\x00\x00\x00h\x00\x00\x00o\x00\x00\x00',
'\x00\x00\x00\x00\x00\x00H\x00\x00\x00e\x00\x00\x00l\x00\x00\x00l\x00\x00\x00o\x00\x00\x00
\x00\x00\x00W\x00\x00\x00o\x00\x00\x00r\x00\x00\x00l\x00\x00\x00d\x00\x00\x00\x00\x00\x00']
>>> shlex.split(str(cmd))
['/bin/bash', 'echo', 'Hello World']
```
