### PR TITLE
Sensible url handling

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -65,9 +65,11 @@ class APIError(requests.exceptions.HTTPError):
 
 
 class Client(requests.Session):
-    def __init__(self, base_url="unix://var/run/docker.sock", version="1.6",
+    def __init__(self, base_url=None, version="1.6",
                  timeout=DEFAULT_TIMEOUT_SECONDS):
         super(Client, self).__init__()
+        if base_url is None:
+            base_url = "unix://var/run/docker.sock"
         if base_url.startswith('unix:///'):
             base_url = base_url.replace('unix:/', 'unix:')
         if base_url.startswith('tcp:'):


### PR DESCRIPTION
Now that the Docker client supports setting the daemon URL via the `DOCKER_HOST` environment variable, it'd be nice to be able to get the same behaviour from docker-py. I'm a bit wary of libraries that configure themselves using magic globals, so I haven't baked in direct reading of `os.environ`, but next best thing:

``` python
import os
from docker import Client
client = Client(os.environ.get('DOCKER_HOST'))
```

I think that's a good application of "explicit is better than implicit".

The actual changes I've made:
- `tcp://` urls are converted to `http://`
- `None` is converted to `unix://var/run/docker.sock`
