### PR TITLE
addresses problems with urllib3 references

### DIFF
--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -18,7 +18,11 @@ class SSLAdapter(HTTPAdapter):
         super(SSLAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
-        urllib_ver = urllib3.__version__
+        try:
+            urllib_ver = urllib3.__version__
+        except NameError:
+            urllib_ver = urllib3 = None
+
         if urllib3 and StrictVersion(urllib_ver) <= StrictVersion('1.5'):
             self.poolmanager = PoolManager(num_pools=connections,
                                            maxsize=maxsize,


### PR DESCRIPTION
addresses problem with urllib3 pool manager logic when urllib3 isn't installed
- Adds the variables to the context explicitly as None.  Otherwise “urllib3” isn’t defined and chokes on a NameError
