### PR TITLE
Add support for .dockerignore

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import json
+import os
 import re
 import shlex
 import struct
@@ -351,7 +352,12 @@ class Client(requests.Session):
                               'git://', 'github.com/')):
             remote = path
         else:
-            context = utils.tar(path)
+            dockerignore = os.path.join(path, '.dockerignore')
+            exclude = None
+            if os.path.exists(dockerignore):
+                with open(dockerignore, 'r') as f:
+                    exclude = list(filter(bool, f.read().split('\n')))
+            context = utils.tar(path, exclude=exclude)
 
         if utils.compare_version('1.8', self._version) >= 0:
             stream = True

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -13,9 +13,11 @@
 #    limitations under the License.
 
 import io
+import os
 import tarfile
 import tempfile
 from distutils.version import StrictVersion
+from fnmatch import fnmatch
 
 import requests
 import six
@@ -42,10 +44,29 @@ def mkbuildcontext(dockerfile):
     return f
 
 
-def tar(path):
+def fnmatch_any(relpath, patterns):
+    return any([fnmatch(relpath, pattern) for pattern in patterns])
+
+
+def tar(path, exclude=None):
     f = tempfile.NamedTemporaryFile()
     t = tarfile.open(mode='w', fileobj=f)
-    t.add(path, arcname='.')
+    for dirpath, dirnames, filenames in os.walk(path):
+        relpath = os.path.relpath(dirpath, path)
+        if relpath == '.':
+            relpath = ''
+        if exclude is None:
+            fnames = filenames
+        else:
+            dirnames[:] = [d for d in dirnames
+                           if not fnmatch_any(os.path.join(relpath, d),
+                                              exclude)]
+            fnames = [name for name in filenames
+                      if not fnmatch_any(os.path.join(relpath, name),
+                                         exclude)]
+        for name in fnames:
+            arcname = os.path.join(relpath, name)
+            t.add(os.path.join(path, arcname), arcname=arcname)
     t.close()
     f.seek(0)
     return f

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -17,12 +17,15 @@ import base64
 import json
 import io
 import os
+import shutil
 import signal
 import tempfile
 import unittest
 
 import docker
 import six
+
+from tests.test import Cleanup
 
 # FIXME: missing tests for
 # export; history; import_image; insert; port; push; tag; get; load
@@ -819,6 +822,43 @@ class TestBuildWithAuth(BaseTestCase):
         self.assertNotEqual(logs, '')
         self.assertEqual(logs.find('HTTP code: 403'), -1)
 
+
+class TestBuildWithDockerignore(Cleanup, BaseTestCase):
+    def runTest(self):
+        if self.client._version < 1.8:
+            return
+
+        base_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, base_dir)
+
+        with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
+            f.write("\n".join([
+                'FROM busybox',
+                'MAINTAINER docker-py',
+                'ADD . /test',
+                'RUN ls -A /test',
+            ]))
+
+        with open(os.path.join(base_dir, '.dockerignore'), 'w') as f:
+            f.write("\n".join([
+                'node_modules',
+                '',  # empty line
+            ]))
+
+        with open(os.path.join(base_dir, 'not-ignored'), 'w') as f:
+            f.write("this file should not be ignored")
+
+        subdir = os.path.join(base_dir, 'node_modules', 'grunt-cli')
+        os.makedirs(subdir)
+        with open(os.path.join(subdir, 'grunt'), 'w') as f:
+            f.write("grunt")
+
+        stream = self.client.build(path=base_dir, stream=True)
+        logs = ''
+        for chunk in stream:
+            logs += chunk
+        self.assertFalse('node_modules' in logs)
+        self.assertTrue('not-ignored' in logs)
 
 #######################
 #  PY SPECIFIC TESTS  #


### PR DESCRIPTION
Fixes #265.

Implementation is a bit more elaborate than docker's implementation and matches with the one proposed in dotcloud/docker#6869 to handle permission issues more nicely.
