### PR TITLE
Client: Add response to the ApiError Exception class

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -35,6 +35,7 @@ class APIError(requests.exceptions.HTTPError):
     def __init__(self, message, response, explanation=None):
         super(APIError, self).__init__(message, response)
 
+        self.response = response
         self.explanation = explanation
 
         if self.explanation is None and response.content:


### PR DESCRIPTION
Currently the exception fails in the **str** method because if tries to check the status of self.response, which is not assigned. This fix ensures self.response is set so the check for self.response.status_code can be performed.

I couldn't find any CLA to sign, let me know if this is required.
