### PR TITLE
Fix travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 docker-py
 =========
 
-[![Build Status](https://travis-ci.org/dotcloud/docker-py.png)](https://travis-ci.org/dotcloud/docker-py)
+[![Build Status](https://travis-ci.org/docker/docker-py.png)](https://travis-ci.org/docker/docker-py)
 
 An API client for docker written in Python
 


### PR DESCRIPTION
Repository moved from dotcloud to docker

Signed-off-by: Ben Firshman ben@firshman.co.uk

Docker-DCO-1.1-Signed-off-by: Ben Firshman ben@firshman.co.uk (github: bfirsh)
