### PR TITLE
Enforce UTC datetimes in arguments to `events()`

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -333,9 +333,9 @@ def convert_filters(filters):
     return json.dumps(result)
 
 
-def datetime_to_timestamp(dt=datetime.now()):
-    """Convert a datetime in local timezone to a unix timestamp"""
-    delta = dt - datetime.fromtimestamp(0)
+def datetime_to_timestamp(dt):
+    """Convert a UTC datetime to a Unix timestamp"""
+    delta = dt - datetime.utcfromtimestamp(0)
     return delta.seconds + delta.days * 24 * 3600
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,8 +251,8 @@ function return a blocking generator you can iterate over to retrieve events as 
 
 **Params**:
 
-* since (datetime or int): get events from this point
-* until (datetime or int): get events until this point
+* since (UTC datetime or int): get events from this point
+* until (UTC datetime or int): get events until this point
 * filters (dict): filter the events by event time, container or image
 * decode (bool): If set to true, stream will be decoded into dicts on the
   fly. False by default.

--- a/tests/test.py
+++ b/tests/test.py
@@ -221,7 +221,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
 
     def test_events_with_since_until(self):
         ts = 1356048000
-        now = datetime.datetime.fromtimestamp(ts)
+        now = datetime.datetime.utcfromtimestamp(ts)
         since = now - datetime.timedelta(seconds=10)
         until = now + datetime.timedelta(seconds=10)
         try:


### PR DESCRIPTION
I can't make the test suite pass on a machine that's not set to UTC, because the `datetime_to_timestamp()` utility function performs date arithmetic under that assumption, causing one of the `events()` tests to fail.

I've changed it so that it always expects a UTC datetime, and made sure we pass one in in the test.

I also removed the default value for its argument, because (a) it wasn't used anywhere and (b) it was being set to to `datetime.now()` at file load time, which almost certainly isn't what the user wants.