### PR TITLE
Make the tar creating utility copy directory entries as well

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -71,7 +71,8 @@ def tar(path, exclude=None):
                                          exclude)]
         for name in fnames + dirnames:
             arcname = os.path.join(relpath, name)
-            t.add(os.path.join(path, arcname), arcname=arcname, recursive=False)
+            t.add(os.path.join(path, arcname), arcname=arcname,
+                  recursive=False)
 
     t.close()
     f.seek(0)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1616,8 +1616,10 @@ class DockerClientTest(Cleanup, unittest.TestCase):
 
         for exclude, names in (
                 (['*.py'], ['bar', 'bar/a.txt', 'bar/other.png',
-                            'test', 'test/foo', 'test/foo/a.txt', 'test/foo/other.png']),
-                (['*.png', 'bar'], ['test', 'test/foo', 'test/foo/a.txt', 'test/foo/b.py']),
+                            'test', 'test/foo', 'test/foo/a.txt',
+                            'test/foo/other.png']),
+                (['*.png', 'bar'], ['test', 'test/foo', 'test/foo/a.txt',
+                                    'test/foo/b.py']),
                 (['test/foo', 'a.txt'], ['bar', 'bar/a.txt', 'bar/b.py',
                                          'bar/other.png', 'test']),
         ):


### PR DESCRIPTION
Some builds can rely on the presence of the empty directories, so we need to make sure they are copied over. The removed (unrelated) test will be resubmitted in another PR.
