### PR TITLE
Don't require websocket-client on Python 3

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,3 +1,2 @@
 requests==2.2.1
 six>=1.3.0
-websocket-client==0.11.0


### PR DESCRIPTION
Installed websocket-client library incompatible with Python 3 and doesn't need for docker-py as I see in source code.
