### PR TITLE
Remove custom error message for image 404

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -239,9 +239,6 @@ class Client(requests.Session):
     def create_container_from_config(self, config):
         u = self._url("/containers/create")
         res = self._post_json(u, config)
-        if res.status_code == 404:
-            self._raise_for_status(res, explanation="{0} is an unrecognized image. Please pull the "
-                "image first.".format(config['Image']))
         return self._result(res, True)
 
     def diff(self, container):


### PR DESCRIPTION
For reasons covered in the discussion on #38, I feel a custom error message is unnecessary. The default exception will contain the message from the server, which is explicit enough:

```
>>> d.create_container('ubuntu', 'bash')
{u'Id': u'7cad7baac3dc'}

>>> d.create_container('doesntexist', 'bash')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "docker/client.py", line 237, in create_container
    return self.create_container_from_config(config)
  File "docker/client.py", line 242, in create_container_from_config
    return self._result(res, True)
  File "docker/client.py", line 82, in _result
    self._raise_for_status(response)
  File "docker/client.py", line 79, in _raise_for_status
    raise APIError(e, response=response, explanation=explanation)
docker.client.APIError: 404 Client Error: Not Found ("No such image: doesntexist (tag: latest)")
```
