### PR TITLE
removed unnecessary registry host check as proposed in #451

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -59,11 +59,6 @@ def resolve_repository_name(repo_name, insecure=False):
         raise errors.InvalidRepository(
             'Invalid repository name ({0})'.format(repo_name))
 
-    if 'index.docker.io' in parts[0] or 'registry.hub.docker.com' in parts[0]:
-        raise errors.InvalidRepository(
-            'Invalid repository name, try "{0}" instead'.format(parts[1])
-        )
-
     return expand_registry_url(parts[0], insecure), parts[1]
 
 


### PR DESCRIPTION
See #451 for reasoning.  The main point is that by not allowing index.docker.io and registry.hub.docker.com to be explicitly provided, client.pull is inconsistent with the docker command line client.