### PR TITLE
Fix infinite loop in Client.logs(stream=True) caused by connection close...

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -260,6 +260,9 @@ class Client(requests.Session):
             data = ''
             while size > 0:
                 block = socket.recv(size)
+                if not block:
+                    return None
+
                 data += block
                 size -= len(block)
             return data
@@ -272,7 +275,11 @@ class Client(requests.Session):
             _, length = struct.unpack('>BxxxL', header)
             if not length:
                 break
-            yield recvall(socket, length).rstrip()
+            data = recvall(socket, length)
+            if data:
+                yield data
+            else:
+                break
 
     def attach(self, container):
         socket = self.attach_socket(container)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -274,6 +274,23 @@ class TestLogs(BaseTestCase):
         logs = self.client.logs(id)
         self.assertEqual(logs, snippet + '\n')
 
+class TestLogsStreaming(BaseTestCase):
+    def runTest(self):
+        snippet = 'Flowering Nights (Sakuya Iyazoi)'
+        container = self.client.create_container(
+            'busybox', 'echo {0}'.format(snippet)
+        )
+        id = container['Id']
+        self.client.start(id)
+        self.tmp_containers.append(id)
+        logs = ''
+        for chunk in self.client.logs(id, stream=True):
+            logs += chunk
+
+        exitcode = self.client.wait(id)
+        self.assertEqual(exitcode, 0)
+
+        self.assertEqual(logs, snippet + '\n')
 
 class TestLogsWithDictInsteadOfId(BaseTestCase):
     def runTest(self):


### PR DESCRIPTION
socker.recv() in function recvall() returns empty string when connection is closed. This causes infinite loop.
