### PR TITLE
Add netmode to tests

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -615,6 +615,16 @@ def create_container_config(
         if volumes_from is not None:
             raise errors.InvalidVersion(message.format('volumes_from'))
 
+    # NetworkMode must be present and valid in host config from 1.20 onwards
+    if compare_version('1.20', version) >= 0:
+        if host_config is None:
+            host_config = {'NetworkMode': 'default'}
+        else:
+            if 'NetworkMode' not in host_config:
+                host_config['NetworkMode'] = 'default'
+            elif host_config['NetworkMode'] == '':
+                host_config['NetworkMode'] = 'default'
+
     return {
         'Hostname': hostname,
         'Domainname': domainname,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -181,7 +181,8 @@ class TestCreateContainerWithBinds(BaseTestCase):
             container = self.client.create_container(
                 'busybox',
                 ['ls', mount_dest], volumes={mount_dest: {}},
-                host_config=create_host_config(binds=binds)
+                host_config=create_host_config(
+                    binds=binds, network_mode='none')
             )
             container_id = container['Id']
             self.client.start(container_id)
@@ -221,7 +222,8 @@ class TestCreateContainerWithRoBinds(BaseTestCase):
             container = self.client.create_container(
                 'busybox',
                 ['ls', mount_dest], volumes={mount_dest: {}},
-                host_config=create_host_config(binds=binds)
+                host_config=create_host_config(
+                    binds=binds, network_mode='none')
             )
             container_id = container['Id']
             self.client.start(container_id)
@@ -273,7 +275,8 @@ class TestCreateContainerReadOnlyFs(BaseTestCase):
     def runTest(self):
         ctnr = self.client.create_container(
             'busybox', ['mkdir', '/shrine'],
-            host_config=create_host_config(read_only=True)
+            host_config=create_host_config(
+                read_only=True, network_mode='none')
         )
         self.assertIn('Id', ctnr)
         self.tmp_containers.append(ctnr['Id'])
@@ -347,7 +350,8 @@ class TestStartContainerWithDictInsteadOfId(BaseTestCase):
 class TestCreateContainerPrivileged(BaseTestCase):
     def runTest(self):
         res = self.client.create_container(
-            'busybox', 'true', host_config=create_host_config(privileged=True)
+            'busybox', 'true', host_config=create_host_config(
+                privileged=True, network_mode='none')
         )
         self.assertIn('Id', res)
         self.tmp_containers.append(res['Id'])
@@ -591,7 +595,8 @@ class TestPort(BaseTestCase):
 
         container = self.client.create_container(
             'busybox', ['sleep', '60'], ports=list(port_bindings.keys()),
-            host_config=create_host_config(port_bindings=port_bindings)
+            host_config=create_host_config(
+                port_bindings=port_bindings, network_mode='bridge')
         )
         id = container['Id']
 
@@ -717,7 +722,8 @@ class TestCreateContainerWithVolumesFrom(BaseTestCase):
             )
         res2 = self.client.create_container(
             'busybox', 'cat', detach=True, stdin_open=True,
-            host_config=create_host_config(volumes_from=vol_names)
+            host_config=create_host_config(
+                volumes_from=vol_names, network_mode='none')
         )
         container3_id = res2['Id']
         self.tmp_containers.append(container3_id)
@@ -760,7 +766,8 @@ class TestCreateContainerWithLinks(BaseTestCase):
 
         res2 = self.client.create_container(
             'busybox', 'env', host_config=create_host_config(
-                links={link_path1: link_alias1, link_path2: link_alias2}
+                links={link_path1: link_alias1, link_path2: link_alias2},
+                network_mode='none'
             )
         )
         container3_id = res2['Id']
@@ -781,7 +788,8 @@ class TestRestartingContainer(BaseTestCase):
     def runTest(self):
         container = self.client.create_container(
             'busybox', ['sleep', '2'], host_config=create_host_config(
-                restart_policy={"Name": "always", "MaximumRetryCount": 0}
+                restart_policy={"Name": "always", "MaximumRetryCount": 0},
+                network_mode='none'
             )
         )
         id = container['Id']
@@ -910,7 +918,7 @@ class TestCreateContainerWithHostPidMode(BaseTestCase):
     def runTest(self):
         ctnr = self.client.create_container(
             'busybox', 'true', host_config=create_host_config(
-                pid_mode='host'
+                pid_mode='host', network_mode='none'
             )
         )
         self.assertIn('Id', ctnr)
@@ -945,7 +953,7 @@ class TestRemoveLink(BaseTestCase):
 
         container2 = self.client.create_container(
             'busybox', 'cat', host_config=create_host_config(
-                links={link_path: link_alias}
+                links={link_path: link_alias}, network_mode='none'
             )
         )
         container2_id = container2['Id']


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@swernli @cpuguy83 

This PR relates to https://github.com/docker/docker/issues/10662 which is for the docker daemon port to Windows. Part of the daemon port requires the checking of the network mode setting to be moved from the CLI to the daemon, as network modes are platform specific. That PR in docker is https://github.com/docker/docker/pull/14530.

However, for CI on docker-py to pass in docker, it requires updates to docker-py to pass the netmode (which the docker CLI itself would normally do - just the tests here are generally written with the smallest amount of config settings necessary for validation). 

Hence this PR adds the network mode where required to the tests. After this is merged, I can update the Dockerfile in 14530 to point to the right docker-py commit.

Validation performed: I have validated docker-py with these changes passes "make binary test-docker-py" against docker/docker master as of this morning. I have also validated that docker-py running against docker with the 14530 changes passes Jenkins CI in docker.
