### PR TITLE
Fix pinging an unauthenticated v2 registry

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -129,7 +129,9 @@ def ping(url):
     except Exception:
         return False
     else:
-        return res.status_code < 400
+        # We don't send yet auth headers
+        # and a v2 registry will respond with status 401
+        return res.status_code == 401 or res.status_code < 400
 
 
 def _convert_port_binding(binding):


### PR DESCRIPTION
Hi,

We're building an auth server for docker v2 registry (without a reverse proxy in front of it) and noticed that the docker python client fails to ping the registry because it returns 401 Unauthorized.

I suggest to consider 401 as a sign that the server is alive and kicking. Or at least until the v2 registry is updated to allow some form of unauthenticated pinging.