### PR TITLE
Support for .dockerignore 'folder/' syntax with tests

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -68,6 +68,35 @@ def fnmatch_any(relpath, patterns):
     return any([fnmatch(relpath, pattern) for pattern in patterns])
 
 
+def _advanced_exclude(exclude):
+    result = {
+        'folders': [],
+        'files': []
+    }
+    for ex in exclude:
+        if ex[-1] == '/':
+            result['folders'].append(ex[:-1])
+        else:
+            result['files'].append(ex)
+    return result
+
+
+def _build_tar_list(dirnames, filenames, relpath, exclude):
+    exclude = _advanced_exclude(exclude)
+    dirnames[:] = [
+        d for d in dirnames if not fnmatch_any(
+            os.path.join(relpath, d),
+            exclude['folders'] + exclude['files']
+        )
+    ]
+    fnames = [
+        name for name in filenames if not fnmatch_any(
+            os.path.join(relpath, name), exclude['files']
+        )
+    ]
+    return sorted(dirnames), sorted(fnames)
+
+
 def tar(path, exclude=None):
     f = tempfile.NamedTemporaryFile()
     t = tarfile.open(mode='w', fileobj=f)
@@ -78,20 +107,17 @@ def tar(path, exclude=None):
         if exclude is None:
             fnames = filenames
         else:
-            dirnames[:] = [d for d in dirnames
-                           if not fnmatch_any(os.path.join(relpath, d),
-                                              exclude)]
-            fnames = [name for name in filenames
-                      if not fnmatch_any(os.path.join(relpath, name),
-                                         exclude)]
-        dirnames.sort()
-        for name in sorted(fnames):
+            dirnames, fnames = _build_tar_list(
+                dirnames, filenames, relpath, exclude
+            )
+        for name in fnames:
             arcname = os.path.join(relpath, name)
             t.add(os.path.join(path, arcname), arcname=arcname)
         for name in dirnames:
             arcname = os.path.join(relpath, name)
-            t.add(os.path.join(path, arcname),
-                  arcname=arcname, recursive=False)
+            t.add(
+                os.path.join(path, arcname), arcname=arcname, recursive=False
+            )
     t.close()
     f.seek(0)
     return f

--- a/tests/test.py
+++ b/tests/test.py
@@ -2337,6 +2337,15 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
                             'test/foo/other.png']),
                 (['*.png', 'bar'], ['test', 'test/foo', 'test/foo/a.txt',
                                     'test/foo/b.py']),
+                # directory without trailing slash
+                (['bar'], ['test', 'test/foo', 'test/foo/a.txt',
+                           'test/foo/b.py', 'test/foo/other.png']),
+                # directory with explicit trailing slash
+                (['bar/'], ['test', 'test/foo', 'test/foo/a.txt',
+                           'test/foo/b.py', 'test/foo/other.png']),
+                # nested directory with trailing slash
+                (['test/foo/'], ['bar', 'bar/a.txt', 'bar/b.py', 'bar/other.png',
+                                 'test']),
                 (['test/foo', 'a.txt'], ['bar', 'bar/a.txt', 'bar/b.py',
                                          'bar/other.png', 'test']),
         ):


### PR DESCRIPTION
Fixes #581.

Added unit tests for trailing slash on folders to https://github.com/docker/docker-py/pull/591 (by @shin-).

**NOTE**: There are still issues with how .dockerignore is implemented in docker-py. I'll open up another issue to discuss.