### PR TITLE
Adds a fix for the bug where a fully-qualified URI given as the registry...

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -22,7 +22,12 @@ import six
 from ..utils import utils
 from .. import errors
 
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    # we're probably in py3k
+    from urllib import parse as urlparse
+
 
 INDEX_URL = 'https://index.docker.io/v1/'
 DOCKER_CONFIG_FILENAME = '.dockercfg'

--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -22,6 +22,8 @@ import six
 from ..utils import utils
 from .. import errors
 
+import urlparse
+
 INDEX_URL = 'https://index.docker.io/v1/'
 DOCKER_CONFIG_FILENAME = '.dockercfg'
 
@@ -36,6 +38,13 @@ def swap_protocol(url):
 
 def expand_registry_url(hostname, insecure=False):
     if hostname.startswith('http:') or hostname.startswith('https:'):
+        parts = urlparse.urlparse(hostname)
+        path = parts.path.split("/")
+        # If v1 is in the URL, strip it. This allows for users who were using
+        # the previous variant of a fully-qualifed URI to have The Right Thing
+        # happen.
+        if "v1" in path:
+            return parts.scheme + "://" + parts.netloc
         return hostname
     if utils.ping('https://' + hostname + '/v1/_ping'):
         return 'https://' + hostname

--- a/tests/test.py
+++ b/tests/test.py
@@ -65,7 +65,6 @@ def fake_resolve_authconfig(authconfig, registry=None):
     return None
 
 def true_ping(uri):
-    print "true ping"
     return True
 
 def false_ping(uri):

--- a/tests/test.py
+++ b/tests/test.py
@@ -64,11 +64,14 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
 def fake_resolve_authconfig(authconfig, registry=None):
     return None
 
+
 def true_ping(uri):
     return True
 
+
 def false_ping(uri):
     return False
+
 
 def fake_resp(url, data=None, **kwargs):
     status_code, content = fake_api.fake_responses[url]()
@@ -2054,7 +2057,7 @@ class DockerClientTest(Cleanup, unittest.TestCase):
 
     def test_unqualified_registry(self, ):
         registry = "my.registry.io"
-        # Force the ping to return true, so that we get a 
+        # Force the ping to return true, so that we get a
         # value back
         with mock.patch("docker.utils.utils.ping", true_ping):
             hn = docker.auth.auth.expand_registry_url(registry, insecure=False)
@@ -2072,7 +2075,6 @@ class DockerClientTest(Cleanup, unittest.TestCase):
 
         self.assertEqual(hn, registry)
 
-
     def test_registry_with_tailing_v1(self):
         registry = "https://my.registry.io/v1/"
         stripped = "https://my.registry.io"
@@ -2080,7 +2082,7 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         hn = docker.auth.auth.expand_registry_url(registry)
 
         self.assertEqual(hn, stripped)
-    
+
     def test_tar_with_excludes(self):
         base = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, base)

--- a/tests/test.py
+++ b/tests/test.py
@@ -2047,6 +2047,35 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         self.assertEqual(cfg['email'], 'sakuya@scarlet.net')
         self.assertEqual(cfg.get('auth'), None)
 
+    def test_registry_with_tailing_v1(self):
+        folder = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, folder)
+
+        dockercfg_path = os.path.join(folder,
+                                      '.{0}.dockercfg'.format(
+                                          random.randrange(100000)))
+        registry_stripped = 'https://your.private.registry.io'
+        registry = registry_stripped + "/v1/"
+        auth_ = base64.b64encode(b'sakuya:izayoi').decode('ascii')
+        config = {
+            registry: {
+                'auth': '{0}'.format(auth_),
+                'email': 'sakuya@scarlet.net'
+            }
+        }
+        
+        with open(dockercfg_path, 'w') as f:
+            f.write(json.dumps(config))
+
+        cfg = docker.auth.load_config(dockercfg_path)
+        self.assertTrue(registry_stripped in cfg)
+        self.assertNotEqual(cfg[registry_stripped], None)
+        cfg = cfg[registry_stripped]
+        self.assertEqual(cfg['username'], 'sakuya')
+        self.assertEqual(cfg['password'], 'izayoi')
+        self.assertEqual(cfg['email'], 'sakuya@scarlet.net')
+        self.assertEqual(cfg.get('auth'), None)
+    
     def test_tar_with_excludes(self):
         base = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, base)


### PR DESCRIPTION
..., with trailing /v1, will be placed as-is in the auth_config directory, whereas subsequent lookups to auth_config will be performed with a registry URI that lacks the trailing /v1.