### PR TITLE
BUG: Fix errors in Python 3 from JSON-decoding bytes.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -169,7 +169,7 @@ class Client(requests.Session):
                 if reader._fp.chunk_left:
                     data += reader.read(reader._fp.chunk_left)
                 if decode:
-                    data = json.loads(data)
+                    data = json.loads(data.decode('utf-8'))
                 yield data
         else:
             # Response isn't chunked, meaning we probably


### PR DESCRIPTION
Without this, passing `decode=True` to any methods that delegate to `stream_helper` results in `TypeError` on Python 3.