### PR TITLE
Split the entrypoint string to shell-like syntax.

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -780,7 +780,7 @@ class Client(clientbase.ClientBase):
             publish_all_ports=publish_all_ports, links=links, dns=dns,
             privileged=privileged, dns_search=dns_search, cap_add=cap_add,
             cap_drop=cap_drop, volumes_from=volumes_from, devices=devices,
-            network_mode=network_mode, restart_policy=restart_policy,
+            network_mode=network_mode or '', restart_policy=restart_policy,
             extra_hosts=extra_hosts, read_only=read_only, pid_mode=pid_mode,
             ipc_mode=ipc_mode, security_opt=security_opt, ulimits=ulimits
         )

--- a/docker/utils/types.py
+++ b/docker/utils/types.py
@@ -6,9 +6,11 @@ class LogConfigTypesEnum(object):
         'json-file',
         'syslog',
         'journald',
+        'gelf',
+        'fluentd',
         'none'
     )
-    JSON, SYSLOG, JOURNALD, NONE = _values
+    JSON, SYSLOG, JOURNALD, GELF, FLUENTD, NONE = _values
 
 
 class DictType(dict):

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -644,6 +644,16 @@ def create_container_config(
         if volumes_from is not None:
             raise errors.InvalidVersion(message.format('volumes_from'))
 
+    # NetworkMode must be present and valid in host config from 1.20 onwards
+    if compare_version('1.20', version) >= 0:
+        if host_config is None:
+            host_config = {'NetworkMode': 'default'}
+        else:
+            if 'NetworkMode' not in host_config:
+                host_config['NetworkMode'] = 'default'
+            elif host_config['NetworkMode'] == '':
+                host_config['NetworkMode'] = 'default'
+
     return {
         'Hostname': hostname,
         'Domainname': domainname,

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -554,6 +554,9 @@ def create_container_config(
     if isinstance(command, six.string_types):
         command = shlex.split(str(command))
 
+    if isinstance(entrypoint, six.string_types):
+        entrypoint = shlex.split(str(entrypoint))
+
     if isinstance(environment, dict):
         environment = [
             six.text_type('{0}={1}').format(k, v)

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -428,6 +428,8 @@ def create_host_config(
 
     if network_mode:
         host_config['NetworkMode'] = network_mode
+    elif network_mode is None:
+        host_config['NetworkMode'] = 'default'
 
     if restart_policy:
         host_config['RestartPolicy'] = restart_policy
@@ -643,16 +645,6 @@ def create_container_config(
             raise errors.InvalidVersion(message.format('dns'))
         if volumes_from is not None:
             raise errors.InvalidVersion(message.format('volumes_from'))
-
-    # NetworkMode must be present and valid in host config from 1.20 onwards
-    if compare_version('1.20', version) >= 0:
-        if host_config is None:
-            host_config = {'NetworkMode': 'default'}
-        else:
-            if 'NetworkMode' not in host_config:
-                host_config['NetworkMode'] = 'default'
-            elif host_config['NetworkMode'] == '':
-                host_config['NetworkMode'] = 'default'
 
     return {
         'Hostname': hostname,

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -232,6 +232,7 @@ def parse_host(addr):
     proto = "http+unix"
     host = DEFAULT_HTTP_HOST
     port = None
+    path = ''
     if not addr or addr.strip() == 'unix://':
         return DEFAULT_UNIX_SOCKET
 
@@ -270,8 +271,12 @@ def parse_host(addr):
         if host_parts[0]:
             host = host_parts[0]
 
+        port = host_parts[1]
+        if '/' in port:
+            port, path = port.split('/', 1)
+            path = '/{0}'.format(path)
         try:
-            port = int(host_parts[1])
+            port = int(port)
         except Exception:
             raise errors.DockerException(
                 "Invalid port: %s", addr
@@ -285,7 +290,7 @@ def parse_host(addr):
 
     if proto == "http+unix":
         return "{0}://{1}".format(proto, host)
-    return "{0}://{1}:{2}".format(proto, host, port)
+    return "{0}://{1}:{2}{3}".format(proto, host, port, path)
 
 
 def parse_devices(devices):

--- a/docs/api.md
+++ b/docs/api.md
@@ -703,6 +703,16 @@ Rename a container. Similar to the `docker rename` command.
 * container (str): ID of the container to rename
 * name (str): New name for the container
 
+## resize
+
+Resize the tty session.
+
+**Params**:
+
+* exec_id (str): ID of the exec instance
+* height (int): Height of tty session
+* width (int): Width of tty session
+
 ## restart
 
 Restart a container. Similar to the `docker restart` command.

--- a/docs/api.md
+++ b/docs/api.md
@@ -709,7 +709,7 @@ Resize the tty session.
 
 **Params**:
 
-* exec_id (str): ID of the exec instance
+* container (str or dict): The container to resize
 * height (int): Height of tty session
 * width (int): Width of tty session
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -182,7 +182,8 @@ class TestCreateContainerWithBinds(BaseTestCase):
                 'busybox',
                 ['ls', mount_dest], volumes={mount_dest: {}},
                 host_config=create_host_config(
-                    binds=binds, network_mode='none')
+                    binds=binds, network_mode='none'
+                )
             )
             container_id = container['Id']
             self.client.start(container_id)
@@ -223,7 +224,8 @@ class TestCreateContainerWithRoBinds(BaseTestCase):
                 'busybox',
                 ['ls', mount_dest], volumes={mount_dest: {}},
                 host_config=create_host_config(
-                    binds=binds, network_mode='none')
+                    binds=binds, network_mode='none'
+                )
             )
             container_id = container['Id']
             self.client.start(container_id)
@@ -276,7 +278,8 @@ class TestCreateContainerReadOnlyFs(BaseTestCase):
         ctnr = self.client.create_container(
             'busybox', ['mkdir', '/shrine'],
             host_config=create_host_config(
-                read_only=True, network_mode='none')
+                read_only=True, network_mode='none'
+            )
         )
         self.assertIn('Id', ctnr)
         self.tmp_containers.append(ctnr['Id'])
@@ -351,7 +354,8 @@ class TestCreateContainerPrivileged(BaseTestCase):
     def runTest(self):
         res = self.client.create_container(
             'busybox', 'true', host_config=create_host_config(
-                privileged=True, network_mode='none')
+                privileged=True, network_mode='none'
+            )
         )
         self.assertIn('Id', res)
         self.tmp_containers.append(res['Id'])
@@ -596,7 +600,8 @@ class TestPort(BaseTestCase):
         container = self.client.create_container(
             'busybox', ['sleep', '60'], ports=list(port_bindings.keys()),
             host_config=create_host_config(
-                port_bindings=port_bindings, network_mode='bridge')
+                port_bindings=port_bindings, network_mode='bridge'
+            )
         )
         id = container['Id']
 
@@ -723,7 +728,8 @@ class TestCreateContainerWithVolumesFrom(BaseTestCase):
         res2 = self.client.create_container(
             'busybox', 'cat', detach=True, stdin_open=True,
             host_config=create_host_config(
-                volumes_from=vol_names, network_mode='none')
+                volumes_from=vol_names, network_mode='none'
+            )
         )
         container3_id = res2['Id']
         self.tmp_containers.append(container3_id)

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -181,7 +181,8 @@ class TestCreateContainerWithBinds(BaseTestCase):
             container = self.client.create_container(
                 'busybox',
                 ['ls', mount_dest], volumes={mount_dest: {}},
-                host_config=create_host_config(binds=binds)
+                host_config=create_host_config(
+                    binds=binds, network_mode='none')
             )
             container_id = container['Id']
             self.client.start(container_id)
