### PR TITLE
Fix registry url canonicalization in resolve_authconfig

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -83,7 +83,7 @@ def resolve_authconfig(authconfig, registry=None):
     #
     # as there is only one auth entry which is fully qualified we need to start
     # parsing and matching
-    if '/' not in registry:
+    if '/v1/' not in registry:
         registry = registry + '/v1/'
     if not registry.startswith('http:') and not registry.startswith('https:'):
         registry = 'https://' + registry


### PR DESCRIPTION
This fixes a problem where URLs aren't canonicalised properly and so authentication isn't pulled out of the file correctly in some cases, causing a 403, even though the correct details are in the .dockercfg file. The problem was that the check whether the URL included the path element was too general and was fooled by the "/" in the method.