### PR TITLE
return the socket on execute

### DIFF
--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -232,11 +232,18 @@ def post_fake_execute():
 
 
 def post_fake_execute_start():
-    status_code = 200
     response = (b'\x01\x00\x00\x00\x00\x00\x00\x11bin\nboot\ndev\netc\n'
                 b'\x01\x00\x00\x00\x00\x00\x00\x12lib\nmnt\nproc\nroot\n'
-                b'\x01\x00\x00\x00\x00\x00\x00\x0csbin\nusr\nvar\n')
-    return status_code, response
+                b'\x01\x00\x00\x00\x00\x00\x00\x0dsbin\nusr\nvar\n')
+
+    class mockSock():
+        def __init__(self):
+            self.content = response
+
+        def __getitem__(self, i):
+            return response[i]
+
+    return 200, mockSock()
 
 
 def post_fake_stop_container():

--- a/tests/test.py
+++ b/tests/test.py
@@ -50,8 +50,11 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
              request=None):
     res = requests.Response()
     res.status_code = status_code
-    if not isinstance(content, six.binary_type):
-        content = json.dumps(content).encode('ascii')
+    try:
+        if not isinstance(content, six.binary_type):
+            content = json.dumps(content).encode('ascii')
+    except:
+        pass
     res._content = content
     res.headers = requests.structures.CaseInsensitiveDict(headers or {})
     res.reason = reason
@@ -1431,17 +1434,55 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         self.assertEqual(json.loads(args[1]['data']),
                          json.loads('''{
                             "Tty": false,
-                            "AttachStderr": true,
-                            "Container": "3cc2351ab11b",
-                            "Cmd": ["ls", "-1"],
-                            "AttachStdin": false,
-                            "User": "",
-                            "Detach": false,
-                            "Privileged": false,
-                            "AttachStdout": true}'''))
+                            "Detach": false}'''))
 
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
+
+    def test_execute_create(self):
+        try:
+            self.client.executeCreate(fake_api.FAKE_CONTAINER_ID, ['ls', '-1'])
+        except Exception as e:
+            msg = 'docker exec create should not raise exception: {0}'
+            self.fail(msg.format(e))
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][0],
+                         url_prefix + 'containers/3cc2351ab11b/exec')
+        self.assertEquals(json.loads(args[1]['data']),
+                          json.loads('''{
+                              "AttachStdin": false,
+                              "AttachStdout": true,
+                              "AttachStderr": true,
+                              "Detach": false,
+                              "Tty": false,
+                              "Privileged": false,
+                              "Cmd": ["ls", "-1"],
+                              "User": "",
+                              "Container": "3cc2351ab11b"}'''))
+
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+        actual_id = json.loads(fake_request(args[0][0], None).content)['Id']
+        self.assertEqual(actual_id,
+                         '3cc2351ab11b')
+
+    def test_execute_start(self):
+        try:
+            res = self.client.executeStart(fake_api.FAKE_CONTAINER_ID,
+                                           stream=False)
+        except Exception as e:
+            msg = 'docker exec start should not raise exception: {0}'
+            self.fail(msg.format(e))
+
+        val = ''
+        if six.PY3:
+            val = bytes().join([x for x in res.read()])
+        else:
+            val = str().join([x for x in res.read()])
+        expected_resp_part1 = '''bin\nboot\ndev\netc\n'''
+        expected_resp_part2 = '''lib\nmnt\nproc\nroot\nsbin\nusr\nvar\n'''
+        self.assertEqual(val, expected_resp_part1 + expected_resp_part2)
 
     def test_pause_container(self):
         try:


### PR DESCRIPTION
`docker_exec -it` is not supported by docker-py. Currently, docker-py only supports reading of the response of executing a command from Stdout/Stderr. 

However, one cannot attach to the Stdin. This pull request is meant to address that.

The way I do it is by returning the raw socket to the caller of this method. The caller can then call read from Stdout/Stderr and write to Stdin using the socket.

Notes: The fake_api.post_fake_execute_start has an object called response. The third value in that tuple breaks docker's defined multiplexing format. The given amount of data  is 13 bytes, but it is set to 12 bytes. This PR also includes a fix for that.
