### PR TITLE
fix tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = py26, py27, py32, py33
+skipsdist=True
 [testenv]
+usedevelop=True
 commands =
-    {envpython} setup.py install
     {envpython} tests/test.py
+
+deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Tox now uses the development client lib in the local repo instead
if using setup.py to install it into every environment. Also
added deps that points to requiremnts.txt so tox installs the needed
dependencies
