### PR TITLE
Fix _stream_helper

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -199,20 +199,15 @@ class Client(requests.Session):
         return websocket.create_connection(url)
 
     def _stream_helper(self, response):
-        socket = self._stream_result_socket(response)
+        socket = self._stream_result_socket(response).makefile()
         while True:
-            chunk = socket.recv(4096)
-            if chunk:
-                parts = chunk.strip().split('\r\n')
-                for i in range(len(parts)):
-                    if i % 2 != 0:
-                        yield parts[i] + '\n'
-                    else:
-                        size = int(parts[i], 16)
-                if size <= 0:
-                    break
-            else:
+            size = int(socket.readline(), 16)
+            if size <= 0:
                 break
+            data = socket.readline()
+            if not data:
+                break
+            yield data
 
     def attach(self, container):
         socket = self.attach_socket(container)


### PR DESCRIPTION
The stream helper that yields the streamed status for push, pull and
build operations was reading data in chunks of 4096 bytes but didn't
support buffering and thus didn't behave well when more than 4096 bytes
were received at once from the socket.

This implementation uses makefile() to get a file object from the socket
on which we can use readline() so we can read line by line the
chunked-encoding data streamed to us by the Docker daemon.

Signed-off-by: Maxime Petazzoni max@signalfuse.com
