### PR TITLE
fix "binds" docs: { host_dir: docker_dir }

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Volume mappings are then declared inside the `Client.start` method like this:
 
 ```python
 c.start(container_id, binds={
-    '/mnt/vol2': '/home/user1/',
-    '/mnt/vol1': '/var/www'
+    '/home/user1/': '/mnt/vol2',
+    '/var/www': '/mnt/vol1'
 })
 ```


### PR DESCRIPTION
Not the other way around.
