### PR TITLE
Complete TLS/SSL Support, near-mirror of Docker CLI

### DIFF
--- a/docker/exceptions/__init__.py
+++ b/docker/exceptions/__init__.py
@@ -1,0 +1,1 @@
+from .exceptions import TLSParameterError

--- a/docker/exceptions/exceptions.py
+++ b/docker/exceptions/exceptions.py
@@ -1,0 +1,6 @@
+class TLSParameterError(ValueError):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg + "\n\nTLS configurations should map the Docker CLI client configurations. See http://docs.docker.io/examples/https/ for API details."

--- a/docker/ssladapter/__init__.py
+++ b/docker/ssladapter/__init__.py
@@ -1,0 +1,1 @@
+from .ssladapter import SSLAdapter

--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -1,0 +1,23 @@
+""" Resolves OpenSSL issues in some servers:
+      https://lukasa.co.uk/2013/01/Choosing_SSL_Version_In_Requests/
+      https://github.com/kennethreitz/requests/pull/799
+"""
+from requests.adapters import HTTPAdapter
+try:
+    from requests.packages.urllib3.poolmanager import PoolManager
+except ImportError:
+    from urllib3.poolmanager import PoolManager
+
+
+class SSLAdapter(HTTPAdapter):
+    '''An HTTPS Transport Adapter that uses an arbitrary SSL version.'''
+    def __init__(self, ssl_version=None, **kwargs):
+        self.ssl_version = ssl_version
+
+        super(SSLAdapter, self).__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(num_pools=connections,
+                                       maxsize=maxsize,
+                                       block=block,
+                                       ssl_version=self.ssl_version)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name="docker-py",
     version='0.3.0',
     description="Python client for Docker.",
-    packages=['docker', 'docker.auth', 'docker.unixconn', 'docker.utils'],
+    packages=['docker', 'docker.auth', 'docker.unixconn', 'docker.utils', 'docker.ssladapter', 'docker.exceptions'],
     install_requires=requirements + test_requirements,
     zip_safe=False,
     test_suite='tests',


### PR DESCRIPTION
This is an expansion of @denibertovic 's work on #187

I'd re-done some of his work today, and expanded on it quite a bit by the time I realized it existed here. I've forked his commit to give him credit, and expanded on his work.

Note: This is my first time writing Python longer than 5-10 lines. Let me know if there are any code smells! I know the Exception class can be a sticking point, but I felt it was important to remind the user where the TLS API comes from, and to DRY that up a bit.

Also, I left a bunch of comments to help readers understand why some of the additions are necessary. Tests pass, and I connect fine using the options; but, alas, I haven't written any new tests for this PR.
