### PR TITLE
Walk file tree in order for deterministic builds

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -72,7 +72,8 @@ def tar(path, exclude=None):
             fnames = [name for name in filenames
                       if not fnmatch_any(os.path.join(relpath, name),
                                          exclude)]
-        for name in fnames:
+        dirnames.sort()
+        for name in sorted(fnames):
             arcname = os.path.join(relpath, name)
             t.add(os.path.join(path, arcname), arcname=arcname)
         for name in dirnames:


### PR DESCRIPTION
Python's `os.walk` does not order the lists of files and directories it returns, so in order to produce a consistent build context tarfile, they should be ordered.

The go client uses [`archive.TarWithOptions`](https://github.com/docker/docker/blob/73057168fa6f8852c52cdc92f790446da865f2e7/pkg/archive/archive.go#L390) which in turn uses go's [`filepath.Walk`](http://golang.org/pkg/path/filepath/#Walk), which states:

> The files are walked in lexical order, which makes the output deterministic but means that for very large directories Walk can be inefficient.

:)
