### PR TITLE
Update resolve_authconfig to bring it in line with Docker client

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -627,8 +627,7 @@ class Client(requests.Session):
         elif not self._auth_configs:
             self._auth_configs = auth.load_config()
 
-        registry = auth.expand_registry_url(registry, insecure_registry) \
-            if registry else auth.INDEX_URL
+        registry = registry or auth.INDEX_URL
 
         authcfg = auth.resolve_authconfig(self._auth_configs, registry)
         # If we found an existing auth config for this registry and username

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -104,7 +104,8 @@ class UtilsTest(unittest.TestCase):
     def test_resolve_authconfig(self):
         auth_config = {
             'https://index.docker.io/v1/': {'auth': 'indexuser'},
-            'http://my.registry.net/v1/': {'auth': 'privateuser'}
+            'my.registry.net': {'auth': 'privateuser'},
+            'http://legacy.registry.url/v1/': {'auth': 'legacyauth'}
         }
         # hostname only
         self.assertEqual(
@@ -153,6 +154,15 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(
             resolve_authconfig(auth_config, 'http://my.registry.net/v1/'),
             {'auth': 'privateuser'}
+        )
+        # legacy entry in config
+        self.assertEqual(
+            resolve_authconfig(auth_config, 'legacy.registry.url'),
+            {'auth': 'legacyauth'}
+        )
+        # no matching entry
+        self.assertTrue(
+            resolve_authconfig(auth_config, 'does.not.exist') is None
         )
 
 


### PR DESCRIPTION
Instead of expanding the registry name we're looking for to a full URL, strip entries in the authconfig down to just the hostname.

This mirrors how the Docker client does it - see [ResolveAuthConfig in auth.go](https://github.com/docker/docker/blob/8b95ad230e2ee76450ceb9a80aa8e942a56bb397/registry/auth.go#L451-L481) - and should fix https://github.com/docker/compose/issues/75.