### PR TITLE
BUG: Don't barf on Client.port when no port settings provided.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -702,6 +702,12 @@ class Client(requests.Session):
         s_port = str(private_port)
         h_ports = None
 
+        # Port settings is None when the container is running with
+        # network_mode=host.
+        port_settings = json_['NetworkSettings']['Ports']
+        if port_settings is None:
+            return None
+
         h_ports = json_['NetworkSettings']['Ports'].get(s_port + '/udp')
         if h_ports is None:
             h_ports = json_['NetworkSettings']['Ports'].get(s_port + '/tcp')

--- a/docker/client.py
+++ b/docker/client.py
@@ -708,9 +708,9 @@ class Client(requests.Session):
         if port_settings is None:
             return None
 
-        h_ports = json_['NetworkSettings']['Ports'].get(s_port + '/udp')
+        h_ports = port_settings.get(s_port + '/udp')
         if h_ports is None:
-            h_ports = json_['NetworkSettings']['Ports'].get(s_port + '/tcp')
+            h_ports = port_settings.get(s_port + '/tcp')
 
         return h_ports
 


### PR DESCRIPTION
Fixes #526 .