### PR TITLE
Stop TLS sockets being closed when attaching

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -259,9 +259,11 @@ class Client(requests.Session):
     def _get_raw_response_socket(self, response):
         self._raise_for_status(response)
         if six.PY3:
-            return response.raw._fp.fp.raw._sock
+            sock = response.raw._fp.fp.raw._sock
         else:
-            return response.raw._fp.fp._sock
+            sock = response.raw._fp.fp._sock
+        sock._response = response
+        return sock
 
     def _stream_helper(self, response):
         """Generator for data coming from a chunked-encoded HTTP response."""


### PR DESCRIPTION
When calling attach_socket, the response is garbage collected, which triggers a close method on the file object, closing the socket.

This stops the response from being garbage collected until we've finished with the underlying socket.

Fixes #350 
