### PR TITLE
Ability to specify Host Devices during container start

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -891,6 +891,41 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             docker.client.DEFAULT_TIMEOUT_SECONDS
         )
 
+    def test_start_container_with_devices(self):
+        try:
+            self.client.start(fake_api.FAKE_CONTAINER_ID,
+                              devices=['/dev/sda:/dev/xvda:rwm',
+                                       '/dev/sdb:/dev/xvdb',
+                                       '/dev/sdc'])
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+        args = fake_request.call_args
+        self.assertEqual(
+            args[0][0],
+            url_prefix + 'containers/3cc2351ab11b/start'
+        )
+        self.assertEqual(
+            json.loads(args[1]['data']),
+            {"PublishAllPorts": False, "Privileged": False,
+             "Devices": [{'CgroupPermissions': 'rwm',
+                          'PathInContainer': '/dev/sda:/dev/xvda:rwm',
+                          'PathOnHost': '/dev/sda:/dev/xvda:rwm'},
+                         {'CgroupPermissions': 'rwm',
+                          'PathInContainer': '/dev/sdb:/dev/xvdb',
+                          'PathOnHost': '/dev/sdb:/dev/xvdb'},
+                         {'CgroupPermissions': 'rwm',
+                          'PathInContainer': '/dev/sdc',
+                          'PathOnHost': '/dev/sdc'}]}
+        )
+        self.assertEqual(
+            args[1]['headers'],
+            {'Content-Type': 'application/json'}
+        )
+        self.assertEqual(
+            args[1]['timeout'],
+            docker.client.DEFAULT_TIMEOUT_SECONDS
+        )
+
     def test_resize_container(self):
         try:
             self.client.resize(


### PR DESCRIPTION
The command line and daemon started supporting --device
parameter during docker start a while ago in the following commit:
docker/docker@e855c4b

Since the command line looks like this,
--device=[] Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc)
This patch allows a list of strings to be passed into the start() method
and we parse out the 3 components just like in the above mentioned commit
