### PR TITLE
Set 'CpusetCpus' with the value of the cpuset param in create_container

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -577,6 +577,7 @@ def create_container_config(
         'Entrypoint': entrypoint,
         'CpuShares': cpu_shares,
         'Cpuset': cpuset,
+        'CpusetCpus': cpuset,
         'WorkingDir': working_dir,
         'MemorySwap': memswap_limit,
         'HostConfig': host_config,

--- a/tests/test.py
+++ b/tests/test.py
@@ -489,6 +489,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
                              "StdinOnce": false,
                              "NetworkDisabled": false,
                              "Cpuset": "0,1",
+                             "CpusetCpus": "0,1",
                              "MemorySwap": 0}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})


### PR DESCRIPTION
Fixes #588 