### PR TITLE
Fixes for flake8

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -48,7 +48,7 @@ def resolve_repository_name(repo_name):
         raise ValueError('Repository name cannot contain a '
                          'scheme ({0})'.format(repo_name))
     parts = repo_name.split('/', 1)
-    if not '.' in parts[0] and not ':' in parts[0] and parts[0] != 'localhost':
+    if '.' not in parts[0] and ':' not in parts[0] and parts[0] != 'localhost':
         # This is a docker index repo (ex: foo/bar or ubuntu)
         return INDEX_URL, repo_name
     if len(parts) < 2:

--- a/docker/unixconn/unixconn.py
+++ b/docker/unixconn/unixconn.py
@@ -40,7 +40,7 @@ class UnixHTTPConnection(httplib.HTTPConnection, object):
         self.sock = sock
 
     def _extract_path(self, url):
-        #remove the base_url entirely..
+        # remove the base_url entirely..
         return url.replace(self.base_url, "")
 
     def request(self, method, url, **kwargs):

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -24,8 +24,8 @@ FAKE_FILE_NAME = 'file'
 FAKE_URL = 'myurl'
 FAKE_PATH = '/path'
 
-### Each method is prefixed with HTTP method (get, post...)
-### for clarity and readability
+# Each method is prefixed with HTTP method (get, post...)
+# for clarity and readability
 
 
 def get_fake_version():
@@ -278,7 +278,7 @@ def post_fake_tag_image():
     return status_code, response
 
 
-## maps real api url to fake response callback
+# Maps real api url to fake response callback
 prefix = 'http+unix://var/run/docker.sock'
 fake_responses = {
     '{1}/{0}/version'.format(CURRENT_VERSION, prefix):

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -51,7 +51,7 @@ class BaseTestCase(unittest.TestCase):
                 pass
 
 #########################
-##  INFORMATION TESTS  ##
+#   INFORMATION TESTS   #
 #########################
 
 
@@ -80,7 +80,7 @@ class TestSearch(BaseTestCase):
         self.assertIn('description', base_img[0])
 
 ###################
-## LISTING TESTS ##
+#  LISTING TESTS  #
 ###################
 
 
@@ -124,7 +124,7 @@ class TestListContainers(BaseTestCase):
         self.assertIn('Status', retrieved)
 
 #####################
-## CONTAINER TESTS ##
+#  CONTAINER TESTS  #
 #####################
 
 
@@ -434,7 +434,7 @@ class TestPort(BaseTestCase):
 
         self.client.start(container, port_bindings=port_bindings)
 
-        #Call the port function on each biding and compare expected vs actual
+        # Call the port function on each biding and compare expected vs actual
         for port in port_bindings:
             actual_bindings = self.client.port(container, port)
             port_binding = actual_bindings.pop()
@@ -561,7 +561,7 @@ class TestStartContainerWithLinks(BaseTestCase):
         self.assertIn('{0}_ENV_FOO=1'.format(link_env_prefix2), logs)
 
 #################
-## LINKS TESTS ##
+#  LINKS TESTS  #
 #################
 
 
@@ -602,7 +602,7 @@ class TestRemoveLink(BaseTestCase):
         self.assertEqual(len(retrieved), 2)
 
 ##################
-## IMAGES TESTS ##
+#  IMAGES TESTS  #
 ##################
 
 
@@ -756,7 +756,7 @@ class TestBuildFromStringIO(BaseTestCase):
 
 
 #######################
-## PY SPECIFIC TESTS ##
+#  PY SPECIFIC TESTS  #
 #######################
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -68,7 +68,7 @@ class DockerClientTest(unittest.TestCase):
         self.client._cfg = {'Configs': {}}
 
     #########################
-    ##  INFORMATION TESTS  ##
+    #   INFORMATION TESTS   #
     #########################
     def test_version(self):
         try:
@@ -112,7 +112,7 @@ class DockerClientTest(unittest.TestCase):
             pass
 
     ###################
-    ## LISTING TESTS ##
+    #  LISTING TESTS  #
     ###################
 
     def test_images(self):
@@ -168,7 +168,7 @@ class DockerClientTest(unittest.TestCase):
         )
 
     #####################
-    ## CONTAINER TESTS ##
+    #  CONTAINER TESTS  #
     #####################
 
     def test_create_container(self):
@@ -192,7 +192,6 @@ class DockerClientTest(unittest.TestCase):
 
     def test_create_container_with_binds(self):
         mount_dest = '/mnt'
-        #mount_origin = '/tmp'
 
         try:
             self.client.create_container('busybox', ['ls', mount_dest],
@@ -905,7 +904,7 @@ class DockerClientTest(unittest.TestCase):
         )
 
     ##################
-    ## IMAGES TESTS ##
+    #  IMAGES TESTS  #
     ##################
 
     def test_pull(self):
@@ -1192,7 +1191,7 @@ class DockerClientTest(unittest.TestCase):
             self.fail('Command should not raise exception: {0}'.format(e))
 
     #######################
-    ## PY SPECIFIC TESTS ##
+    #  PY SPECIFIC TESTS  #
     #######################
 
     def test_load_config_no_file(self):


### PR DESCRIPTION
Next rules were broken
- E265 block comment should start with '# '
- E713 test for membership should be 'not in'

Version of flake8 - 2.1.0 (pep8: 1.5.1, mccabe: 0.2.1, pyflakes: 0.8) CPython 2.7.3 on Linux
