### PR TITLE
Raise ValueError on empty argument to inspect_{container,image}() methods.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -747,6 +747,8 @@ class Client(requests.Session):
 
     @check_resource
     def inspect_image(self, image):
+        if isinstance(image, dict):
+            image = image.get('Id')
         return self._result(
             self._get(self._url("/images/{0}/json".format(image))),
             True

--- a/docker/utils/decorators.py
+++ b/docker/utils/decorators.py
@@ -12,5 +12,7 @@ def check_resource(f):
                 raise errors.NullResource(
                     'image or container param is undefined'
                 )
+        if not resource_id:
+            raise ValueError('image or container param is empty')
         return f(self, resource_id, *args, **kwargs)
     return wrapped

--- a/tests/test.py
+++ b/tests/test.py
@@ -1782,6 +1782,12 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
+        try:
+            self.client.inspect_container('')
+        except ValueError as e:
+            self.assertEqual(e.args[0],
+                             'image or container param is empty')
+
         fake_request.assert_called_with(
             url_prefix + 'containers/3cc2351ab11b/json',
             timeout=DEFAULT_TIMEOUT_SECONDS
@@ -1952,6 +1958,12 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
             self.client.inspect_image(fake_api.FAKE_IMAGE_NAME)
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
+
+        try:
+            self.client.inspect_image('')
+        except ValueError as e:
+            self.assertEqual(e.args[0],
+                             'image or container param is empty')
 
         fake_request.assert_called_with(
             url_prefix + 'images/test_image/json',


### PR DESCRIPTION
Fix #602. Raise `ValueError` on empty argument to `inspect_{container,image}()` methods.