### PR TITLE
Add exception check to push before returning stream

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -949,6 +949,9 @@ class Client(requests.Session):
         else:
             response = self._post_json(u, None, stream=stream, params=params)
 
+        if response.status_code != 200:
+            raise errors.DockerException('Error pushing image\n%s', response.text)
+
         return stream and self._stream_helper(response) \
             or self._result(response)
 


### PR DESCRIPTION
As underlying exceptions(such as push already in progress) will be hidden otherwise. I haven't come across them yet, but I presume that exceptions are being hidden by other methods that use streaming output as well.