### PR TITLE
Fix bug in urllib3 version comparison

### DIFF
--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -26,7 +26,7 @@ class SSLAdapter(HTTPAdapter):
             'maxsize': maxsize,
             'block': block
         }
-        if urllib3 and urllib_ver != 'dev' and \
+        if urllib_ver and urllib_ver != 'dev' and \
            StrictVersion(urllib_ver) > StrictVersion('1.5'):
             kwargs['ssl_version'] = self.ssl_version
 


### PR DESCRIPTION
If urllib_ver is 'dev', `StrictVersion()` will throw an exception. The check should ensure that it is not dev.
