### PR TITLE
A socket that is wrapped in a file-like object must be set to blocking.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -227,7 +227,9 @@ class Client(requests.Session):
 
     def _stream_helper(self, response):
         """Generator for data coming from a chunked-encoded HTTP response."""
-        socket = self._stream_result_socket(response).makefile()
+        socket_fp = self._stream_result_socket(response)
+        socket_fp.setblocking(1)
+        socket = socket_fp.makefile()
         while True:
             size = int(socket.readline(), 16)
             if size <= 0:


### PR DESCRIPTION
fixes #124

The python documentation mentions that the socket mode must be set to blocking when wrapped in a file interface with makefile(). For example, here: http://bugs.python.org/issue7322

This change resolves the issue on push for me.
