### PR TITLE
bump six req to >=1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.5.3
-six>=1.3.0
+six>=1.4.0
 websocket-client==0.32.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
     'requests >= 2.5.2',
-    'six >= 1.3.0',
+    'six >= 1.4.0',
     'websocket-client >= 0.32.0',
 ]
 


### PR DESCRIPTION
Addresses #344 - bumps the six library version to at least 1.4 which seems to resolve the issue.