### PR TITLE
Enable the overriding of `assert_hostname` on TLSConfig

### DIFF
--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -15,15 +15,17 @@ PoolManager = urllib3.poolmanager.PoolManager
 
 class SSLAdapter(HTTPAdapter):
     '''An HTTPS Transport Adapter that uses an arbitrary SSL version.'''
-    def __init__(self, ssl_version=None, **kwargs):
+    def __init__(self, ssl_version=None, assert_hostname=None, **kwargs):
         self.ssl_version = ssl_version
+        self.assert_hostname = assert_hostname
         super(SSLAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
         kwargs = {
             'num_pools': connections,
             'maxsize': maxsize,
-            'block': block
+            'block': block,
+            'assert_hostname': self.assert_hostname,
         }
         if self.can_override_ssl_version():
             kwargs['ssl_version'] = self.ssl_version

--- a/docker/tls.py
+++ b/docker/tls.py
@@ -10,7 +10,7 @@ class TLSConfig(object):
     ssl_version = None
 
     def __init__(self, client_cert=None, ca_cert=None, verify=None,
-                 ssl_version=None):
+                 ssl_version=None, assert_hostname=None):
         # Argument compatibility/mapping with
         # http://docs.docker.com/examples/https/
         # This diverges from the Docker CLI in that users can specify 'tls'
@@ -20,6 +20,7 @@ class TLSConfig(object):
         # urllib3 sets a default ssl_version if ssl_version is None
         # http://tinyurl.com/kxga8hb
         self.ssl_version = ssl_version
+        self.assert_hostname = assert_hostname
 
         # "tls" and "tls_verify" must have both or neither cert/key files
         # In either case, Alert the user when both are expected, but any are
@@ -65,4 +66,7 @@ class TLSConfig(object):
             client.verify = self.verify
         if self.cert:
             client.cert = self.cert
-        client.mount('https://', ssladapter.SSLAdapter(self.ssl_version))
+        client.mount('https://', ssladapter.SSLAdapter(
+            ssl_version=self.ssl_version,
+            assert_hostname=self.assert_hostname,
+        ))


### PR DESCRIPTION
When using fig against boot2docker with TLS enabled, hostname verification fails because `DOCKER_HOST` is an IP address but the generated certificate is for the `boot2docker` hostname.

The docker client doesn't have this problem because it doesn't verify the hostname; this change enables fig to skip that step too.
