### PR TITLE
Add missing options to the events command

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -23,6 +23,8 @@ import requests
 import requests.exceptions
 import six
 
+from datetime import datetime
+
 from .auth import auth
 from .unixconn import unixconn
 from .ssladapter import ssladapter
@@ -565,8 +567,24 @@ class Client(requests.Session):
         return self._result(self._get(self._url("/containers/{0}/changes".
                             format(container))), True)
 
-    def events(self):
-        return self._stream_helper(self.get(self._url('/events'), stream=True))
+    def events(self, since=None, until=None, filters=None):
+        if isinstance(since, datetime):
+            since = utils.datetime_to_timestamp(since)
+
+        if isinstance(until, datetime):
+            until = utils.datetime_to_timestamp(until)
+
+        if filters:
+            filters = utils.convert_filters(filters)
+
+        params = {
+            'since': since,
+            'until': until,
+            'filters': filters
+        }
+
+        return self._stream_helper(self.get(self._url('/events'),
+                                            params=params, stream=True))
 
     def execute(self, container, cmd, detach=False, stdout=True, stderr=True,
                 stream=False, tty=False):

--- a/docker/client.py
+++ b/docker/client.py
@@ -569,7 +569,7 @@ class Client(requests.Session):
         return self._result(self._get(self._url("/containers/{0}/changes".
                             format(container))), True)
 
-    def events(self, since=None, until=None, filters=None):
+    def events(self, since=None, until=None, filters=None, decode=None):
         if isinstance(since, datetime):
             since = utils.datetime_to_timestamp(since)
 
@@ -587,7 +587,7 @@ class Client(requests.Session):
 
         return self._stream_helper(self.get(self._url('/events'),
                                             params=params, stream=True),
-                                   decode=True)
+                                   decode=decode)
 
     def execute(self, container, cmd, detach=False, stdout=True, stderr=True,
                 stream=False, tty=False):

--- a/docker/client.py
+++ b/docker/client.py
@@ -18,12 +18,11 @@ import re
 import shlex
 import struct
 import warnings
+from datetime import datetime
 
 import requests
 import requests.exceptions
 import six
-
-from datetime import datetime
 
 from .auth import auth
 from .unixconn import unixconn
@@ -31,6 +30,7 @@ from .ssladapter import ssladapter
 from .utils import utils
 from . import errors
 from .tls import TLSConfig
+
 
 if not six.PY3:
     import websocket

--- a/docker/client.py
+++ b/docker/client.py
@@ -292,7 +292,7 @@ class Client(requests.Session):
 
         return sock
 
-    def _stream_helper(self, response):
+    def _stream_helper(self, response, decode=False):
         """Generator for data coming from a chunked-encoded HTTP response."""
         if response.raw._fp.chunked:
             reader = response.raw
@@ -303,6 +303,8 @@ class Client(requests.Session):
                     break
                 if reader._fp.chunk_left:
                     data += reader.read(reader._fp.chunk_left)
+                if decode:
+                    data = json.loads(data)
                 yield data
         else:
             # Response isn't chunked, meaning we probably
@@ -584,7 +586,8 @@ class Client(requests.Session):
         }
 
         return self._stream_helper(self.get(self._url('/events'),
-                                            params=params, stream=True))
+                                            params=params, stream=True),
+                                   decode=True)
 
     def execute(self, container, cmd, detach=False, stdout=True, stderr=True,
                 stream=False, tty=False):

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -28,6 +28,7 @@ import six
 from .. import errors
 from .. import tls
 
+
 DEFAULT_HTTP_HOST = "127.0.0.1"
 DEFAULT_UNIX_SOCKET = "http+unix://var/run/docker.sock"
 
@@ -299,7 +300,8 @@ def convert_filters(filters):
 
 def datetime_to_timestamp(dt=datetime.now()):
     """Convert a datetime in local timezone to a unix timestamp"""
