### PR TITLE
Fix lost data & hangs when reading chunked streams

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -17,7 +17,6 @@ import os
 import re
 import shlex
 import struct
-from socket import socket as socket_obj
 import warnings
 
 import requests
@@ -283,31 +282,15 @@ class Client(requests.Session):
 
     def _stream_helper(self, response):
         """Generator for data coming from a chunked-encoded HTTP response."""
-        if six.PY3:
-            socket_fp = self._get_raw_response_socket(response)
-        else:
-            socket_fp = socket_obj(
-                _sock=self._get_raw_response_socket(response)
-            )
-        socket_fp.setblocking(1)
-        socket = socket_fp.makefile()
-        while True:
-            # Because Docker introduced newlines at the end of chunks in v0.9,
-            # and only on some API endpoints, we have to cater for both cases.
-            size_line = socket.readline()
-            if size_line == '\r\n' or size_line == '\n':
-                size_line = socket.readline()
-
-            if len(size_line.strip()) > 0:
-                size = int(size_line, 16)
-            else:
-                break
-
-            if size <= 0:
-                break
-            data = socket.readline()
+        reader = response.raw
+        assert reader._fp.chunked
+        while not reader.closed:
+            # this read call will block until we get a chunk
+            data = reader.read(1)
             if not data:
                 break
+            if reader._fp.chunk_left:
+                data += reader.read(reader._fp.chunk_left)
             yield data
 
     def _multiplexed_buffer_helper(self, response):


### PR DESCRIPTION
I managed to [track down a hang when calling `build()`](https://groups.google.com/forum/#!topic/docker-dev/fhrTqwF7IJQ) to a problem handling streams.

`strace` proved that the problem was somewhere in the python client and I manage to create a test harness for this issue.

This is not the most elegant fix, I could do with some advice:
- I've changed the return value of attach_socket
- In _stream_helper it creates a new fileobj, when we just threw away the one which had our data buffer in it, we could just keep the old one.
