### PR TITLE
use password in dockercfg if reauth set to True

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -531,6 +531,9 @@ class Client(clientbase.ClientBase):
                 and not reauth:
             return authcfg
 
+        if authcfg and not password:
+            password = authcfg.get('password', None)
+
         req_data = {
             'username': username,
             'password': password,


### PR DESCRIPTION
password have to be provided if
.dockercfg is used and reauth
is set to True. Make sure password
argument is handled in this case.

This PR fixes this issue #689 
