### PR TITLE
Add timeout to client.wait()

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -906,11 +906,11 @@ class Client(requests.Session):
     def version(self):
         return self._result(self._get(self._url("/version")), True)
 
-    def wait(self, container):
+    def wait(self, container, timeout=None):
         if isinstance(container, dict):
             container = container.get('Id')
         url = self._url("/containers/{0}/wait".format(container))
-        res = self._post(url, timeout=None)
+        res = self._post(url, timeout=timeout)
         self._raise_for_status(res)
         json_ = res.json()
         if 'StatusCode' in json_:


### PR DESCRIPTION
When waiting for a container to do something I found it useful to be able to give a timeout.  If specified, an exception will be generated when the timeout occurs which will allow my code to handle it accordingly and move on.
