### PR TITLE
make memory units compatible with native docker cli

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -322,6 +322,9 @@ def parse_bytes(s):
     if len(s) == 0:
         s = 0
     else:
+        if s[-2:-1].isalpha() and s[-1].isalpha():
+            if (s[-1] == "b" or s[-1] == "B"):
+                s = s[:-1]
         units = BYTE_UNITS
         suffix = s[-1].lower()
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -6,7 +6,7 @@ from docker.client import Client
 from docker.errors import DockerException
 from docker.utils import (
     parse_repository_tag, parse_host, convert_filters, kwargs_from_env,
-    create_host_config, Ulimit, LogConfig
+    create_host_config, Ulimit, LogConfig, parse_bytes
 )
 from docker.utils.ports import build_port_bindings, split_port
 from docker.auth import resolve_authconfig
@@ -36,6 +36,12 @@ class UtilsTest(base.BaseTestCase):
                          ("url:5000/repo", None))
         self.assertEqual(parse_repository_tag("url:5000/repo:tag"),
                          ("url:5000/repo", "tag"))
+
+    def test_parse_bytes(self):
+        self.assertEqual(parse_bytes("512MB"), (536870912))
+        self.assertEqual(parse_bytes("512M"), (536870912))
+        self.assertRaises(DockerException, parse_bytes, "512MK")
+        self.assertRaises(DockerException, parse_bytes, "512L")
 
     def test_parse_host(self):
         invalid_hosts = [


### PR DESCRIPTION
Signed-off-by: sivaram mothiki <smothiki@engineyard.com>

There is no hard enforcement of syntax on  specifying memory from docker side . I think docker-py should return an Error only if docker engine errors out and accept any syntax.
```
$ sudo docker run -d --name serame -m 30MB busybox sleep 30
$ docker inspect serame|grep Memory
        "Memory": 31457280,
        "MemorySwap": 0,
$ sudo docker run -d --name serame -m 30M busybox sleep 30
$ docker inspect serame|grep Memory
        "Memory": 31457280,
        "MemorySwap": 0,
$ sudo docker run -d --name serame -m 30Mb busybox sleep 30
$ docker inspect serame|grep Memory
        "Memory": 31457280,
        "MemorySwap": 0,
$ sudo docker run -d --name serame -m 30mb busybox sleep 30
$ docker inspect serame|grep Memory
        "Memory": 31457280,
        "MemorySwap": 0,
$ sudo docker run -d --name serame -m 30MK busybox sleep 30
FATA[0000] invalid size: '30MK'