### PR TITLE
Add resize() method to Client

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -811,6 +811,15 @@ class Client(requests.Session):
         res = self._post_json(url, data=start_config)
         self._raise_for_status(res)
 
+    def resize(self, container, height, width):
+        if isinstance(container, dict):
+            container = container.get('Id')
+
+        params = {'h': height, 'w': width}
+        url = self._url("/containers/{0}/resize".format(container))
+        res = self._post(url, params=params)
+        self._raise_for_status(res)
+
     def stop(self, container, timeout=10):
         if isinstance(container, dict):
             container = container.get('Id')

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -103,6 +103,12 @@ def post_fake_start_container():
     return status_code, response
 
 
+def post_fake_resize_container():
+    status_code = 200
+    response = {'Id': FAKE_CONTAINER_ID}
+    return status_code, response
+
+
 def post_fake_create_container():
     status_code = 200
     response = {'Id': FAKE_CONTAINER_ID}
@@ -310,6 +316,8 @@ fake_responses = {
     get_fake_containers,
     '{1}/{0}/containers/3cc2351ab11b/start'.format(CURRENT_VERSION, prefix):
     post_fake_start_container,
+    '{1}/{0}/containers/3cc2351ab11b/resize'.format(CURRENT_VERSION, prefix):
+    post_fake_resize_container,
     '{1}/{0}/containers/3cc2351ab11b/json'.format(CURRENT_VERSION, prefix):
     get_fake_inspect_container,
     '{1}/{0}/images/e9aa60c60128/tag'.format(CURRENT_VERSION, prefix):

--- a/tests/test.py
+++ b/tests/test.py
@@ -690,6 +690,22 @@ class DockerClientTest(unittest.TestCase):
             docker.client.DEFAULT_TIMEOUT_SECONDS
         )
 
+    def test_resize_container(self):
+        try:
+            self.client.resize(
+                {'Id': fake_api.FAKE_CONTAINER_ID},
+                height=15,
+                width=120
+            )
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        fake_request.assert_called_with(
+            url_prefix + 'containers/3cc2351ab11b/resize',
+            params={'h': 15, 'w': 120},
+            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
     def test_wait(self):
         try:
             self.client.wait(fake_api.FAKE_CONTAINER_ID)


### PR DESCRIPTION
The `/containers/:id/resize` endpoint in the API is not implemented in this Python client. I needed to use it to present the pseudo-tty and keep it correctly sized. A quick search shows others are also using this endpoint, by forking this repository in different ways. It makes sense for it to be in the official docker-py client.
