### PR TITLE
Fix expand_registry_url to be consistent with docker client.

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -36,13 +36,11 @@ def swap_protocol(url):
 
 def expand_registry_url(hostname, insecure=False):
     if hostname.startswith('http:') or hostname.startswith('https:'):
-        if '/' not in hostname[9:]:
-            hostname = hostname + '/v1/'
         return hostname
     if utils.ping('https://' + hostname + '/v1/_ping'):
-        return 'https://' + hostname + '/v1/'
+        return 'https://' + hostname
     elif insecure:
-        return 'http://' + hostname + '/v1/'
+        return 'http://' + hostname
     else:
         raise errors.DockerException(
             "HTTPS endpoint unresponsive and insecure mode isn't enabled."


### PR DESCRIPTION
In docker-py's auth.py the functions 'resolve_repository_name' and 'expand_registry_url' work together to resolve a hostname prefix to a base URL suitable for interaction as a Docker registry.

For example, "docker push foo.com/bar/baz" would try to resolve the base URL "http[s]://foo.com".

These functions loosely correlate to 'ResolveRepositoryName' and 'newEndpoint' in the docker client code, respectively.

You can see from their implementations:
- ResolveRepositoryName: https://github.com/docker/docker/blob/master/registry/registry.go#L191
- newEndpoint: https://github.com/docker/docker/blob/master/registry/endpoint.go#L71

that neither of them appends 'v1' to the hostname during resolution.

This change simply removes the 'v1' suffix from these code paths, which enables docker-py to authenticate against private registries with which the docker client can already.
