### PR TITLE
Fix authconfig resolve for private registries

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -83,7 +83,7 @@ def resolve_authconfig(authconfig, registry=None):
     #
     # as there is only one auth entry which is fully qualified we need to start
     # parsing and matching
-    if '/' not in registry:
+    if not registry.endswith("/v1/"):
         registry = registry + '/v1/'
     if not registry.startswith('http:') and not registry.startswith('https:'):
         registry = 'https://' + registry


### PR DESCRIPTION
Due to d8eb04084b6631c1d2b9c864ddcd171a183b6025, private registry auth configs were not resolved. This commit fixes it.