### PR TITLE
Add a version_info attribute

### DIFF
--- a/docker/__init__.py
+++ b/docker/__init__.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from .version import version
+from .version import version, version_info
 
 __version__ = version
 __title__ = 'docker-py'

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,1 +1,2 @@
 version = "1.1.1-dev"
+version_info = (1, 1, 1)


### PR DESCRIPTION
This makes comparing docker-py versions *much* easier. Having to account for
the potential of a "-dev" suffix is a PITA.