### PR TITLE
support loading DOCKER_HOST from environ if available

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import json
+import os
 import re
 import shlex
 import struct
@@ -40,7 +41,8 @@ class Client(requests.Session):
                  timeout=DEFAULT_TIMEOUT_SECONDS):
         super(Client, self).__init__()
         if base_url is None:
-            base_url = "http+unix://var/run/docker.sock"
+            base_url = os.environ.get('DOCKER_HOST',
+                                      'http+unix://var/run/docker.sock')
         if 'unix:///' in base_url:
             base_url = base_url.replace('unix:/', 'unix:')
         if base_url.startswith('unix:'):


### PR DESCRIPTION
You can argue this should be done by the developer instead of the library, but I think it's more useful for the library to support the standard set by the docker cli.

Side note, without something like this it's impossible to run the integration tests on another host (e.g. on osx in a vm). Of course we could just fix the integration tests to support loading the environ key.
