### PR TITLE
Update Client.build() docs to note rm default mis-match

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -52,7 +52,9 @@ correct value (e.g `gzip`).
 * quiet (bool): Whether to return the status
 * fileobj: A file object to use as the Dockerfile. (Or a file-like object)
 * nocache (bool): Don't use the cache when set to `True`
-* rm (bool): Remove intermediate containers
+* rm (bool): Remove intermediate containers. The `docker build` command now
+  defaults to ``--rm=true``, but we have kept the old default of `False`
+  to preserve backward compatibility
 * stream (bool): *Deprecated for API version > 1.8 (always True)*.
   Return a blocking generator you can iterate over to retrieve build output as
   it happens


### PR DESCRIPTION
I figured we probably wanted to include some context for the mis-match, so this ended up being a little bit of a long param docstring. Seemed worth explaining so people won't repeatedly bring this up in the issue tracker. Fixes #332 .