### PR TITLE
Pass through port binding dict

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -78,7 +78,7 @@ def _convert_port_binding(binding):
     if result['HostPort'] is None:
         result['HostPort'] = ''
     else:
-        result['HostPort'] = str(result['HostPort'])
+        result['HostPort'] = str(int(result['HostPort']))
 
     return result
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,41 @@
+import unittest
+
+from docker.utils import convert_port_bindings
+
+class UtilsTest(unittest.TestCase):
+    def test_convert_port_binding_with_dict(self):
+        """
+        Ensure the port binding raises an exception if the value is clearly unexpected
+        """
+        binding = [{
+            'HostIp': '0.0.0.0',
+            'HostPort': '4000',
+        }]
+
+        bindings = {
+            '80': binding,
+        }
+
+        self.assertRaises(TypeError, convert_port_bindings, bindings)
+
+    def test_convert_port_binding_with_non_int_string(self):
+        """
+        Ensure the port binding raises an exception if the value is clearly unexpected
+        """
+        binding = ['hi']
+
+        bindings = {
+            '80': binding,
+        }
+
+        self.assertRaises(ValueError, convert_port_bindings, bindings)
+
+    def test_convert_port_binding_just_port_number(self):
+        binding = '4000'
+        bindings = {
+            '80': binding,
+        }
+
+        converted = convert_port_bindings(bindings)
+
+        self.assertEqual(binding, converted.values()[0][0]['HostPort'])


### PR DESCRIPTION
Upon upgrading docker and docker-py my code stopped working because I was passing the port bindings as a properly formatted list of dict objects.  This patch re-allows passing the ports in the already-correct format.

Please let me know if this is a good fix and/or if it needs some tweaks.

Thanks!
