### PR TITLE
Add /exec/{id}/info support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -258,7 +258,7 @@ function return a blocking generator you can iterate over to retrieve events as 
 
 ```python
 c.execute(container, cmd, detach=False, stdout=True, stderr=True,
-       stream=False, tty=False)
+       stream=False, tty=False, exec_id=False)
 ```
 
 Execute a command in a running container.
@@ -278,6 +278,23 @@ running `inspect_container`), unique id or container name.
 
 * stream (bool): indicates whether to return a generator which will yield
   the streaming response in chunks.
+
+* exec_id (bool) whether to return the execution id or not as a second value
+
+## execute_inspect
+
+```python
+>>> _, exec_id = c.execute(container, cmd, exec_id=True)
+>>> info = c.execute_inspect(exec_id)
+```
+
+Retrieve information about a previous execute call
+
+**Params**:
+
+* exec_id (str): an execution unique id
+
+**Returns** (urllib3.response.HTTPResponse object): The response from the docker daemon
 
 ## export
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1082,6 +1082,21 @@ class TestExecuteCommandStreaming(BaseTestCase):
         self.assertEqual(res, expected)
 
 
+@unittest.skipIf(not EXEC_DRIVER_IS_NATIVE, 'Exec driver not native')
+class TestExecuteCommandInspect(BaseTestCase):
+    def runTest(self):
+        container = self.client.create_container('busybox', 'cat',
+                                                 detach=True, stdin_open=True)
+        id = container['Id']
+        self.client.start(id)
+        self.tmp_containers.append(id)
+
+        _, exec_id = self.client.execute(id, ['sh', '-c', 'exit 5'],
+                                         exec_id=True)
+        res = self.client.execute_inspect(exec_id)
+        self.assertEqual(res['ExitCode'], 5)
+
+
 class TestRunContainerStreaming(BaseTestCase):
     def runTest(self):
         container = self.client.create_container('busybox', '/bin/sh',


### PR DESCRIPTION
Adds a new boolean parameter `exec_id` to `execute` to return the execution id as a second value.
That value can then be fed to `execute_inspect` to get informations about the execution (running status, exit code, etc...).

Usage:

```python
out, exec_id = c.execute(container, ['ls', '/foobar'], exec_id=True)
info = c.execute_inspect(exec_id)
if info.get('ExitCode') == 2:
    raise IOError('Folder /foobar does not exists')
```