### PR TITLE
Fix readme.md documentation for the 'volume' arg in create_container

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Creates a container that can then be `start`ed. Parameters are similar to those
 for the `docker run` command except it doesn't support the attach options
 (`-a`)  
 In order to create volumes that can be rebinded at start time, use the
-following syntax: `volumes={"/srv": {} }`.   The `ports` parameter is a
+following syntax: `volumes={"/srv": {}}`.   The `ports` parameter is a
 dictionary whose key is the port to expose and the value is an empty
 dictionary: `ports={"2181/tcp": {}}`.  Note, this will simply expose the ports in
 the container, but does not make them available on the host.  See `start`


### PR DESCRIPTION
Readme.md mentions that creating a volume which can be rebound later is done via `volumes={"/some/mount/point": ""}`. This is incorrect, and doing so will cause the following error to be returned by the Remote API:

```
500 Server Error: Internal Server Error ("create: ExportEnv json: cannot unmarshal string into Go value of type struct {}")
```

The correct syntax is `volumes={"/some/mount/point": {}}`.
