### PR TITLE
Require highest level of client-supported SSL/TLS crypto

### DIFF
--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -4,6 +4,7 @@
 """
 from distutils.version import StrictVersion
 from requests.adapters import HTTPAdapter
+import ssl
 try:
     import requests.packages.urllib3 as urllib3
 except ImportError:
@@ -13,9 +14,19 @@ except ImportError:
 PoolManager = urllib3.poolmanager.PoolManager
 
 
+def get_max_tls_protocol():
+    protocols = ('PROTOCOL_TLSv1_2',
+                 'PROTOCOL_TLSv1_1',
+                 'PROTOCOL_TLSv1')
+    for proto in protocols:
+        if hasattr(ssl, proto):
+            return proto
+
+
 class SSLAdapter(HTTPAdapter):
     '''An HTTPS Transport Adapter that uses an arbitrary SSL version.'''
     def __init__(self, ssl_version=None, assert_hostname=None, **kwargs):
+        ssl_version = ssl_version or get_max_tls_protocol()
         self.ssl_version = ssl_version
         self.assert_hostname = assert_hostname
         super(SSLAdapter, self).__init__(**kwargs)

--- a/docker/tls.py
+++ b/docker/tls.py
@@ -17,8 +17,11 @@ class TLSConfig(object):
         # here, but also disable any public/default CA pool verification by
         # leaving tls_verify=False
 
-        # urllib3 sets a default ssl_version if ssl_version is None
-        # http://tinyurl.com/kxga8hb
+        # urllib3 sets a default ssl_version if ssl_version is None,
+        # but that default is the vulnerable PROTOCOL_SSLv23 selection,
+        # so we override the default with the maximum supported in the running
+        # Python interpeter up to TLS 1.2. (see: http://tinyurl.com/kxga8hb)
+        ssl_version = ssl_version or ssladapter.get_max_tls_protocol()
         self.ssl_version = ssl_version
         self.assert_hostname = assert_hostname
 


### PR DESCRIPTION
Up to TLS 1.2, support the highest locally supported crypto
protocol. This eliminates the previous default of PROTOCOL_SSLv23,
replacing it with what should be TLSv1 for Python 2.7 and TLSv1.2
for newer versions of Python 3.

Developers using docker-py may still specify the ssl_version to
override the default.

Fixes #367 
