### PR TITLE
Ability to set cpuset flag during container create

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -104,7 +104,7 @@ class Client(requests.Session):
                           volumes=None, volumes_from=None,
                           network_disabled=False, entrypoint=None,
                           cpu_shares=None, working_dir=None, domainname=None,
-                          memswap_limit=0):
+                          memswap_limit=0, cpu_set=None):
         if isinstance(command, six.string_types):
             command = shlex.split(str(command))
         if isinstance(environment, dict):
@@ -217,6 +217,7 @@ class Client(requests.Session):
             'NetworkDisabled': network_disabled,
             'Entrypoint': entrypoint,
             'CpuShares': cpu_shares,
+            'Cpuset': cpu_set,
             'WorkingDir': working_dir,
             'MemorySwap': memswap_limit
         }
@@ -515,7 +516,7 @@ class Client(requests.Session):
                          volumes=None, volumes_from=None,
                          network_disabled=False, name=None, entrypoint=None,
                          cpu_shares=None, working_dir=None, domainname=None,
-                         memswap_limit=0):
+                         memswap_limit=0, cpu_set=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -523,7 +524,8 @@ class Client(requests.Session):
         config = self._container_config(
             image, command, hostname, user, detach, stdin_open, tty, mem_limit,
             ports, environment, dns, volumes, volumes_from, network_disabled,
-            entrypoint, cpu_shares, working_dir, domainname, memswap_limit
+            entrypoint, cpu_shares, working_dir, domainname, memswap_limit,
+            cpu_set
         )
         return self.create_container_from_config(config, name)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -349,6 +349,30 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 
+    def test_create_container_with_cpu_set(self):
+        try:
+            self.client.create_container('busybox', 'ls',
+                                         cpu_set="0-3")
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][0],
+                         url_prefix + 'containers/create')
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls"], "AttachStdin": false,
+                             "Memory": 0,
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false,
+                             "Cpuset": "0-3",
+                             "MemorySwap": 0}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
     def test_create_container_with_working_dir(self):
         try:
             self.client.create_container('busybox', 'ls',


### PR DESCRIPTION
Adding support for the following feature:
docker/docker@adbe309

Allow API users to set the string that is passed through using 'Cpuset' as the
key.
