### PR TITLE
Add API version discovery

### DIFF
--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -35,6 +35,13 @@ def get_fake_version():
     return status_code, response
 
 
+def get_fake_discover_version():
+    status_code = 200
+    response = {'GoVersion': '1', 'Version': '1.1.1',
+                'GitCommit': 'deadbeef+CHANGES', 'ApiVersion': '1.1.1'}
+    return status_code, response
+
+
 def get_fake_info():
     status_code = 200
     response = {'Containers': 1, 'Images': 1, 'Debug': False,
@@ -302,6 +309,8 @@ prefix = 'http+unix://var/run/docker.sock'
 fake_responses = {
     '{1}/{0}/version'.format(CURRENT_VERSION, prefix):
     get_fake_version,
+    '{0}/version'.format(prefix):
+    get_fake_discover_version,
     '{1}/{0}/info'.format(CURRENT_VERSION, prefix):
     get_fake_info,
     '{1}/{0}/images/search'.format(CURRENT_VERSION, prefix):

--- a/tests/test.py
+++ b/tests/test.py
@@ -77,7 +77,20 @@ class DockerClientTest(unittest.TestCase):
 
         fake_request.assert_called_with(
             url_prefix + 'version',
+            api_version=True,
             timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_discover_version(self):
+        try:
+            self.client.version(api_version=False)
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        fake_request.assert_called_with(
+            url_prefix + 'version',
+            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS,
+            api_version=False,
         )
 
     def test_info(self):


### PR DESCRIPTION
Since docker-py handles API differences well already, in many cases
it's entirely possible to write scripts that can talk to different
versions of docker without the user knowing in advance what the API
version is. Add an opt-in ability for a consumer to request that
docker-py figure out what version the server is, by making an
unversioned call to /version and retreiving the version if
Client(version=False)