### PR TITLE
Default to /tcp for port definitions in create_container()

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -134,15 +134,12 @@ class Client(requests.Session):
             exposed_ports = {}
             for port_definition in ports:
                 port = port_definition
-                proto = None
+                proto = 'tcp'
                 if isinstance(port_definition, tuple):
                     if len(port_definition) == 2:
                         proto = port_definition[1]
                     port = port_definition[0]
-                exposed_ports['{0}{1}'.format(
-                    port,
-                    '/' + proto if proto else ''
-                )] = {}
+                exposed_ports['{0}/{1}'.format(port, proto)] = {}
             ports = exposed_ports
 
         if volumes and isinstance(volumes, list):

--- a/tests/test.py
+++ b/tests/test.py
@@ -223,9 +223,9 @@ class DockerClientTest(unittest.TestCase):
                             {"Tty": false, "Image": "busybox",
                              "Cmd": ["ls"], "AttachStdin": false,
                              "Memory": 0, "ExposedPorts": {
-                                "1111": {},
+                                "1111/tcp": {},
                                 "2222/udp": {},
-                                "3333": {}
+                                "3333/tcp": {}
                              },
                              "AttachStderr": true,
                              "AttachStdout": true, "OpenStdin": false,


### PR DESCRIPTION
Fixes #141.

Signed-off-by: Maxime Petazzoni max@signalfuse.com
