### PR TITLE
fix import ping function used when pushing an image

### DIFF
--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -1,1 +1,1 @@
-from .utils import mkbuildcontext, tar, compare_version  # flake8: noqa
+from .utils import mkbuildcontext, tar, compare_version, ping  # flake8: noqa


### PR DESCRIPTION
When calling `push` to a private repository, the following error is raised:

```
Traceback (most recent call last):
[...]
  File "/home/ubuntu/src/docker/docker/client.py", line 411, in push
    registry, repo_name = auth.resolve_repository_name(repository)
  File "/home/ubuntu/src/docker/docker/auth/auth.py", line 59, in resolve_repository_name
    return expand_registry_url(parts[0]), parts[1]
  File "/home/ubuntu/src/docker/docker/auth/auth.py", line 39, in expand_registry_url
    if utils.ping('https://' + hostname + '_ping'):
AttributeError: 'module' object has no attribute 'ping'
```
