### PR TITLE
Stop timeout should be added to the request timeout

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -873,7 +873,7 @@ class Client(requests.Session):
         params = {'t': timeout}
         url = self._url("/containers/{0}/stop".format(container))
         res = self._post(url, params=params,
-                         timeout=max(timeout, self._timeout))
+                         timeout=(timeout + self._timeout))
         self._raise_for_status(res)
 
     def tag(self, image, repository, tag=None, force=False):

--- a/tests/test.py
+++ b/tests/test.py
@@ -934,27 +934,30 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         )
 
     def test_stop_container(self):
+        timeout = 2
         try:
-            self.client.stop(fake_api.FAKE_CONTAINER_ID, timeout=2)
+            self.client.stop(fake_api.FAKE_CONTAINER_ID, timeout=timeout)
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
         fake_request.assert_called_with(
             url_prefix + 'containers/3cc2351ab11b/stop',
-            params={'t': 2},
-            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
+            params={'t': timeout},
+            timeout=(docker.client.DEFAULT_TIMEOUT_SECONDS + timeout)
         )
 
     def test_stop_container_with_dict_instead_of_id(self):
+        timeout = 2
         try:
-            self.client.stop({'Id': fake_api.FAKE_CONTAINER_ID}, timeout=2)
+            self.client.stop({'Id': fake_api.FAKE_CONTAINER_ID},
+                             timeout=timeout)
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
         fake_request.assert_called_with(
             url_prefix + 'containers/3cc2351ab11b/stop',
-            params={'t': 2},
-            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
+            params={'t': timeout},
+            timeout=(docker.client.DEFAULT_TIMEOUT_SECONDS + timeout)
         )
 
     def test_kill_container(self):


### PR DESCRIPTION
Using the max of the stop timeout and request timeout did not entirely
make sure that a stop timeout greater than a request timeout wouldn't
fail prematurely with a HTTPTimeout exception. The correct behavior is
to add the timeouts together, as the stop timeout is understood to be
part of the "request processing time". Any transport-level timeout thus
comes in addition to that.

Signed-off-by: Maxime Petazzoni max@signalfuse.com
