### PR TITLE
Remove non-existing argument

### DIFF
--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -66,7 +66,6 @@ for example:
 
 **Params**
 
-* container (str): The container to start
 * binds: Volumes to bind. See [Using volumes](volumes.md) for more information.
 * port_bindings (dict): Port bindings. See [Port bindings](port-bindings.md)
   for more information.


### PR DESCRIPTION
There is no container argument in create_container_config. This is probably a leftover when this was copied from the Client.start documentation