### PR TITLE
Fix APIError for requests 1.1

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -35,7 +35,10 @@ STREAM_HEADER_SIZE_BYTES = 8
 
 class APIError(requests.exceptions.HTTPError):
     def __init__(self, message, response, explanation=None):
-        super(APIError, self).__init__(message, response=response)
+        # requests 1.2 supports response as a keyword argument, but
+        # requests 1.1 doesn't
+        super(APIError, self).__init__(message)
+        self.response = response
 
         self.explanation = explanation
 


### PR DESCRIPTION
requests 1.1, which is what's available on CentOS 6, doesn't support passing the response code as a keyword argument.  It can be set after the fact on both requests 1.1 and 1.2.

This obsoletes #164.
