### PR TITLE
"six" dependency fixed to greater-or-equal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock==1.0.1
 requests==1.2.3
-six==1.3.0
+six>=1.3.0
 websocket-client==0.11.0


### PR DESCRIPTION
Updated old strict six==1.3.0 dependency version

Issue #130
