### PR TITLE
Use functools.wraps for check_resource decorator.

### DIFF
--- a/docker/utils/decorators.py
+++ b/docker/utils/decorators.py
@@ -1,7 +1,10 @@
+from functools import wraps
 from .. import errors
 
 
 def check_resource(f):
+
+    @wraps(f)
     def wrapped(self, resource_id=None, *args, **kwargs):
         if resource_id is None:
             if kwargs.get('container'):


### PR DESCRIPTION
This helps runtime introspection tools like the `help()` builtin or
IPython's `?` operators correctly find the underlying method definition instead of
the decorator definition by setting `__module__`, `__name__`, and `__wrapped__` attributes on the returned method.  This change should otherwise be entirely transparent.

Before:
```
In [4]: Client.start?
Signature: Client.start(self, resource_id=None, *args, **kwargs)
Docstring: <no docstring>
File:      ~/clones/docker-py/docker/utils/decorators.py
Type:      function
```

After:
```
In [4]: Client.start?
Signature: Client.start(self, container, binds=None, port_bindings=None, lxc_conf=None, publish_all_ports=False, links=None, privileged=False, dns=None, dns_search=None, volumes_from=None, network_mode=None, restart_policy=None, cap_add=None, cap_drop=None, devices=None, extra_hosts=None, read_only=None, pid_mode=None, ipc_mode=None, security_opt=None, ulimits=None)
Docstring: <no docstring>
File:      ~/clones/docker-py/docker/client.py
Type:      function
```