### PR TITLE
add remove '/v1/' to try get the authcfg

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -99,7 +99,7 @@ def resolve_authconfig(authconfig, registry=None):
         return authconfig[org_registry]
 
     rs = authconfig.get(swap_protocol(registry), None) \
-    or authconfig.get(swap_protocol(org_registry), None)
+        or authconfig.get(swap_protocol(org_registry), None)
 
     return rs
 


### PR DESCRIPTION
If docker login registry not add the '/v1/', the docker will not save the '/v1/' to .dockercfg.
So push to the registry will not find the authcfg and the 'X-Registry-Auth' will not add to push request .

eg:

docker login https://quay.io
It will save {"https://quay.io":{"auth":"xxxxx","email":"xxxxx"}} to .dockercfg

And if push:
client.push("quay.io/xxx/xxx", stream=False, insecure_registry=True)
it will not get the record, so the 'X-Registry-Auth' will not add to the push request.
