### PR TITLE
More rigorous support for .dockerignore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 requests==2.5.3
 six>=1.3.0
 websocket-client==0.11.0
+#pathspec >=0.3.3, <0.3.99
+# Currently use HEAD version until new pathspec release (0.3.4)
+-e git://github.com/cpburnz/python-path-specification.git#egg=pathspec

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,2 +1,5 @@
 requests==2.5.3
 six>=1.3.0
+#pathspec >=0.3.3, <0.3.99
+# Currently use HEAD version until new pathspec release (0.3.4)
+-e git://github.com/cpburnz/python-path-specification.git#egg=pathspec


### PR DESCRIPTION
Fixes #581. The current implementation for parsing `.dockerignore` files and applying the exclusion to the build path does not account for many common and uncommon syntax and behaviors (see `tests/test.py` for a few of these cases). The problem is that the rules for parsing `.dockerignore` files are complex. Luckily, [pathspec](https://github.com/cpburnz/python-path-specification) provides a robust implementation of `.gitignore` rules, which are almost identical for `.dockerignore`.

This PR uses the `pathspec` library in place of the current `fnmatch_any`. Additional tests for `.dockerignore` have been added. All tests pass for py27.

Thanks @shin-!