### PR TITLE
If attaching to stdin, set StdinOnce, as per the docker CLI.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -152,6 +152,7 @@ class Client(requests.Session):
         attach_stdin = False
         attach_stdout = False
         attach_stderr = False
+        stdin_once = False
 
         if not detach:
             attach_stdout = True
@@ -159,6 +160,7 @@ class Client(requests.Session):
 
             if stdin_open:
                 attach_stdin = True
+                stdin_once = True
 
         return {
             'Hostname':     hostname,
@@ -166,6 +168,7 @@ class Client(requests.Session):
             'User':         user,
             'Tty':          tty,
             'OpenStdin':    stdin_open,
+            'StdinOnce':    stdin_once,
             'Memory':       mem_limit,
             'AttachStdin':  attach_stdin,
             'AttachStdout': attach_stdout,

--- a/tests/test.py
+++ b/tests/test.py
@@ -176,6 +176,7 @@ class DockerClientTest(unittest.TestCase):
                             {"Tty": false, "Image": "busybox", "Cmd": ["true"],
                              "AttachStdin": false, "Memory": 0,
                              "AttachStderr": true, "AttachStdout": true,
+                             "StdinOnce": false,
                              "OpenStdin": false, "NetworkDisabled": false}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
@@ -200,6 +201,7 @@ class DockerClientTest(unittest.TestCase):
                              "Volumes": {"/mnt": {}}, "Memory": 0,
                              "AttachStderr": true,
                              "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
                              "NetworkDisabled": false}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
@@ -225,6 +227,7 @@ class DockerClientTest(unittest.TestCase):
                              },
                              "AttachStderr": true,
                              "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
                              "NetworkDisabled": false}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
@@ -246,6 +249,7 @@ class DockerClientTest(unittest.TestCase):
                              "Memory": 0,
                              "AttachStderr": true,
                              "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
                              "NetworkDisabled": false,
                              "Entrypoint": "cowsay"}'''))
         self.assertEqual(args[1]['headers'],
@@ -268,6 +272,7 @@ class DockerClientTest(unittest.TestCase):
                              "Memory": 0,
                              "AttachStderr": true,
                              "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
                              "NetworkDisabled": false,
                              "CpuShares": 5}'''))
         self.assertEqual(args[1]['headers'],
@@ -290,8 +295,28 @@ class DockerClientTest(unittest.TestCase):
                              "Memory": 0,
                              "AttachStderr": true,
                              "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
                              "NetworkDisabled": false,
                              "WorkingDir": "/root"}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
+    def test_create_container_with_stdin_open(self):
+        try:
+            self.client.create_container('busybox', 'true', stdin_open=True)
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][0],
+                         'unix://var/run/docker.sock/v1.6/containers/create')
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox", "Cmd": ["true"],
+                             "AttachStdin": true, "Memory": 0,
+                             "AttachStderr": true, "AttachStdout": true,
+                             "StdinOnce": true,
+                             "OpenStdin": true, "NetworkDisabled": false}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 
@@ -310,6 +335,7 @@ class DockerClientTest(unittest.TestCase):
                             {"Tty": false, "Image": "busybox", "Cmd": ["true"],
                              "AttachStdin": false, "Memory": 0,
                              "AttachStderr": true, "AttachStdout": true,
+                             "StdinOnce": false,
                              "OpenStdin": false, "NetworkDisabled": false}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})


### PR DESCRIPTION
See [lines 1943-1946 in commands.go](https://github.com/dotcloud/docker/blob/fb981bdace66e5b34d41125beb16e450998fd1e7/commands.go#L1943-L1946).
