### PR TITLE
Docs: Update boot2docker shellinit example to use 'eval'

### DIFF
--- a/docs/boot2docker.md
+++ b/docs/boot2docker.md
@@ -4,13 +4,10 @@ For usage with boot2docker, there is a helper function in the utils package name
 
 First run boot2docker in your shell:
 ```bash
-$ $(boot2docker shellinit)
+$ eval "$(boot2docker shellinit)"
 Writing /Users/you/.boot2docker/certs/boot2docker-vm/ca.pem
 Writing /Users/you/.boot2docker/certs/boot2docker-vm/cert.pem
 Writing /Users/you/.boot2docker/certs/boot2docker-vm/key.pem
-export DOCKER_HOST=tcp://192.168.59.103:2376
-export DOCKER_CERT_PATH=/Users/you/.boot2docker/certs/boot2docker-vm
-export DOCKER_TLS_VERIFY=1
 ```
 
 You can then instantiate `docker.Client` like this:


### PR DESCRIPTION
The boot2docker documentation has since changed the recommended way to use shellinit - see boot2docker/boot2docker#786. The command also no longer prints the export lines to the console, so have updated the example output.