### PR TITLE
add __title__ and __version__ variables to module

### DIFF
--- a/docker/__init__.py
+++ b/docker/__init__.py
@@ -12,4 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+__title__ = 'docker-py'
+__version__ = '0.3.0'
+
 from .client import Client, APIError  # flake8: noqa


### PR DESCRIPTION
With 0.3.0 introducing some backwards-incompatible changes, it'd be nice to add a `__version__` variable to the module that will allow upstream tools that depend on docker-py to know which version they're working with. Also added a `__title__` variable while we're there.
