### PR TITLE
fix ssl_version exception when urllib3 version <= 1.5

### DIFF
--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -2,10 +2,12 @@
       https://lukasa.co.uk/2013/01/Choosing_SSL_Version_In_Requests/
       https://github.com/kennethreitz/requests/pull/799
 """
+from distutils.version import StrictVersion
 from requests.adapters import HTTPAdapter
 try:
     from requests.packages.urllib3.poolmanager import PoolManager
 except ImportError:
+    import urllib3
     from urllib3.poolmanager import PoolManager
 
 
@@ -16,7 +18,13 @@ class SSLAdapter(HTTPAdapter):
         super(SSLAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(num_pools=connections,
-                                       maxsize=maxsize,
-                                       block=block,
-                                       ssl_version=self.ssl_version)
+        urllib_ver = urllib3.__version__
+        if urllib3 and StrictVersion(urllib_ver) <= StrictVersion('1.5'):
+            self.poolmanager = PoolManager(num_pools=connections,
+                                           maxsize=maxsize,
+                                           block=block)
+        else:
+            self.poolmanager = PoolManager(num_pools=connections,
+                                           maxsize=maxsize,
+                                           block=block,
+                                           ssl_version=self.ssl_version)


### PR DESCRIPTION
on centos6 ,default urllib3 version is `1.5` . 
HTTPSConnectionPool have not param `ssl_version`
got exception:

```
>>> client = docker.Client(base_url='https://127.0.0.1:2735', tls=tls_config)
>>> client.containers()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.6/site-packages/docker/client.py", line 445, in containers
    res = self._result(self._get(u, params=params), True)
  File "/usr/lib/python2.6/site-packages/docker/client.py", line 82, in _get
    return self.get(url, **self._set_request_timeout(kwargs))
  File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 310, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 279, in request
    resp = self.send(prep, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
  File "/usr/lib/python2.6/site-packages/requests/sessions.py", line 374, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.6/site-packages/requests/adapters.py", line 155, in send
    conn = self.get_connection(request.url, proxies)
  File "/usr/lib/python2.6/site-packages/requests/adapters.py", line 125, in get_connection
    conn = self.poolmanager.connection_from_url(url)
  File "/usr/lib/python2.6/site-packages/urllib3/poolmanager.py", line 100, in connection_from_url
    return self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
  File "/usr/lib/python2.6/site-packages/urllib3/poolmanager.py", line 84, in connection_from_host
    pool = pool_cls(host, port, **self.connection_pool_kw)
TypeError: __init__() got an unexpected keyword argument 'ssl_version'
```
