### PR TITLE
Add response check to stream helper

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -187,6 +187,9 @@ class Client(requests.Session):
 
     def _stream_helper(self, response, decode=False):
         """Generator for data coming from a chunked-encoded HTTP response."""
+        if response.status_code != 200:
+            raise errors.DockerException(response.text)
+
         if response.raw._fp.chunked:
             reader = response.raw
             while not reader.closed:


### PR DESCRIPTION
as underlying exceptions(such as push already in progress) will be hidden in the
returned generator otherwise.