### PR TITLE
Improvements to import_image() function

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -42,31 +42,35 @@ class Client(requests.Session):
     def __init__(self, base_url=None, version=DEFAULT_DOCKER_API_VERSION,
                  timeout=DEFAULT_TIMEOUT_SECONDS, tls=False):
         super(Client, self).__init__()
-        base_url = utils.parse_host(base_url)
-        if 'http+unix:///' in base_url:
-            base_url = base_url.replace('unix:/', 'unix:')
+
         if tls and not base_url.startswith('https://'):
             raise errors.TLSParameterError(
                 'If using TLS, the base_url argument must begin with '
                 '"https://".')
+
         if not isinstance(version, six.string_types):
             raise errors.DockerException(
                 'version parameter must be a string. Found {0}'.format(
                     type(version).__name__
                 )
             )
-        self.base_url = base_url
+
         self._version = version
         self._timeout = timeout
         self._auth_configs = auth.load_config()
 
-        # Use SSLAdapter for the ability to specify SSL version
-        if isinstance(tls, TLSConfig):
-            tls.configure_client(self)
-        elif tls:
-            self.mount('https://', ssladapter.SSLAdapter())
+        base_url = utils.parse_host(base_url)
+        if base_url.startswith('http+unix://'):
+            unix_socket_adapter = unixconn.UnixAdapter(base_url, timeout)
+            self.mount('http+docker://', unix_socket_adapter)
+            self.base_url = 'http+docker://localunixsocket'
         else:
