### PR TITLE
Use different requirements list on Python 2 and 3 (fixes #174)

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,0 +1,4 @@
+mock==1.0.1
+requests==2.2.1
+six>=1.3.0
+websocket-client==0.11.0

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python
 import os
+import sys
 from setuptools import setup
 
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
+if sys.version_info[0] == 3:
+    requirements_file = './requirements3.txt'
+else:
+    requirements_file = './requirements.txt'
+
 test_requirements = []
-with open('./requirements.txt') as requirements_txt:
+with open(requirements_file) as requirements_txt:
     requirements = [line for line in requirements_txt]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,23 @@
 envlist = py26, py27, py32, py33, flake8
 skipsdist=True
 
-[testenv]
+[testenv:py26]
 usedevelop=True
 commands =
     {envpython} tests/test.py
 deps = -r{toxinidir}/requirements.txt
+
+[testenv:py27]
+usedevelop=True
+commands =
+    {envpython} tests/test.py
+deps = -r{toxinidir}/requirements.txt
+
+[testenv]
+usedevelop=True
+commands =
+    {envpython} tests/test.py
+deps = -r{toxinidir}/requirements3.txt
 
 [testenv:flake8]
 commands = flake8 docker tests


### PR DESCRIPTION
In Python 3 websocker-client not required (and previously requiested
version doesn't work at all).
