### PR TITLE
Added Content-Type header to pull procedure

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -820,7 +820,9 @@ class Client(requests.Session):
             'tag': tag,
             'fromImage': repository
         }
-        headers = {}
+        headers = {
+            'Content-Type': 'text/plain'
+        }
 
         if utils.compare_version('1.5', self._version) >= 0:
             # If we don't have any auth data so far, try reloading the config


### PR DESCRIPTION
I did a packet capture between a manual docker pull with swarm and a docker pull from the python client with swarm. The python client was missing a header 'Content-Type' that was causing an API error with swarm. When I added this header to the pull procedure, the python client started working with swarm.