### PR TITLE
Fix joining of unicode and byte strings in python3

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -250,7 +250,7 @@ class Client(requests.Session):
             start = walker + STREAM_HEADER_SIZE_BYTES
             end = start + length
             walker = end
-            yield str(buf[start:end])
+            yield buf[start:end]
 
     def _multiplexed_socket_stream_helper(self, response):
         """A generator of multiplexed data blocks coming from a response
@@ -311,8 +311,10 @@ class Client(requests.Session):
             return stream_result() if stream else \
                 self._result(response, binary=True)
 
+        sep = bytes() if six.PY3 else str()
+
         return stream and self._multiplexed_socket_stream_helper(response) or \
-            ''.join([x for x in self._multiplexed_buffer_helper(response)])
+            sep.join([x for x in self._multiplexed_buffer_helper(response)])
 
     def attach_socket(self, container, params=None, ws=False):
         if params is None:

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -202,7 +202,8 @@ def get_fake_wait():
 
 def get_fake_logs():
     status_code = 200
-    response = 'Flowering Nights (Sakuya Iyazoi)'
+    response = (b'\x01\x00\x00\x00\x00\x00\x00\x11Flowering Nights\n'
+                b'\x01\x00\x00\x00\x00\x00\x00\x10(Sakuya Iyazoi)\n')
     return status_code, response
 
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -278,7 +278,7 @@ class TestLogs(BaseTestCase):
         exitcode = self.client.wait(id)
         self.assertEqual(exitcode, 0)
         logs = self.client.logs(id)
-        self.assertEqual(logs, snippet + '\n')
+        self.assertEqual(logs, (snippet + '\n').encode(encoding='ascii'))
 
 
 class TestLogsStreaming(BaseTestCase):
@@ -290,14 +290,14 @@ class TestLogsStreaming(BaseTestCase):
         id = container['Id']
         self.client.start(id)
         self.tmp_containers.append(id)
-        logs = ''
+        logs = bytes() if six.PY3 else str()
         for chunk in self.client.logs(id, stream=True):
             logs += chunk
 
         exitcode = self.client.wait(id)
         self.assertEqual(exitcode, 0)
 
-        self.assertEqual(logs, snippet + '\n')
+        self.assertEqual(logs, (snippet + '\n').encode(encoding='ascii'))
 
 
 class TestLogsWithDictInsteadOfId(BaseTestCase):
@@ -312,7 +312,7 @@ class TestLogsWithDictInsteadOfId(BaseTestCase):
         exitcode = self.client.wait(id)
         self.assertEqual(exitcode, 0)
         logs = self.client.logs(container)
-        self.assertEqual(logs, snippet + '\n')
+        self.assertEqual(logs, (snippet + '\n').encode(encoding='ascii'))
 
 
 class TestDiff(BaseTestCase):

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,10 +39,8 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
              request=None):
     res = requests.Response()
     res.status_code = status_code
-    if not isinstance(content, six.string_types):
-        content = json.dumps(content)
-    if six.PY3:
-        content = content.encode('ascii')
+    if not isinstance(content, six.binary_type):
+        content = json.dumps(content).encode('ascii')
     res._content = content
     res.headers = requests.structures.CaseInsensitiveDict(headers or {})
     res.reason = reason
@@ -737,7 +735,7 @@ class DockerClientTest(unittest.TestCase):
 
     def test_logs(self):
         try:
-            self.client.logs(fake_api.FAKE_CONTAINER_ID)
+            logs = self.client.logs(fake_api.FAKE_CONTAINER_ID)
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
@@ -748,9 +746,14 @@ class DockerClientTest(unittest.TestCase):
             stream=False
         )
 
+        self.assertEqual(
+            logs,
+            'Flowering Nights\n(Sakuya Iyazoi)\n'.encode('ascii')
+        )
+
     def test_logs_with_dict_instead_of_id(self):
         try:
-            self.client.logs({'Id': fake_api.FAKE_CONTAINER_ID})
+            logs = self.client.logs({'Id': fake_api.FAKE_CONTAINER_ID})
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
@@ -759,6 +762,11 @@ class DockerClientTest(unittest.TestCase):
             params={'stream': 0, 'logs': 1, 'stderr': 1, 'stdout': 1},
             timeout=docker.client.DEFAULT_TIMEOUT_SECONDS,
             stream=False
+        )
+
+        self.assertEqual(
+            logs,
+            'Flowering Nights\n(Sakuya Iyazoi)\n'.encode('ascii')
         )
 
     def test_log_streaming(self):


### PR DESCRIPTION
This changes the response from string to a byte string in python3, however bring it in line with _multiplexed_socket_stream_helper.

```
/bin/bash -c "echo '☺'; echo '☺'"
```

before:

```
"b'\\xe2\\x98\\xba\\n'b'\\xe2\\x98\\xba\\n'"
```

after:

```
b'\xe2\x98\xba\n\xe2\x98\xba\n'
```
