### PR TITLE
environment variables with utf-8 enconding

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -109,7 +109,7 @@ class Client(requests.Session):
             command = shlex.split(str(command))
         if isinstance(environment, dict):
             environment = [
-                '{0}={1}'.format(k, v) for k, v in environment.items()
+                u'{0}={1}'.format(k, v) for k, v in environment.items()
             ]
 
         if isinstance(mem_limit, six.string_types):


### PR DESCRIPTION
I was getting this problem below when using environment variables with utf-8 characters.

``` bash
Traceback (most recent call last):
  File "/usr/local/bin/fig", line 9, in <module>
    load_entry_point('fig==1.0.1', 'console_scripts', 'fig')()
  File "/usr/local/lib/python2.7/dist-packages/fig/cli/main.py", line 31, in main
    command.sys_dispatch()
  File "/usr/local/lib/python2.7/dist-packages/fig/cli/docopt_command.py", line 21, in sys_dispatch
    self.dispatch(sys.argv[1:], None)
  File "/usr/local/lib/python2.7/dist-packages/fig/cli/command.py", line 30, in dispatch
    super(Command, self).dispatch(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/fig/cli/docopt_command.py", line 24, in dispatch
    self.perform_command(*self.parse(argv, global_options))
  File "/usr/local/lib/python2.7/dist-packages/fig/cli/command.py", line 58, in perform_command
    handler(project, command_options)
  File "/usr/local/lib/python2.7/dist-packages/fig/cli/main.py", line 319, in run
    **container_options
  File "/usr/local/lib/python2.7/dist-packages/fig/service.py", line 178, in create_container
    return Container.create(self.client, **container_options)
  File "/usr/local/lib/python2.7/dist-packages/fig/container.py", line 37, in create
    response = client.create_container(**options)
  File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 527, in create_container
    entrypoint, cpu_shares, working_dir, domainname, memswap_limit
  File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 115, in _container_config
    '{0}={1}'.format(k, v) for k, v in environment.items()
UnicodeEncodeError: 'ascii' codec can't encode character u'\xea' in position 14: ordinal not in range(128)
```

I solved the problem with this approach in this pull request. Since I'm not a python developer I'm not sure this is really the best approach. I have tried also open my yaml file (which is where [fig](https://github.com/docker/fig) set the environment variables) but that didn't solve the problem.
