### PR TITLE
Add volumes_from argument to start()

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -668,8 +668,9 @@ class Client(requests.Session):
                                       params={'term': term}),
                             True)
 
-    def start(self, container, binds=None, port_bindings=None, lxc_conf=None,
-              publish_all_ports=False, links=None, privileged=False):
+    def start(self, container, binds=None, volumes_from=None,
+              port_bindings=None, lxc_conf=None, publish_all_ports=False,
+              links=None, privileged=False):
         if isinstance(container, dict):
             container = container.get('Id')
 
@@ -691,6 +692,11 @@ class Client(requests.Session):
             ]
 
             start_config['Binds'] = bind_pairs
+
+        if volumes_from and not isinstance(volumes_from, six.string_types):
+            volumes_from = ','.join(volumes_from)
+
+        start_config['VolumesFrom'] = volumes_from
 
         if port_bindings:
             start_config['PortBindings'] = utils.convert_port_bindings(

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -535,13 +535,19 @@ class TestStartContainerWithVolumesFrom(BaseTestCase):
         res2 = self.client.create_container(
             'busybox', 'cat',
             detach=True, stdin_open=True,
-            volumes_from=vol_names)
+        )
         container3_id = res2['Id']
         self.tmp_containers.append(container3_id)
-        self.client.start(container3_id)
+        self.client.start(
+            container3_id,
+            volumes_from=vol_names,
+        )
 
         info = self.client.inspect_container(res2['Id'])
-        self.assertEqual(info['Config']['VolumesFrom'], ','.join(vol_names))
+        self.assertEqual(
+            info['HostConfig']['VolumesFrom'],
+            ','.join(vol_names),
+        )
 
 
 class TestStartContainerWithLinks(BaseTestCase):


### PR DESCRIPTION
As of docker 0.10.0, `VolumesFrom` is supplied when starting a container, not when creating it. This adds a `volumes_from` argument to `start()`, and leaves the existing argument in place on `create_container()` so that it can be used against pre-0.10 servers.
