### PR TITLE
fix premature EOF detection in streams

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -233,7 +233,7 @@ class Client(requests.Session):
                 break
             _, length = struct.unpack('>BxxxL', header)
             if not length:
-                break
+                continue
             data = response.raw.read(length)
             if not data:
                 break


### PR DESCRIPTION
The docker engine may send empty chunks of data in the stream
(especially since https://github.com/docker/docker/pull/13033)
They should not be taken for EOF

Signed-off-by: Anthony Baire <Anthony.Baire@irisa.fr>