### PR TITLE
removed exception thrown if registry.hub.docker.com is explicitly define...

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -59,7 +59,7 @@ def resolve_repository_name(repo_name, insecure=False):
         raise errors.InvalidRepository(
             'Invalid repository name ({0})'.format(repo_name))
 
-    if 'index.docker.io' in parts[0] or 'registry.hub.docker.com' in parts[0]:
+    if 'index.docker.io' in parts[0]:
         raise errors.InvalidRepository(
             'Invalid repository name, try "{0}" instead'.format(parts[1])
         )


### PR DESCRIPTION
...d in repository param for client.pull

Replaces #452 since index.docker.io is still not allowed to be explicitly provided when pulling with the docker client