### PR TITLE
Add and document a decode parameter for build

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -307,7 +307,8 @@ class Client(requests.Session):
     def build(self, path=None, tag=None, quiet=False, fileobj=None,
               nocache=False, rm=False, stream=False, timeout=None,
               custom_context=False, encoding=None, pull=True,
-              forcerm=False, dockerfile=None, container_limits=None):
+              forcerm=False, dockerfile=None, container_limits=None,
+              decode=False):
         remote = context = headers = None
         container_limits = container_limits or {}
         if path is None and fileobj is None:
@@ -398,7 +399,7 @@ class Client(requests.Session):
             context.close()
 
         if stream:
-            return self._stream_helper(response)
+            return self._stream_helper(response, decode=decode)
         else:
             output = self._result(response)
             srch = r'Successfully built ([0-9a-f]+)'

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,8 @@ correct value (e.g `gzip`).
     - memswap (int): Total memory (memory + swap), -1 to disable swap
     - cpushares (int): CPU shares (relative weight)
     - cpusetcpus (str): CPUs in which to allow exection, e.g., `"0-3"`, `"0,1"`
+* decode (bool): If set to true, the returned stream will be decoded into dicts on the fly. 
+  False by default.
 
 **Returns** (generator): A generator of the build output
 


### PR DESCRIPTION
This makes the build method consistent with the events method and adds
some convenience.