@@ -221,7 +222,8 @@ class TestCreateContainerWithRoBinds(BaseTestCase):
             container = self.client.create_container(
                 'busybox',
                 ['ls', mount_dest], volumes={mount_dest: {}},
-                host_config=create_host_config(binds=binds)
+                host_config=create_host_config(
+                    binds=binds, network_mode='none')
             )
             container_id = container['Id']
             self.client.start(container_id)
@@ -273,7 +275,8 @@ class TestCreateContainerReadOnlyFs(BaseTestCase):
     def runTest(self):
         ctnr = self.client.create_container(
             'busybox', ['mkdir', '/shrine'],
-            host_config=create_host_config(read_only=True)
+            host_config=create_host_config(
+                read_only=True, network_mode='none')
         )
         self.assertIn('Id', ctnr)
         self.tmp_containers.append(ctnr['Id'])
@@ -347,7 +350,8 @@ class TestStartContainerWithDictInsteadOfId(BaseTestCase):
 class TestCreateContainerPrivileged(BaseTestCase):
     def runTest(self):
         res = self.client.create_container(
-            'busybox', 'true', host_config=create_host_config(privileged=True)
+            'busybox', 'true', host_config=create_host_config(
+                privileged=True, network_mode='none')
         )
         self.assertIn('Id', res)
         self.tmp_containers.append(res['Id'])
