### PR TITLE
handle APIError for inspect_image

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -537,10 +537,13 @@ class Client(requests.Session):
             True)
 
     def inspect_image(self, image_id):
-        return self._result(
-            self._get(self._url("/images/{0}/json".format(image_id))),
-            True
-        )
+        try:
+            return self._result(
+                self._get(self._url("/images/{0}/json".format(image_id))),
+                True
+            )
+        except APIError:
+            print("No such image: {0}".format(image_id))
 
     def kill(self, container, signal=None):
         if isinstance(container, dict):


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Lokesh Mandvekar lsm5@redhat.com (github: lsm5)

```
modified:   docker/client.py
```

This is with reference to cstpierre's comment here: https://admin.fedoraproject.org/updates/FEDORA-EPEL-2014-0490/python-docker-py-0.2.3-7.el6
