### PR TITLE
Add special cases for .dockerignore

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -297,6 +297,12 @@ class Client(requests.Session):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(bool, f.read().split('\n')))
+                    # These are handled by the docker daemon and should not be
+                    # excluded on the client
+                    if 'Dockerfile' in exclude:
+                        exclude.remove('Dockerfile')
+                    if '.dockerignore' in exclude:
+                        exclude.remove(".dockerignore")
             context = utils.tar(path, exclude=exclude)
 
         if utils.compare_version('1.8', self._version) >= 0:

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1311,6 +1311,8 @@ class TestBuildWithDockerignore(Cleanup, BaseTestCase):
         with open(os.path.join(base_dir, '.dockerignore'), 'w') as f:
             f.write("\n".join([
                 'node_modules',
+                'Dockerfile',
+                '.dockerginore',
                 '',  # empty line
             ]))
 
@@ -1329,6 +1331,8 @@ class TestBuildWithDockerignore(Cleanup, BaseTestCase):
                 chunk = chunk.decode('utf-8')
             logs += chunk
         self.assertFalse('node_modules' in logs)
+        self.assertFalse('Dockerfile' in logs)
+        self.assertFalse('.dockerginore' in logs)
         self.assertTrue('not-ignored' in logs)
 
 #######################


### PR DESCRIPTION
Fixes #498
Allowing `Dockerfile` and `.dockerignore` in the exclusion filter
completely breaks the build on docker < 1.5

In Docker 1.5 these entries are treated as special cases when included
in the .dockerignore and are still sent as part of the context. The
daemon ends up excluding them from any `ADD`, `COPY`, and cache
validation.