### PR TITLE
Change decorators to use a relative import.

### DIFF
--- a/docker/utils/decorators.py
+++ b/docker/utils/decorators.py
@@ -1,4 +1,4 @@
-import docker.errors
+from .. import errors
 
 
 def check_resource(f):
@@ -6,7 +6,7 @@ def check_resource(f):
         if resource_id is None and (
             kwargs.get('container') is None and kwargs.get('image') is None
         ):
-            raise docker.errors.NullResource(
+            raise errors.NullResource(
                 'image or container param is None'
             )
         return f(self, resource_id, *args, **kwargs)


### PR DESCRIPTION
This is more consistent with the way the rest of the package
imports errors. This also solves a crazy cyclical import issue
I'm seeing.