### PR TITLE
Ports `--env-file` in minimalistic fashion

### DIFF
--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -2,7 +2,7 @@ from .utils import (
     compare_version, convert_port_bindings, convert_volume_binds,
     mkbuildcontext, tar, parse_repository_tag, parse_host,
     kwargs_from_env, convert_filters, create_host_config,
-    create_container_config, parse_bytes, ping_registry
+    create_container_config, parse_bytes, ping_registry, parse_env_file
 ) # flake8: noqa
 
 from .types import Ulimit, LogConfig # flake8: noqa

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -518,6 +518,32 @@ def create_host_config(
     return host_config
 
 
+def parse_env_file(env_file):
+    """
+    Reads a line-separated environment file.
+    The format of each line should be "key=value".
+    """
+    environment = {}
+
+    with open(env_file, 'r') as f:
+        for line in f:
+
+            if line[0] == '#':
+                continue
+
+            parse_line = line.strip().split('=')
+            if len(parse_line) == 2:
+                k = parse_line[0]
+                v = parse_line[1]
+                environment[k] = v
+            else:
+                raise errors.DockerException(
+                    'Invalid line in environment file {0}:\n{1}'.format(
+                        env_file, line))
+
+    return environment
+
+
 def create_container_config(
     version, image, command, hostname=None, user=None, detach=False,
     stdin_open=False, tty=False, mem_limit=None, ports=None, environment=None,
@@ -528,6 +554,7 @@ def create_container_config(
 ):
     if isinstance(command, six.string_types):
         command = shlex.split(str(command))
+
     if isinstance(environment, dict):
         environment = [
             six.text_type('{0}={1}').format(k, v)

--- a/docs/api.md
+++ b/docs/api.md
@@ -234,6 +234,27 @@ from. Optionally a single string joining container id's with commas
  'Warnings': None}
 ```
 
+### parse_env_file
+
+A utility for parsing an environment file.
+
+The expected format of the file is as follows:
+
+```
+USERNAME=jdoe
+PASSWORD=secret
+```
+
+The utility can be used as follows:
+
+```python
+>> import docker.utils
+>> my_envs = docker.utils.parse_env_file('/path/to/file')
+>> docker.utils.create_container_config('1.18', '_mongodb', 'foobar',  environment=my_envs)
+```
+
+You can now use this with 'environment' for `create_container`.
+
 ## diff
 
 Inspect changes on a container's filesystem


### PR DESCRIPTION
Refs #565. Adds support for providing environment variables from a file instead of manually providing them one-by-one. 