### PR TITLE
Add support for tailing logs (introduced in API : v1.13)

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -33,7 +33,7 @@ from .tls import TLSConfig
 if not six.PY3:
     import websocket
 
-DEFAULT_DOCKER_API_VERSION = '1.12'
+DEFAULT_DOCKER_API_VERSION = '1.13'
 DEFAULT_TIMEOUT_SECONDS = 60
 STREAM_HEADER_SIZE_BYTES = 8
 
@@ -661,7 +661,7 @@ class Client(requests.Session):
         return self._result(response, json=True)
 
     def logs(self, container, stdout=True, stderr=True, stream=False,
-             timestamps=False):
+             timestamps=False, tail=-1):
         if isinstance(container, dict):
             container = container.get('Id')
         if utils.compare_version('1.11', self._version) >= 0:
@@ -669,6 +669,9 @@ class Client(requests.Session):
                       'stdout': stdout and 1 or 0,
                       'timestamps': timestamps and 1 or 0,
                       'follow': stream and 1 or 0}
+            if tail and tail >= 0 and \
+                    utils.compare_version('1.13', self._version) >= 0:
+                params['tail'] = tail
             url = self._url("/containers/{0}/logs".format(container))
             res = self._get(url, params=params, stream=stream)
             if stream:

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-CURRENT_VERSION = 'v1.12'
+CURRENT_VERSION = 'v1.13'
 
 FAKE_CONTAINER_ID = '3cc2351ab11b'
 FAKE_IMAGE_ID = 'e9aa60c60128'

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -291,6 +291,22 @@ class TestLogs(BaseTestCase):
         self.assertEqual(logs, (snippet + '\n').encode(encoding='ascii'))
 
 
+class TestLogsWithTailOption(BaseTestCase):
+    def runTest(self):
+        snippet = '''Line1
+Line2'''
+        container = self.client.create_container(
+            'busybox', 'echo "{0}"'.format(snippet)
+        )
+        id = container['Id']
+        self.client.start(id)
+        self.tmp_containers.append(id)
+        exitcode = self.client.wait(id)
+        self.assertEqual(exitcode, 0)
+        logs = self.client.logs(id, tail=1)
+        self.assertEqual(logs, ('Line2\n').encode(encoding='ascii'))
+
+
 # class TestLogsStreaming(BaseTestCase):
 #     def runTest(self):
 #         snippet = 'Flowering Nights (Sakuya Iyazoi)'

--- a/tests/test.py
+++ b/tests/test.py
@@ -900,6 +900,20 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             stream=True
         )
 
+    def test_log_tail(self):
+        try:
+            self.client.logs(fake_api.FAKE_CONTAINER_ID, stream=False, tail=10)
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        fake_request.assert_called_with(
+            url_prefix + 'containers/3cc2351ab11b/logs',
+            params={'timestamps': 0, 'follow': 0, 'stderr': 1, 'stdout': 1,
+                    'tail': 10},
+            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS,
+            stream=False
+        )
+
     def test_diff(self):
         try:
             self.client.diff(fake_api.FAKE_CONTAINER_ID)


### PR DESCRIPTION
Add support for tailing logs (introduced in API : v1.13)
Updated default version to v1.13
