### PR TITLE
don't yield blank lines

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -234,7 +234,8 @@ class Client(requests.Session):
     def _stream_helper(self, response):
         """Generator for data coming from a chunked-encoded HTTP response."""
         for line in response.iter_lines(chunk_size=32):
-            yield line
+            if line:
+                yield line
 
     def _multiplexed_buffer_helper(self, response):
         """A generator of multiplexed data blocks read from a buffered


### PR DESCRIPTION
`docker.Client._stream_helper()` will currently yield blank lines, where `docker.Client._multiplexed_socket_stream_helper()` and `stream_result()` (in `docker.Client.attach()`) will not.  This causes problems when parsing the stream incrementally (e.g. in Ansible's `docker_image`, see ansible/ansible#6767 - see output below).

Seems reasonable to make this behavior consistent, but let me know if allowing blank lines is desirable.

Ansible output:

```
fatal: [dockerctl] => failed to parse: chunk: {"stream":"Step 0 : FROM ubuntu:precise\n"}
chunk: {"stream":" ---\u003e 9cd978db300e\n"}
chunk: {"stream":"Step 1 : MAINTAINER Matt Way \u003cxx@xxxx.xx\u003e\n"}
chunk: {"stream":" ---\u003e Running in 11a93e0d62ca\n"}
chunk: {"stream":" ---\u003e 6634576c0a6a\n"}
chunk: {"stream":"Step 2 : RUN locale-gen en_US.UTF-8\n"}
chunk: {"stream":" ---\u003e Running in e10cf0cac661\n"}
chunk: {"stream":"Generating locales...\n"}
chunk:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1396208911.87-244473107486548/docker_image", line 1331, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1396208911.87-244473107486548/docker_image", line 221, in main
    image_id = manager.build()
  File "/root/.ansible/tmp/ansible-tmp-1396208911.87-244473107486548/docker_image", line 144, in build
    chunk_json = json.loads(chunk)
  File "/usr/lib/python2.7/json/__init__.py", line 326, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```