-    return int((dt - datetime.fromtimestamp(0)).total_seconds())
+    delta = dt - datetime.fromtimestamp(0)
+    return delta.seconds + delta.days * 24 * 3600
 
 
 def create_host_config(

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -20,6 +20,7 @@ import tarfile
 import tempfile
 from distutils.version import StrictVersion
 from fnmatch import fnmatch
+from datetime import datetime
 
 import requests
 import six
@@ -294,6 +295,11 @@ def convert_filters(filters):
             v = [v, ]
         result[k] = v
     return json.dumps(result)
+
+
+def datetime_to_timestamp(dt=datetime.now()):
+    """Convert a datetime in local timezone to a unix timestamp"""
+    return int((dt - datetime.fromtimestamp(0)).total_seconds())
 
 
 def create_host_config(

--- a/docs/api.md
+++ b/docs/api.md
@@ -245,10 +245,10 @@ function return a blocking generator you can iterate over to retrieve events as 
 **Returns** (generator):
 
 ```python
-{"status":"die",
-"id":"container-id",
-"from":"image/with:tag",
-"time":unix-timestamp}
+{u'status': u'start',
+ u'from': u'image/with:tag',
+ u'id': u'container-id',
+ u'time': 1423339459}
 ```
 
 ## execute

--- a/docs/api.md
+++ b/docs/api.md
@@ -229,6 +229,28 @@ Inspect changes on a container's filesystem
 
 **Returns** (str):
 
+## events
+
+Identical to the `docker events` command: get real time events from the server. The `events`
+function return a blocking generator you can iterate over to retrieve events as they happen.
+
+**Params**:
+
+* since (datetime or int): get events from this point
+
+* until (datetime or int): get events until this point
+
+* filters (dict): filter the events by event time, container or image
+
+**Returns** (generator):
+
+```python
+{"status":"die",
+"id":"container-id",
+"from":"image/with:tag",
+"time":unix-timestamp}
+```
+
 ## execute
 
 ```python

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -221,6 +221,13 @@ def get_fake_diff():
     return status_code, response
 
 
+def get_fake_events():
+    status_code = 200
+    response = [{'status': 'stop', 'id': FAKE_CONTAINER_ID,
+                 'from': FAKE_IMAGE_ID, 'time': 1423247867}]
+    return status_code, response
+
+
 def get_fake_export():
     status_code = 200
     response = 'Byte Stream....'
@@ -402,5 +409,7 @@ fake_responses = {
     '{1}/{0}/containers/create'.format(CURRENT_VERSION, prefix):
     post_fake_create_container,
     '{1}/{0}/build'.format(CURRENT_VERSION, prefix):
-    post_fake_build_container
+    post_fake_build_container,
+    '{1}/{0}/events'.format(CURRENT_VERSION, prefix):
+    get_fake_events
 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -190,10 +190,10 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         )
 
     def test_events_with_since_until(self):
-        now = datetime.datetime.now()
+        ts = 1356048000
+        now = datetime.datetime.fromtimestamp(ts)
         since = now - datetime.timedelta(seconds=10)
         until = now + datetime.timedelta(seconds=10)
-        ts = int((now - datetime.datetime.fromtimestamp(0)).total_seconds())
         try:
             self.client.events(since=since, until=until)
         except Exception as e:
@@ -210,7 +210,8 @@ class DockerClientTest(Cleanup, unittest.TestCase):
         )
 
     def test_events_with_filters(self):
-        filters = {'event': ['die', 'stop'], 'container': fake_api.FAKE_CONTAINER_ID}
+        filters = {'event': ['die', 'stop'],
+                   'container': fake_api.FAKE_CONTAINER_ID}
         try:
             self.client.events(filters=filters)
         except Exception as e:


### PR DESCRIPTION
- Add since, until and filters parameters to `Client.events`
- Add missing `events`command in the documentation

Signed-off-by: Christophe Labouisse <christophe@labouisse.org>