### PR TITLE
Added example to the lxc_conf argument in the start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ dictionary whose key is the container's port and the value is a `[{'HostIp': ''
 all host interfaces.  By leaving the `HostPort` blank, Docker will
 automatically assign a port.  For example: `port_bindings={"2181/tcp": [{'HostIp': ''
 'HostPort': ''}]}`.
-`lxc_conf` allows to pass LXC configuration options in dict form.
+`lxc_conf` allows to pass LXC configuration options using a dictionary in the form of Key Value pairs.
+For example: `lxc_conf=[{"Key":"lxc.cgroup.cpu.shares","Value":"1"}, {"Key": ..., "Value": }]`.
 
 * `c.stop(container, timeout=10)`  
 Stops a container. Similar to the `docker stop` command.


### PR DESCRIPTION
Clarifies documentation for the `lxc_conf` argument in the `start` command. The documentation says the parameter is a dict; however, it requires a specific syntax such as:

```
[{"Key":"lxc.cgroup.cpu.shares","Value":"1"}, {"Key": ..., "Value": }]`
```

Related to dotcloud/docker-py#79
