### PR TITLE
Use Requests.iter_lines to fix #176

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -233,17 +233,8 @@ class Client(requests.Session):
 
     def _stream_helper(self, response):
         """Generator for data coming from a chunked-encoded HTTP response."""
-        socket_fp = self._get_raw_response_socket(response)
-        socket_fp.setblocking(1)
-        socket = socket_fp.makefile()
-        while True:
-            size = int(socket.readline(), 16)
-            if size <= 0:
-                break
-            data = socket.readline()
-            if not data:
-                break
-            yield data
+        for line in response.iter_lines(chunk_size=32):
+            yield line
 
     def _multiplexed_buffer_helper(self, response):
         """A generator of multiplexed data blocks read from a buffered


### PR DESCRIPTION
Two changes are made in the PR.
1. Switch to Requests.iter_lines() so that chunks are read properly.  Docker 0.9.x introduced newlines into the streamed responses which surfaced a bug in docker-py in which it wasn't properly reading the HTTP chunked data.
2. If the version of the API is >= 1.8 ensure that the stream=True parameter is sent to requests.

No tests are added in this PR because the existing integration tests were already failing against 0.9.0.  This PR makes all integration tests succeed again.

Fixes https://github.com/dotcloud/docker-py/issues/176
