### PR TITLE
Added a timeout to the https ping

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -101,7 +101,7 @@ def compare_version(v1, v2):
 
 def ping(url):
     try:
-        res = requests.get(url)
+        res = requests.get(url, timeout=3)
     except Exception:
         return False
     else:


### PR DESCRIPTION
For those not using https who might have it firewalled, this request without a timeout causes significant delay. Adding a moderately generous timeout shouldn't affect anyone negatively, but will make things a bit nicer otherwise.
