### PR TITLE
Fix crash when building from remote sources

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -450,6 +450,8 @@ class Client(requests.Session):
             # Send the full auth configuration (if any exists), since the build
             # could use any (or all) of the registries.
             if self._auth_configs:
+                if headers is None:
+                    headers = {}
                 headers['X-Registry-Config'] = auth.encode_full_header(
                     self._auth_configs
                 )

--- a/tests/test.py
+++ b/tests/test.py
@@ -2003,6 +2003,20 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
+    def test_build_remote_with_registry_auth(self):
+        try:
+            self.client._auth_configs = {
+                'https://example.com': {
+                    'user': 'example',
+                    'password': 'example',
+                    'email': 'example@example.com'
+                }
+            }
+
+            self.client.build(path='https://github.com/docker-library/mongo')
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
     #######################
     #  PY SPECIFIC TESTS  #
     #######################


### PR DESCRIPTION
Avoid crashing when the Docker python client is able to load
registry credentials when building using a remote source