-            self.mount('http+unix://', unixconn.UnixAdapter(base_url, timeout))
+            # Use SSLAdapter for the ability to specify SSL version
+            if isinstance(tls, TLSConfig):
+                tls.configure_client(self)
+            elif tls:
+                self.mount('https://', ssladapter.SSLAdapter())
+            self.base_url = base_url
 
     def _set_request_timeout(self, kwargs):
         """Prepare the kwargs for an HTTP request by inserting the timeout

--- a/docs/api.md
+++ b/docs/api.md
@@ -314,6 +314,48 @@ the name of an existing image to import from.
 * tag (str): The tag to apply
 * image (str): Use another image like the `FROM` Dockerfile parameter
 
+## import_image_from_data
+
+Like `.import_image()`, but allows importing in-memory bytes data.
+
+**Params**:
+
+* data (bytes collection): Bytes collection containing valid tar data
+* repository (str): The repository to create
+* tag (str): The tag to apply
+
+## import_image_from_file
+
+Like `.import_image()`, but only supports importing from a tar file on
+disk. If the file doesn't exist it will raise `IOError`.
+
+**Params**:
+
+* filename (str): Full path to a tar file.
+* repository (str): The repository to create
+* tag (str): The tag to apply
+
+## import_image_from_url
+
+Like `.import_image()`, but only supports importing from a URL.
+
+**Params**:
+
+* url (str): A URL pointing to a tar file.
+* repository (str): The repository to create
+* tag (str): The tag to apply
+
+## import_image_from_image
+
+Like `.import_image()`, but only supports importing from another image,
+like the `FROM` Dockerfile parameter.
+
+**Params**:
+
+* image (str): Image name to import from
+* repository (str): The repository to create
+* tag (str): The tag to apply
+
 ## info
 
 Display system-wide information. Identical to the `docker info` command.

--- a/docs/api.md
+++ b/docs/api.md
@@ -296,16 +296,20 @@ layers)
 
 ## import_image
 
-Identical to the `docker import` command. If `src` is a string or unicode
-string, it will be treated as a URL to fetch the image from. To import an image
-from the local machine, `src` needs to be a file-like object or bytes
-collection.  To import from a tarball use your absolute path to your tarball.
-To load arbitrary data as tarball use whatever you want as src and your
-tarball content in data.
+Similar to the `docker import` command.
+
+If `src` is a string or unicode string, it will first be treated as a path to
+a tarball on the local system. If there is an error reading from that file,
+src will be treated as a URL instead to fetch the image from. You can also pass
+an open file handle as 'src', in which case the data will be read from that
+file.
+
+If `src` is unset but `image` is set, the `image` paramater will be taken as
+the name of an existing image to import from.
 
 **Params**:
 
-* src (str or file): Path to tarfile or URL
+* src (str or file): Path to tarfile, URL, or file-like object
 * repository (str): The repository to create
 * tag (str): The tag to apply
 * image (str): Use another image like the `FROM` Dockerfile parameter

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -324,7 +324,7 @@ def post_fake_tag_image():
 
 
 # Maps real api url to fake response callback
-prefix = 'http+unix://var/run/docker.sock'
+prefix = 'http+docker://localunixsocket'
 fake_responses = {
     '{1}/{0}/version'.format(CURRENT_VERSION, prefix):
     get_fake_version,

--- a/tests/test.py
+++ b/tests/test.py
@@ -71,7 +71,7 @@ def fake_resp(url, data=None, **kwargs):
 
 
 fake_request = mock.Mock(side_effect=fake_resp)
-url_prefix = 'http+unix://var/run/docker.sock/v{0}/'.format(
+url_prefix = 'http+docker://localunixsocket/v{0}/'.format(
     docker.client.DEFAULT_DOCKER_API_VERSION)
 
 
@@ -1267,20 +1267,24 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             timeout=None
         )
 
+    def _socket_path_for_client_session(self, client):
+        socket_adapter = client.get_adapter('http+docker://')
+        return socket_adapter.socket_path
+
     def test_url_compatibility_unix(self):
         c = docker.Client(base_url="unix://socket")
 
-        assert c.base_url == "http+unix://socket"
+        assert self._socket_path_for_client_session(c) == '/socket'
 
     def test_url_compatibility_unix_triple_slash(self):
         c = docker.Client(base_url="unix:///socket")
 
-        assert c.base_url == "http+unix://socket"
+        assert self._socket_path_for_client_session(c) == '/socket'
 
     def test_url_compatibility_http_unix_triple_slash(self):
         c = docker.Client(base_url="http+unix:///socket")
 
-        assert c.base_url == "http+unix://socket"
+        assert self._socket_path_for_client_session(c) == '/socket'
 
     def test_url_compatibility_http(self):
         c = docker.Client(base_url="http://hostname:1234")

--- a/tests/test.py
+++ b/tests/test.py
@@ -1700,12 +1700,11 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
         )
 
-    def test_import_image_from_file(self):
-        buf = tempfile.NamedTemporaryFile(delete=False)
+    def test_import_image_from_bytes(self):
+        stream = (i for i in range(0, 100))
         try:
-            # pretent the buffer is a file
             self.client.import_image(
-                buf.name,
+                stream,
                 repository=fake_api.FAKE_REPO_NAME,
                 tag=fake_api.FAKE_TAG_NAME
             )
@@ -1717,13 +1716,14 @@ class DockerClientTest(Cleanup, unittest.TestCase):
             params={
                 'repo': fake_api.FAKE_REPO_NAME,
                 'tag': fake_api.FAKE_TAG_NAME,
-                'fromSrc': '-'
+                'fromSrc': '-',
             },
-            data='',
+            headers={
+                'Content-Type': 'application/tar',
+            },
+            data=stream,
             timeout=docker.client.DEFAULT_TIMEOUT_SECONDS
         )
-        buf.close()
-        os.remove(buf.name)
 
     def test_import_image_from_image(self):
         try:


### PR DESCRIPTION
I've been looking at https://github.com/docker/docker-py/issues/322 and these are the various fixes I've come up with so far.

All types of import now work except for importing from a stream (by which I mean: a file-like object which Requests is unable to determine the length of). We need to use HTTP chunked transfer encoding for this (since it might be too big to read the whole thing into memory at once) but the connection gets closed after the first chunk. This may be a bug in Requests or Docker rather than docker-py.

I added integration tests for the import_image() function. All pass except for TestImportFromStream. Without the changes in this branch, all tests fail other than TestImportFromURL, with the following output:

    ======================================================================
    ERROR: runTest (tests.integration_test.TestImportFromBytes)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "tests/integration_test.py", line 894, in runTest
        src=content, repository='test/import-from-bytes')
      File "docker/client.py", line 660, in import_image
        fic = open(src)
    TypeError: file() argument 1 must be encoded string without NULL bytes,
    not str

    ======================================================================
    ERROR: runTest (tests.integration_test.TestImportFromFile)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "tests/integration_test.py", line 910, in runTest
        src=tar_filename, repository='test/import-from-file')
      File "docker/client.py", line 669, in import_image
        return self._result(self._post(u, data=data, params=params))
      File "docker/client.py", line 79, in _post
        return self.post(url, **self._set_request_timeout(kwargs))
      File "/usr/lib/python2.7/site-packages/requests/sessions.py", line
    425, in post
        return self.request('POST', url, data=data, **kwargs)
      File "/usr/lib/python2.7/site-packages/requests/sessions.py", line
    383, in request
        resp = self.send(prep, **send_kwargs)
      File "/usr/lib/python2.7/site-packages/requests/sessions.py", line
    486, in send
        r = adapter.send(request, **kwargs)
      File "/usr/lib/python2.7/site-packages/requests/adapters.py", line
    330, in send
        timeout=timeout
      File
    "/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py",
    line 480, in urlopen
        body=body, headers=headers)
      File
    "/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py",
    line 285, in _make_request
        conn.request(method, url, **httplib_request_kw)
      File "docker/unixconn/unixconn.py", line 53, in request
        super(UnixHTTPConnection, self).request(method, url, **kwargs)
      File "/usr/lib64/python2.7/httplib.py", line 973, in request
        self._send_request(method, url, body, headers)
      File "/usr/lib64/python2.7/httplib.py", line 1007, in _send_request
        self.endheaders(body)
      File "/usr/lib64/python2.7/httplib.py", line 969, in endheaders
        self._send_output(message_body)
      File "/usr/lib64/python2.7/httplib.py", line 827, in _send_output
        msg += message_body
    MemoryError

    ======================================================================
    ERROR: runTest (tests.integration_test.TestImportFromStream)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "tests/integration_test.py", line 928, in runTest
        src=tar_stream, repository='test/import-from-stream')
      File "docker/client.py", line 660, in import_image
        fic = open(src)
    TypeError: coercing to Unicode: need string or buffer, instance found