### PR TITLE
parse_repository_tag function and accompanying test

### DIFF
--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -1,1 +1,1 @@
-from .utils import compare_version, mkbuildcontext, ping, tar  # flake8: noqa
+from .utils import compare_version, mkbuildcontext, ping, tar, parse_repository_tag  # flake8: noqa

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -60,3 +60,15 @@ def ping(url):
         return res.status >= 400
     except Exception:
         return False
+
+
+def parse_repository_tag(repo):
+    column_index = repo.rfind(':')
+    if column_index < 0:
+        return repo, ""
+    tag = repo[column_index+1:]
+    slash_index = tag.find('/')
+    if slash_index < 0:
+        return repo[:column_index], tag
+
+    return repo, ""

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,18 @@
+import unittest
+
+from docker.utils import parse_repository_tag
+
+
+class UtilsTest(unittest.TestCase):
+
+    def test_parse_repository_tag(self):
+        self.assertEqual(parse_repository_tag("root"), ("root", ""))
+        self.assertEqual(parse_repository_tag("root:tag"), ("root", "tag"))
+        self.assertEqual(parse_repository_tag("user/repo"), ("user/repo", ""))
+        self.assertEqual(parse_repository_tag("user/repo:tag"), ("user/repo", "tag"))
+        self.assertEqual(parse_repository_tag("url:5000/repo"), ("url:5000/repo", ""))
+        self.assertEqual(parse_repository_tag("url:5000/repo:tag"), ("url:5000/repo", "tag"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This function exists in a go code and is being used by the docker client to pull image if it doesn't exist. I needed the same functionality on the python side, hence this pull request.
