### PR TITLE
websocket-client version hard-dependency removed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.5.3
 six>=1.3.0
-websocket-client==0.11.0
+websocket-client>=0.11.0


### PR DESCRIPTION
websocket-client version is hard-dependent on 0.11.0. Some of the newer OSes (like RHEL 7.1) already have 0.14 and above. This hard-dependency causes this already available version non-usable and requires pulling 0.11.0, which is redundant. Is there any specific reason why docker.py needs websocket-client==0.11.0 only? If there is no specific reason (sorry, I am new here, so may not be aware) then please approve this request. Thanks. 