### PR TITLE
Added support for the same DOCKER_HOST environment variable the official Docker client uses

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import json
+import os
 import re
 import shlex
 import struct
@@ -39,7 +40,8 @@ class Client(requests.Session):
                  timeout=DEFAULT_TIMEOUT_SECONDS):
         super(Client, self).__init__()
         if base_url is None:
-            base_url = "http+unix://var/run/docker.sock"
+            base_url = os.getenv('DOCKER_HOST',
+                                 'http+unix://var/run/docker.sock')
         if 'unix:///' in base_url:
             base_url = base_url.replace('unix:/', 'unix:')
         if base_url.startswith('unix:'):


### PR DESCRIPTION
For an example case where this is useful, imagine I'm using an application which uses docker-py, but doesn't offer a flag for me to control the `base_url` it tries to connect to.  If I run my Docker on a separate host or on a non-standard socket path, then without this change I have to actually modify the source code of the application I'm using.  With this change, everything can "just work" if I set the `DOCKER_HOST` variable correctly, just like the Docker client itself does. :)
