### PR TITLE
Making examples in doc a bit clearer for volumes and ports_binding

### DIFF
--- a/docs/port-bindings.md
+++ b/docs/port-bindings.md
@@ -3,7 +3,7 @@ Port bindings is done in two parts. Firstly, by providing a list of ports to
 open inside the container in the `Client().create_container()` method.
 
 ```python
-c.create_container('busybox', 'ls', ports=[1111, 2222])
+container_id = c.create_container('busybox', 'ls', ports=[1111, 2222])
 ```
 
 Bindings are then declared in the `Client.start` method.

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -4,7 +4,7 @@ Volume declaration is done in two parts. First, you have to provide
 a list of mountpoints to the `Client().create_container()` method.
 
 ```python
-c.create_container('busybox', 'ls', volumes=['/mnt/vol1', '/mnt/vol2'])
+container_id = c.create_container('busybox', 'ls', volumes=['/mnt/vol1', '/mnt/vol2'])
 ```
 
 Volume mappings are then declared inside the `Client.start` method like this:


### PR DESCRIPTION
The examples refer to a variable container_id, but it had not been introduced before.