### PR TITLE
Fixed bug in utils.mkbuildcontext for BytesIO Dockerfiles

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -36,6 +36,7 @@ def mkbuildcontext(dockerfile):
                             'Dockerfiles with Python 3')
         else:
             dfinfo.size = len(dockerfile.getvalue())
+            dockerfile.seek(0)
     elif isinstance(dockerfile, io.BytesIO):
         dfinfo = tarfile.TarInfo('Dockerfile')
         dfinfo.size = len(dockerfile.getvalue())


### PR DESCRIPTION
- resetting dockerfile seek position to 0 after dockerfile.getvalue() is called
- prevents traceback on line utils.py line 43
- 'IOError("end of file reached")' in tarfile.py
