### PR TITLE
Allow extra_hosts to be a list too

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -434,7 +434,7 @@ def create_host_config(
                 for k, v in sorted(six.iteritems(extra_hosts))
             ]
 
-            host_config['ExtraHosts'] = extra_hosts
+        host_config['ExtraHosts'] = extra_hosts
 
     if links is not None:
         if isinstance(links, dict):


### PR DESCRIPTION
The current map syntax does not allow the API equivalent of

    --add-host foo:1.1.1.1 --add-host foo:2.2.2.2

The above will map one hostname to two IPs.  The above is valid in Docker.