### PR TITLE
Change minimum API version for exec_inspect

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -307,7 +307,9 @@ class Client(clientbase.ClientBase):
 
     def exec_inspect(self, exec_id):
         if utils.compare_version('1.16', self._version) < 0:
-            raise errors.InvalidVersion('Exec is not supported in API < 1.16')
+            raise errors.InvalidVersion(
+                'exec_inspect is not supported in API < 1.16'
+            )
         if isinstance(exec_id, dict):
             exec_id = exec_id.get('Id')
         res = self._get(self._url("/exec/{0}/json".format(exec_id)))

--- a/docker/client.py
+++ b/docker/client.py
@@ -306,8 +306,8 @@ class Client(clientbase.ClientBase):
         return self._result(res, True)
 
     def exec_inspect(self, exec_id):
-        if utils.compare_version('1.15', self._version) < 0:
-            raise errors.InvalidVersion('Exec is not supported in API < 1.15')
+        if utils.compare_version('1.16', self._version) < 0:
+            raise errors.InvalidVersion('Exec is not supported in API < 1.16')
         if isinstance(exec_id, dict):
             exec_id = exec_id.get('Id')
         res = self._get(self._url("/exec/{0}/json".format(exec_id)))


### PR DESCRIPTION
This PR changes the minimum API version required for `exec_inspect` call. The current implementation tests against API version 1.15.

The HTTP call that is used by `exec_inspect` was added to API version 1.16 which was introduced in Docker 1.4.0 https://github.com/docker/docker/commit/00c2a8f323548b7d0aa54cfd10a594dd93ddbed0. `exec_inspect` can be found in the documentation for version 1.16 (https://docs.docker.com/reference/api/docker_remote_api_v1.16/#exec-inspect) but does not appear in the documentation for version 1.15 (https://docs.docker.com/reference/api/docker_remote_api_v1.15/).

The other `exec` functions were introduced in API version 1.15 and are correct.