### PR TITLE
container_output() method for streaming the output without logs=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ Identical to the `docker logs` command. The `stream` parameter makes the
 retrieve log output as it happens.
 
 ```python
+c.attach(container, stdout=True, stderr=True, stream=False, logs=False)
+```
+
+The `logs` function is a wrapper around this one, which you can use
+instead if you want to fetch/stream container output without first
+retrieving the entire backlog.
+
+```python
 c.port(container, private_port)
 ```
 


### PR DESCRIPTION
I need to stream a container's output, _with_ the parsing/processing of frames, but _without_ the backlog. The `logs` method seems to be the only one that does that processing, so I've extracted the body of `logs` and added a parameter. `logs` just calls `container_output` with `logs=True`.

The semantics of `logs` vs `attach` is perhaps getting a bit confusing, and there's some repetition - I wonder if it can all be simplified somehow.
