### PR TITLE
Configurable timeout on build(), defaults to None

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -332,7 +332,12 @@ class Client(requests.Session):
             headers = {'Content-Type': 'application/tar'}
 
         response = self._post(
-            u, data=context, params=params, headers=headers, stream=stream, timeout=timeout
+            u,
+            data=context,
+            params=params,
+            headers=headers,
+            stream=stream,
+            timeout=timeout,
         )
 
         if context is not None:


### PR DESCRIPTION
Many commands used in Dockerfiles hang for an extended period of time without producing any output, which will result in a socket timeout. Accordingly, it makes sense for `build()` to specify no timeout by default.
