### PR TITLE
Change remove_image to check if image is a dictionary.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -795,7 +795,7 @@ class Client(requests.Session):
 
     def remove_image(self, image, force=False, noprune=False):
         if isinstance(image, dict):
-            image = image.get('Id') 
+            image = image.get('Id')
         params = {'force': force, 'noprune': noprune}
         res = self._delete(self._url("/images/" + image), params=params)
         self._raise_for_status(res)


### PR DESCRIPTION
`remove_image` should behave similarly to `remove_containers` in that the `image` argument it takes can either be a dictionary or the name of an image to remove
