### PR TITLE
removing hard-dependency of websocket-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.5.3
 six>=1.3.0
-websocket-client==0.11.0
+websocket-client>=0.11.0


### PR DESCRIPTION
Making websocket-client version more flexible from current hard-dependency of 0.11.0, reason is this package is available on linux destro and for example rhel 7.1 it is 0.14.0 which causes to donwload this particular version of websocket-client for docker.py. I am not sure if there are any particular reasons for hard-binding it to this version, if not so, please approve. Thanks.