### PR TITLE
fix remote testing

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -28,6 +28,8 @@ import six
 # FIXME: missing tests for
 # export; history; import_image; insert; port; push; tag; get; load
 
+DEFAULT_BASE_URL = os.environ.get('DOCKER_HOST')
+
 
 class BaseTestCase(unittest.TestCase):
     tmp_imgs = []
@@ -35,7 +37,7 @@ class BaseTestCase(unittest.TestCase):
     tmp_folders = []
 
     def setUp(self):
-        self.client = docker.Client(timeout=5)
+        self.client = docker.Client(base_url=DEFAULT_BASE_URL, timeout=5)
         self.tmp_imgs = []
         self.tmp_containers = []
         self.tmp_folders = []
@@ -910,6 +912,6 @@ class TestConnectionTimeout(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    c = docker.Client()
+    c = docker.Client(base_url=DEFAULT_BASE_URL)
     c.pull('busybox')
     unittest.main()


### PR DESCRIPTION
All tests (except 1 that was failing anyway) pass on OS X now by running docker in a VM with shared folders configured.

```
DOCKER_HOST=tcp://localdocker:4243 TMPDIR=$(pwd) env/bin/python setup.py test
```

The failing test is `TestKillWithSignal`, which I haven't touched. It fails on master as well, running everything inside a clean ubuntu 14.04 vm. Even running a container such as the following does not work using docker 1.1.0 client/daemon:

```
ID=$(docker run -d busybox sleep 60)
docker kill -s SIGTERM $ID
docker ps $ID # it's still running
```

Temporary folders for a few tests are now properly cleaned up after the test is over instead of leaving them to accumulate for the OS to deal with.
