### PR TITLE
Fix handling output from tty-enabled containers.

### DIFF
--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -129,11 +129,11 @@ def post_fake_create_container():
     return status_code, response
 
 
-def get_fake_inspect_container():
+def get_fake_inspect_container(tty=False):
     status_code = 200
     response = {
         'Id': FAKE_CONTAINER_ID,
-        'Config': {'Privileged': True},
+        'Config': {'Privileged': True, 'Tty': tty},
         'ID': FAKE_CONTAINER_ID,
         'Image': 'busybox:latest',
         "State": {


### PR DESCRIPTION
As described in issue #630, getting the stdout/stderr from tty-enabled containers doesn't work properly, because docker-py treats the output as multiplexed, when docker is actually sending a raw stream. This patch attempts to address this by determining if a container to is tty-enabled before trying to read its output, and if it is, read the raw stream, rather than reading at a multiplexed stream.

I previously submitted a pull request for this issue [here](https://github.com/docker/docker-py/pull/631), but ended up screwing up the revision history in that branch, so I've opened a new one. Please see that request for comments on an earlier version of the diff.