### PR TITLE
Allow any mode string to be passed into a volume bind

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -177,8 +177,21 @@ def convert_volume_binds(binds):
     result = []
     for k, v in binds.items():
         if isinstance(v, dict):
+            if 'ro' in v and 'mode' in v:
+                raise ValueError(
+                    'Binding cannot contain both "ro" and "mode": {}'
+                    .format(repr(v))
+                )
+
+            if 'ro' in v:
+                mode = 'ro' if v['ro'] else 'rw'
+            elif 'mode' in v:
+                mode = v['mode']
+            else:
+                mode = 'rw'
+
             result.append('{0}:{1}:{2}'.format(
-                k, v['bind'], 'ro' if v.get('ro', False) else 'rw'
+                k, v['bind'], mode
             ))
         else:
             result.append('{0}:{1}:rw'.format(k, v))

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -10,11 +10,11 @@ container_id = c.create_container(
     host_config=docker.utils.create_host_config(binds={
         '/home/user1/': {
             'bind': '/mnt/vol2',
-            'ro': False
+            'mode': 'rw',
         },
         '/var/www': {
             'bind': '/mnt/vol1',
-            'ro': True
+            'mode': 'ro',
         }
     })
 )


### PR DESCRIPTION
- Volume binds now take a `mode` key, whose value can be any string.
- `ro` is still supported. It is an error to specify both `ro` and `mode`.

The rationale for this: Docker has added support for a [variety of volume modes](https://github.com/docker/docker/blob/53d9609de472f2fc9e6aaef2b713f526605f4ab8/daemon/volumes.go#L115-L132). I reckon it's best to leave it to the Docker daemon to validate them.