### PR TITLE
Allow copy() to accept dictionary like diff()

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -403,6 +403,8 @@ class Client(requests.Session):
         return res
 
     def copy(self, container, resource):
+        if isinstance(container, dict):
+            container = container.get('Id')
         res = self._post_json(
             self._url("/containers/{0}/copy".format(container)),
             data={"Resource": resource},


### PR DESCRIPTION
Client.diff() silently convert container as a dictionary
to container['Id'] while Client.copy() does not.

This change makes copy() do the same job.
