### PR TITLE
Make history() return json.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -547,8 +547,7 @@ class Client(requests.Session):
 
     def history(self, image):
         res = self._get(self._url("/images/{0}/history".format(image)))
-        self._raise_for_status(res)
-        return self._result(res)
+        return self._result(res, True)
 
     def images(self, name=None, quiet=False, all=False, viz=False):
         if viz:


### PR DESCRIPTION
I found that history() was simply returning the unicode response instead of parsing the json.  I also took out the redundant status code check while I was in there.  Code deletion > addition :-)
