### PR TITLE
docs: document parameter tail of method logs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -450,6 +450,7 @@ output as it happens.
 * stderr (bool): Get STDERR
 * stream (bool): Stream the response
 * timestamps (bool): Show timestamps
+* tail (str or int): Output specified number of lines at the end of logs: `"all"` or `number`. Default `"all"`
 
 **Returns** (generator or str):
 


### PR DESCRIPTION
taken directly from official documentation