### PR TITLE
flake8 fails with F821 for unicode under python 3.4.2

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -115,7 +115,8 @@ class Client(requests.Session):
             command = shlex.split(str(command))
         if isinstance(environment, dict):
             environment = [
-                unicode('{0}={1}').format(k, v) for k, v in environment.items()
+                (six.text_type('{0}={1}').format(k, v)
+                    for k, v in environment.items())
             ]
 
         if isinstance(mem_limit, six.string_types):

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -132,7 +132,7 @@ class TestListContainers(BaseTestCase):
         self.assertEqual(len(retrieved), 1)
         retrieved = retrieved[0]
         self.assertIn('Command', retrieved)
-        self.assertEqual(retrieved['Command'], unicode('true'))
+        self.assertEqual(retrieved['Command'], six.text_type('true'))
         self.assertIn('Image', retrieved)
         self.assertRegexpMatches(retrieved['Image'], r'busybox:.*')
         self.assertIn('Status', retrieved)
@@ -1064,7 +1064,7 @@ class TestBuildFromStringIO(BaseTestCase):
     def runTest(self):
         if six.PY3:
             return
-        script = io.StringIO(unicode('\n').join([
+        script = io.StringIO(six.text_type('\n').join([
             'FROM busybox',
             'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',


### PR DESCRIPTION
fix for issue https://github.com/docker/docker-py/issues/434
