### PR TITLE
Catch invalid path in build method

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -395,6 +395,8 @@ class Client(requests.Session):
         elif path.startswith(('http://', 'https://',
                               'git://', 'github.com/')):
             remote = path
+        elif not os.path.isdir(path):
+            raise TypeError("You must specify a directory to build in path")
         else:
             dockerignore = os.path.join(path, '.dockerignore')
             exclude = None


### PR DESCRIPTION
The server responds with an unuseful message (server error EOF), which
happens because an empty tar file is sent over. So check in the client,
who knows why that's happening and tell the user.