@@ -591,7 +595,8 @@ class TestPort(BaseTestCase):
 
         container = self.client.create_container(
             'busybox', ['sleep', '60'], ports=list(port_bindings.keys()),
-            host_config=create_host_config(port_bindings=port_bindings)
+            host_config=create_host_config(
+                port_bindings=port_bindings, network_mode='bridge')
         )
         id = container['Id']
 
@@ -717,7 +722,8 @@ class TestCreateContainerWithVolumesFrom(BaseTestCase):
             )
         res2 = self.client.create_container(
             'busybox', 'cat', detach=True, stdin_open=True,
-            host_config=create_host_config(volumes_from=vol_names)
+            host_config=create_host_config(
+                volumes_from=vol_names, network_mode='none')
         )
         container3_id = res2['Id']
         self.tmp_containers.append(container3_id)
@@ -760,7 +766,8 @@ class TestCreateContainerWithLinks(BaseTestCase):
 
         res2 = self.client.create_container(
             'busybox', 'env', host_config=create_host_config(
-                links={link_path1: link_alias1, link_path2: link_alias2}
+                links={link_path1: link_alias1, link_path2: link_alias2},
+                network_mode='none'
             )
         )
         container3_id = res2['Id']
@@ -781,7 +788,8 @@ class TestRestartingContainer(BaseTestCase):
     def runTest(self):
         container = self.client.create_container(
             'busybox', ['sleep', '2'], host_config=create_host_config(
-                restart_policy={"Name": "always", "MaximumRetryCount": 0}
+                restart_policy={"Name": "always", "MaximumRetryCount": 0},
+                network_mode='none'
             )
         )
         id = container['Id']
@@ -910,7 +918,7 @@ class TestCreateContainerWithHostPidMode(BaseTestCase):
     def runTest(self):
         ctnr = self.client.create_container(
             'busybox', 'true', host_config=create_host_config(
-                pid_mode='host'
+                pid_mode='host', network_mode='none'
             )
         )
         self.assertIn('Id', ctnr)
@@ -945,7 +953,7 @@ class TestRemoveLink(BaseTestCase):
 
         container2 = self.client.create_container(
             'busybox', 'cat', host_config=create_host_config(
-                links={link_path: link_alias}
+                links={link_path: link_alias}, network_mode='none'
             )
         )
         container2_id = container2['Id']

--- a/tests/test.py
+++ b/tests/test.py
@@ -428,7 +428,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
     def test_create_container_with_entrypoint(self):
         try:
             self.client.create_container('busybox', 'hello',
-                                         entrypoint='cowsay')
+                                         entrypoint='cowsay entry')
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
@@ -443,7 +443,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
                              "AttachStdout": true, "OpenStdin": false,
                              "StdinOnce": false,
                              "NetworkDisabled": false,
-                             "Entrypoint": "cowsay"}'''))
+                             "Entrypoint": ["cowsay", "entry"]}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -141,7 +141,7 @@ class UtilsTest(base.BaseTestCase):
             self.assertEqual(convert_filters(filters), expected)
 
     def test_create_empty_host_config(self):
-        empty_config = create_host_config()
+        empty_config = create_host_config(network_mode='')
         self.assertEqual(empty_config, {})
 
     def test_create_host_config_dict_ulimit(self):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -72,7 +72,10 @@ class UtilsTest(base.BaseTestCase):
             '': 'http+unix://var/run/docker.sock',
             None: 'http+unix://var/run/docker.sock',
             'unix:///var/run/docker.sock': 'http+unix:///var/run/docker.sock',
-            'unix://': 'http+unix://var/run/docker.sock'
+            'unix://': 'http+unix://var/run/docker.sock',
+            'somehost.net:80/service/swarm': (
+                'http://somehost.net:80/service/swarm'
+            ),
         }
 
         for host in invalid_hosts:


### PR DESCRIPTION
If not doing shlex for ```entrypoint``` parameter. 
Jenkin image cannot start successful.