### PR TITLE
When building, include submoduled .git files as .git subdirectory trees

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -86,7 +86,18 @@ def tar(path, exclude=None):
         dirnames.sort()
         for name in sorted(fnames):
             arcname = os.path.join(relpath, name)
-            t.add(os.path.join(path, arcname), arcname=arcname)
+            fullname = os.path.join(path, arcname)
+            # Deal with .git file/folder for nested submodules
+            if (  os.path.basename(fullname) == '.git' and
+                  os.path.isfile(fullname) ):
+                with open(fullname, 'r') as git_file:
+                    content = git_file.read()
+                    if content.startswith('gitdir: '):
+                        rellinkpath = string.split(content, 'gitdir: ').pop
+                        linkpath = os.path.join(relpath, rellinkpath)
+                        t.add(os.path.join(path, linkpath), arcname=arcname)
+            else
+                t.add(os.path.join(path, arcname), arcname=arcname)
         for name in dirnames:
             arcname = os.path.join(relpath, name)
             t.add(os.path.join(path, arcname),

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -88,12 +88,12 @@ def tar(path, exclude=None):
             arcname = os.path.join(relpath, name)
             fullname = os.path.join(path, arcname)
             # Deal with .git file/folder for nested submodules
-            if (  os.path.basename(fullname) == '.git' and
-                  os.path.isfile(fullname) ):
+            if (os.path.basename(fullname) == '.git' and
+                  os.path.isfile(fullname)):
                 with open(fullname, 'r') as git_file:
                     content = git_file.read()
                     if content.startswith('gitdir: '):
-                        rellinkpath = string.split(content, 'gitdir: ').pop
+                        rellinkpath = content.split('gitdir: ').pop
                         linkpath = os.path.join(relpath, rellinkpath)
                         t.add(os.path.join(path, linkpath), arcname=arcname)
             else:

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -89,7 +89,7 @@ def tar(path, exclude=None):
             fullname = os.path.join(path, arcname)
             # Deal with .git file/folder for nested submodules
             if (os.path.basename(fullname) == '.git' and
-                os.path.isfile(fullname)):
+               os.path.isfile(fullname)):
                 with open(fullname, 'r') as git_file:
                     content = git_file.read()
                     if content.startswith('gitdir: '):

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -89,7 +89,7 @@ def tar(path, exclude=None):
             fullname = os.path.join(path, arcname)
             # Deal with .git file/folder for nested submodules
             if (os.path.basename(fullname) == '.git' and
-                  os.path.isfile(fullname)):
+                os.path.isfile(fullname)):
                 with open(fullname, 'r') as git_file:
                     content = git_file.read()
                     if content.startswith('gitdir: '):

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -96,7 +96,7 @@ def tar(path, exclude=None):
                         rellinkpath = string.split(content, 'gitdir: ').pop
                         linkpath = os.path.join(relpath, rellinkpath)
                         t.add(os.path.join(path, linkpath), arcname=arcname)
-            else
+            else:
                 t.add(os.path.join(path, arcname), arcname=arcname)
         for name in dirnames:
             arcname = os.path.join(relpath, name)


### PR DESCRIPTION
Submodules projects with a fig.yml/docker-compose.yml have a build: directive that includes a subdirectory path. If that subdirectory has a .git file in it (that isn't otherwise excluded by a .dockerignore) and check if it starts with gitdir:. If so: include that relative path as a relatively placed .git directory in the tarball that is sent to the docker server.
