### PR TITLE
When docker is stopped, docker-py receive a empty string

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -291,7 +291,7 @@ class Client(requests.Session):
                 size = int(size_line, 16)
             else:
                 break
-            
+
             if size <= 0:
                 break
             data = socket.readline()


### PR DESCRIPTION
I have a daemon that wait on docker with c.events().

When I restart docker, it fail with :

```
  File "./dockerdns.py", line 532, in loop
    for e in self.c.events():
  File "/usr/lib/python2.6/site-packages/docker/client.py", line 233, in _stream_helper
    size = int(size_line, 16)
```

I'm running this on a Redhat 6, with standard python (2.6.6)
This small patch should avoid that.
