### PR TITLE
return the socket on execute

### DIFF
--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -232,11 +232,18 @@ def post_fake_execute():
 
 
 def post_fake_execute_start():
-    status_code = 200
     response = (b'\x01\x00\x00\x00\x00\x00\x00\x11bin\nboot\ndev\netc\n'
                 b'\x01\x00\x00\x00\x00\x00\x00\x12lib\nmnt\nproc\nroot\n'
-                b'\x01\x00\x00\x00\x00\x00\x00\x0csbin\nusr\nvar\n')
-    return status_code, response
+                b'\x01\x00\x00\x00\x00\x00\x00\x0dsbin\nusr\nvar\n')
+
+    class mockSock():
+        def __init__(self):
+            self.content = response
+
+        def __getitem__(self, i):
+            return response[i]
+
+    return 200, mockSock()
 
 
 def post_fake_stop_container():


### PR DESCRIPTION
`docker exec -it` is not supported by docker-py. Currently, docker-py supports reading of the response on executing a command. 

However, one cannot attach to the Stdin and send data. This pull request is meant to address that.

The way I do it is by returning the raw socket to the caller of this method. The caller can then call read from Stdout/Stderr and write to Stdin using the socket.
