### PR TITLE
fix(client.py): unification the container argument for commit

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -400,6 +400,8 @@ class Client(requests.Session):
 
     def commit(self, container, repository=None, tag=None, message=None,
                author=None, conf=None):
+        if isinstance(container, dict):
+            container = container.get('Id')
         params = {
             'container': container,
             'repo': repository,


### PR DESCRIPTION
Example:

    container = _client.create_container(..)
    _client.start(container)  # correct!
    _client.attach(container)  # correct!
    _client.wait(container)  # correct !
    _client.commit(container)  # INCORRECT!

