### PR TITLE
return NotFound on 404 errors

### DIFF
--- a/docker/clientbase.py
+++ b/docker/clientbase.py
@@ -99,6 +99,8 @@ class ClientBase(requests.Session):
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                raise errors.NotFound(e, response, explanation=explanation)
             raise errors.APIError(e, response, explanation=explanation)
 
     def _result(self, response, json=False, binary=False):

--- a/docker/errors.py
+++ b/docker/errors.py
@@ -53,6 +53,10 @@ class DockerException(Exception):
     pass
 
 
+class NotFound(APIError):
+    pass
+
+
 class InvalidVersion(DockerException):
     pass
 


### PR DESCRIPTION
This changes raises docker.errors.NotFound on 404 errors.  This gives
client code the ability to differentiate between "an image does not
exist" and "you are using the api incorrectly".

This inherits from docker.errors.APIError so it will not affect any
existing code.

The particular case I am trying to address is client code that does something like this:

        try:
            container = create_a_container()
        except:
            pull_an_image(image)
            container = create_a_container()

It really only makes sense to retry the create operation if the image
was not found; any other API error will simply fail the second time as
well.

