### PR TITLE
Accept invalid SSL certificates on insecure registry pings.

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -39,7 +39,7 @@ def expand_registry_url(hostname, insecure=False):
         if '/' not in hostname[9:]:
             hostname = hostname + '/v1/'
         return hostname
-    if utils.ping('https://' + hostname + '/v1/_ping'):
+    if utils.ping('https://' + hostname + '/v1/_ping', insecure):
         return 'https://' + hostname + '/v1/'
     elif insecure:
         return 'http://' + hostname + '/v1/'

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -99,9 +99,11 @@ def compare_version(v1, v2):
         return 1
 
 
-def ping(url):
+def ping(url, insecure=False):
     try:
         res = requests.get(url, timeout=3)
+    except requests.exceptions.SSLError:
+        return insecure
     except Exception:
         return False
     else:


### PR DESCRIPTION
When validation of the SSL certificate fails, the current implementation tries to connect via HTTP instead. However, a connect via unvalidated HTTPS should be attempted prior to using HTTP.
This PR accepts invalid SSL certificates, if `insecure_registry` in `pull` or `push` operations is set to `True`.

Possibly this is not the best workaround. The ping is performed from the client running the `docker-py`-based application; the actual connect however takes place from the remote-controlled client, which may have different certificate settings and therefore different standards of "secure" connections.