### PR TITLE
Wrap response socket for platform compatibility.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -17,7 +17,7 @@ import os
 import re
 import shlex
 import struct
-from socket import socket as socket_wrapper
+from socket import socket as socket_obj
 import warnings
 
 import requests
@@ -265,7 +265,7 @@ class Client(requests.Session):
 
     def _stream_helper(self, response):
         """Generator for data coming from a chunked-encoded HTTP response."""
-        socket_fp = socket_wrapper(_sock=self._get_raw_response_socket(response))
+        socket_fp = socket_obj(_sock=self._get_raw_response_socket(response))
         socket_fp.setblocking(1)
         socket = socket_fp.makefile()
         while True:


### PR DESCRIPTION
This PR was rebased in a new branch. It is identical to #289, except for renaming the wrapping object.
