### PR TITLE
Add tests to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include requirements.txt
 include requirements3.txt
 include README.md
 include LICENSE
+recursive-include tests *.py


### PR DESCRIPTION
When using the tarball from PyPi, the tests directory is missing and thus the tests can't be run to verify the environment.  This adds the directory to the sdist but not the installation so the tests can be run if desired.
