### PR TITLE
Add pause/unpause needed by OpenStack Nova Docker driver

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -904,6 +904,22 @@ class Client(requests.Session):
                          timeout=(timeout + self._timeout))
         self._raise_for_status(res)
 
+    def pause(self, container):
+        if isinstance(container, dict):
+            container = container.get('Id')
+        url = self._url("/containers/{0}/pause".format(container))
+        res = self._post(url)
+        self._raise_for_status(res)
+        return res.status_code == 204
+
+    def unpause(self, container):
+        if isinstance(container, dict):
+            container = container.get('Id')
+        url = self._url("/containers/{0}/unpause".format(container))
+        res = self._post(url)
+        self._raise_for_status(res)
+        return res.status_code == 204
+
     def tag(self, image, repository, tag=None, force=False):
         params = {
             'tag': tag,

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -133,6 +133,18 @@ def get_fake_inspect_container():
     return status_code, response
 
 
+def post_fake_pause_container():
+    status_code = 204
+    response = None
+    return status_code, response
+
+
+def post_fake_unpause_container():
+    status_code = 204
+    response = None
+    return status_code, response
+
+
 def get_fake_inspect_image():
     status_code = 200
     response = {
@@ -320,6 +332,10 @@ fake_responses = {
     post_fake_resize_container,
     '{1}/{0}/containers/3cc2351ab11b/json'.format(CURRENT_VERSION, prefix):
     get_fake_inspect_container,
+    '{1}/{0}/containers/3cc2351ab11b/pause'.format(CURRENT_VERSION, prefix):
+    post_fake_pause_container,
+    '{1}/{0}/containers/3cc2351ab11b/unpause'.format(CURRENT_VERSION, prefix):
+    post_fake_unpause_container,
     '{1}/{0}/images/e9aa60c60128/tag'.format(CURRENT_VERSION, prefix):
     post_fake_tag_image,
     '{1}/{0}/containers/3cc2351ab11b/wait'.format(CURRENT_VERSION, prefix):

--- a/tests/test.py
+++ b/tests/test.py
@@ -1195,6 +1195,28 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
         )
 
+    def test_pause_container(self):
+        try:
+            self.client.pause(fake_api.FAKE_CONTAINER_ID)
+        except Exception as e:
+            self.fail('Command should not raise exception : {0}'.format(e))
+
+        fake_request.assert_called_with(
+            url_prefix + 'containers/3cc2351ab11b/pause',
+            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_unpause_container(self):
+        try:
+            self.client.unpause(fake_api.FAKE_CONTAINER_ID)
+        except Exception as e:
+            self.fail('Command should not raise exception : {0}'.format(e))
+
+        fake_request.assert_called_with(
+            url_prefix + 'containers/3cc2351ab11b/unpause',
+            timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
     ##################
     #  IMAGES TESTS  #
     ##################


### PR DESCRIPTION
Nova Docker driver has a custom http client which we are trying
to replace with docker-py and during the initial review, pause
and unpause seem to be missing from docker-py.

https://github.com/stackforge/nova-docker/blob/master/novadocker/virt/docker/client.py#L177

The Docker Remote API documentation is here:
https://docs.docker.com/reference/api/docker_remote_api_v1.14/#pause-a-container
https://docs.docker.com/reference/api/docker_remote_api_v1.14/#unpause-a-container
