### PR TITLE
Update boot2docker docs with tls workaround

### DIFF
--- a/docs/boot2docker.md
+++ b/docs/boot2docker.md
@@ -21,3 +21,17 @@ from docker.utils import kwargs_from_env
 client = Client(**kwargs_from_env())
 print client.version()
 ```
+
+To avoid the common error `SSLError: hostname '192.168.59.103' doesn't match 'boot2docker'`, you
+can disable hostname validation.
+
+```python
+from docker.client import Client
+from docker.utils import kwargs_from_env
+
+kwargs = kwargs_from_env()
+kwargs['tls'].assert_hostname = False
+
+client = Client(**kwargs)
+print client.version()
+```


### PR DESCRIPTION
Is this is an appropriate solution to tls with boot2docker failing on OSX?

```python
from docker.client import Client
from docker.utils import kwargs_from_env

kwargs = kwargs_from_env()
kwargs['tls'].assert_hostname = False

client = Client(**kwargs)
print client.version()
```

Updating docs (also mentioned in https://github.com/docker/docker-py/issues/369#issuecomment-62772509)