### PR TITLE
Use relative imports

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -19,7 +19,7 @@ import os
 
 import six
 
-import docker.utils as utils
+from ..utils import utils
 
 INDEX_URL = 'https://index.docker.io/v1/'
 DOCKER_CONFIG_FILENAME = '.dockercfg'

--- a/docker/client.py
+++ b/docker/client.py
@@ -21,9 +21,9 @@ import requests
 import requests.exceptions
 import six
 
-import docker.auth as auth
-import docker.unixconn as unixconn
-import docker.utils as utils
+from .auth import auth
+from .unixconn import unixconn
+from .utils import utils
 
 if not six.PY3:
     import websocket


### PR DESCRIPTION
Just a small thing - makes vendoring docker-py possible, in contexts where that's useful.
