### PR TITLE
Update docker-py to use a more portable sense of HOME.

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -115,7 +115,7 @@ def load_config(config_path=None):
     conf = {}
     data = None
 
-    config_file = config_path or os.path.join(os.environ.get('HOME', '.'),
+    config_file = config_path or os.path.join(os.path.expanduser('~'),
                                               DOCKER_CONFIG_FILENAME)
 
     # if config path doesn't exist return empty config


### PR DESCRIPTION
This makes docker-py consistent with Docker's newish way of establishing the path to .dockercfg:
   https://github.com/docker/docker/blob/master/pkg/homedir/homedir.go


NOTE: this is only now relevant as Docker 1.6 was the first release with an official Windows build.