### PR TITLE
Only exclude the buggy "requests" release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'requests >= 2.2.1, < 2.5.0',
+    'requests >= 2.2.1, != 2.5.0',
     'six >= 1.3.0',
 ]
 


### PR DESCRIPTION
The commit 9e295d6 force "requests" version lower than 2.5.0 because of an urllib3 bug.
The version 2.5.1 (http://docs.python-requests.org/en/latest/community/updates/#id1) seems to fix the issue so it's better to only exclude the faulty release allowing user to upgrade requests above 2.5.1.