### PR TITLE
Windows : fix EOL of .dockerignore file

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -322,7 +322,7 @@ class Client(requests.Session):
             exclude = None
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
-                    exclude = list(filter(bool, f.read().split('\n')))
+                    exclude = list(filter(bool, f.read().splitlines()))
                     # These are handled by the docker daemon and should not be
                     # excluded on the client
                     if 'Dockerfile' in exclude:


### PR DESCRIPTION
To be able to read `.dockerignore` file edited on Windows, python-py may use the multi-platform split function `str.splitlines()`

Ref : https://docs.python.org/2/library/stdtypes.html#str.splitlines

(tested rudimentarily only)