### PR TITLE
Switch to send full AuthConfig object for build action

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -102,12 +102,6 @@ def encode_header(auth):
     return base64.b64encode(auth_json)
 
 
-def encode_full_header(auth):
-    """ Returns the given auth block encoded for the X-Registry-Config header.
-    """
-    return encode_header({'configs': auth})
-
-
 def parse_auth(entries):
     """
     Parses authentication entries

--- a/docker/client.py
+++ b/docker/client.py
@@ -139,7 +139,7 @@ class Client(clientbase.ClientBase):
             if self._auth_configs:
                 if headers is None:
                     headers = {}
-                headers['X-Registry-Config'] = auth.encode_full_header(
+                headers['X-Registry-Config'] = auth.encode_header(
                     self._auth_configs
                 )
 


### PR DESCRIPTION
In order to support the docker API for version 1.7+, this command
changes the way the `X-Registry-Config` header is sent when attempting
to build an image.

This fixes an issue I've experienced when using `docker-compose` and building
an image which is based off of a private image hosted at Docker Hub. I don't believe
this change is backwards compatible, and I'm not familiar enough with python to
have a solution for that. I'd appreciate some help if that is necessary.

[Here's the commit](https://github.com/docker/docker/commit/02c7bbefb8841e5e86a4b9d467defa668e3ea613) on the Docker project where they changed the way the AuthConfig
objects were being parsed for the build API endpoint.

