### PR TITLE
add timeout options to commit and push

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -652,16 +652,26 @@ class Client(requests.Session):
         return stream and self._stream_helper(response) \
             or self._result(response)
 
-    def remove_container(self, container, v=False, link=False):
+    def remove_container(self, container, v=False, link=False, **kwargs):
+        # we do this because when timeout=None, we want to pass in None
+        if 'timeout' in kwargs:
+            timeout = kwargs['timeout']
+        else:
+            timeout = self._timeout
         if isinstance(container, dict):
             container = container.get('Id')
         params = {'v': v, 'link': link}
         res = self._delete(self._url("/containers/" + container),
-                           params=params)
+                           params=params, timeout=timeout)
         self._raise_for_status(res)
 
-    def remove_image(self, image):
-        res = self._delete(self._url("/images/" + image))
+    def remove_image(self, image, **kwargs):
+        # we do this because when timeout=None, we want to pass in None
+        if 'timeout' in kwargs:
+            timeout = kwargs['timeout']
+        else:
+            timeout = self._timeout
+        res = self._delete(self._url("/images/" + image), timeout=timeout)
         self._raise_for_status(res)
 
     def restart(self, container, timeout=10):


### PR DESCRIPTION
I committed a container after a big change and tried to push it to my private repository. Since it was such a big change, it took too long to commit, push and remove so docker-py kept timing out. So I added 'timeout' options to these functions (commit, push, remove_container and remove_image).
