### PR TITLE
Expand registry URL before login.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -639,13 +639,14 @@ class Client(requests.Session):
         self._raise_for_status(res)
 
     def login(self, username, password=None, email=None, registry=None,
-              reauth=False):
+              reauth=False, insecure_registry=False):
         # If we don't have any auth data so far, try reloading the config file
         # one more time in case anything showed up in there.
         if not self._auth_configs:
             self._auth_configs = auth.load_config()
 
-        registry = registry or auth.INDEX_URL
+        registry = auth.expand_registry_url(registry, insecure_registry) \
+            if registry else auth.INDEX_URL
 
         authcfg = auth.resolve_authconfig(self._auth_configs, registry)
         # If we found an existing auth config for this registry and username


### PR DESCRIPTION
The behavior of `login` differs from `push` and `pull` as well as the command-line client in the following two aspects:
- It does not expand the registry URL, if the `registry` argument was not specified including a protocol and the path `v1`. This leads to a mismatch when caching and reusing the credentials (in `_auth_configs`).
- It accepts insecure connections by default.

Applying the same expansion as `push`/`pull` provides more consistency.
