### PR TITLE
add support to add or drop capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ Identical to the `docker search` command.
 ```python
 c.start(container, binds=None, port_bindings=None, lxc_conf=None,
         publish_all_ports=False, links=None, privileged=False,
-        dns=None, dns_search=None, volumes_from=None, network_mode=None, restart_policy=None)
+        dns=None, dns_search=None, volumes_from=None, network_mode=None,
+        restart_policy=None, cap_add=None, cap_drop=None)
 ```
 
 Similar to the `docker start` command, but doesn't support attach
@@ -276,6 +277,15 @@ for example:
     "MaximumRetryCount": 5, 
     "Name": "on-failure"
 }
+```
+
+`cap_add` and `cap_drop` are available since v1.2.0 and can be used to add or drop certain capabilities.
+The user may specify the capabilities as an array for example:
+```
+[
+    "SYS_ADMIN",
+    "MKNOD"
+]
 ```
 
  

--- a/docker/client.py
+++ b/docker/client.py
@@ -807,7 +807,7 @@ class Client(requests.Session):
     def start(self, container, binds=None, port_bindings=None, lxc_conf=None,
               publish_all_ports=False, links=None, privileged=False,
               dns=None, dns_search=None, volumes_from=None, network_mode=None,
-              restart_policy=None):
+              restart_policy=None, cap_add=None, cap_drop=None):
         if isinstance(container, dict):
             container = container.get('Id')
 
@@ -868,6 +868,12 @@ class Client(requests.Session):
 
         if restart_policy:
             start_config['RestartPolicy'] = restart_policy
+
+        if cap_add:
+            start_config['CapAdd'] = cap_add
+
+        if cap_drop:
+            start_config['CapDrop'] = cap_drop
 
         url = self._url("/containers/{0}/start".format(container))
         res = self._post_json(url, data=start_config)

--- a/tests/test.py
+++ b/tests/test.py
@@ -841,6 +841,56 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             docker.client.DEFAULT_TIMEOUT_SECONDS
         )
 
+    def test_start_container_with_added_capabilities(self):
+        try:
+            self.client.start(fake_api.FAKE_CONTAINER_ID,
+                              cap_add=['MKNOD'])
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+        args = fake_request.call_args
+        self.assertEqual(
+            args[0][0],
+            url_prefix + 'containers/3cc2351ab11b/start'
+        )
+        self.assertEqual(
+            json.loads(args[1]['data']),
+            {"PublishAllPorts": False, "Privileged": False,
+             "CapAdd": ["MKNOD"]}
+        )
+        self.assertEqual(
+            args[1]['headers'],
+            {'Content-Type': 'application/json'}
+        )
+        self.assertEqual(
+            args[1]['timeout'],
+            docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_start_container_with_dropped_capabilities(self):
+        try:
+            self.client.start(fake_api.FAKE_CONTAINER_ID,
+                              cap_drop=['MKNOD'])
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+        args = fake_request.call_args
+        self.assertEqual(
+            args[0][0],
+            url_prefix + 'containers/3cc2351ab11b/start'
+        )
+        self.assertEqual(
+            json.loads(args[1]['data']),
+            {"PublishAllPorts": False, "Privileged": False,
+             "CapDrop": ["MKNOD"]}
+        )
+        self.assertEqual(
+            args[1]['headers'],
+            {'Content-Type': 'application/json'}
+        )
+        self.assertEqual(
+            args[1]['timeout'],
+            docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
     def test_resize_container(self):
         try:
             self.client.resize(


### PR DESCRIPTION
Simple addition that let's you add or drop capabilities when you start a container. `SYS_ADMIN`, for example, is required if you want to use `systemd` inside your container.
