### PR TITLE
Ensure client version is a string.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -51,7 +51,7 @@ class Client(requests.Session):
                 'If using TLS, the base_url argument must begin with '
                 '"https://".')
         self.base_url = base_url
-        self._version = version
+        self._version = str(version)
         self._timeout = timeout
         self._auth_configs = auth.load_config()
 


### PR DESCRIPTION
I was bitten by specifying the Docker client version as a float rather than a string.

Example test case:

``` python
>>> import docker
>>> client = docker.Client(version=1.14)
>>> client.containers()
[]
>>> client.pull('ubuntu')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "docker/client.py", line 816, in pull
    if utils.compare_version('1.5', self._version) >= 0:
  File "docker/utils/utils.py", line 100, in compare_version
    s2 = StrictVersion(v2)
  File "/usr/lib/python2.7/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/usr/lib/python2.7/distutils/version.py", line 105, in parse
    match = self.version_re.match(vstring)
TypeError: expected string or buffer

>>> client = docker.Client(version='1.14')
>>> client.containers()
[]
>>> client.pull('ubuntu')
u'{"status":"Pulling repository ubuntu"} [... snip ...] "id":"0b310e6bf058"}'
```
