### PR TITLE
Added support for cgroup parent

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -225,7 +225,8 @@ class Client(clientbase.ClientBase):
                          network_disabled=False, name=None, entrypoint=None,
                          cpu_shares=None, working_dir=None, domainname=None,
                          memswap_limit=None, cpuset=None, host_config=None,
-                         mac_address=None, labels=None, volume_driver=None):
+                         mac_address=None, labels=None, volume_driver=None,
+                         cgroup_parent=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -240,7 +241,7 @@ class Client(clientbase.ClientBase):
             tty, mem_limit, ports, environment, dns, volumes, volumes_from,
             network_disabled, entrypoint, cpu_shares, working_dir, domainname,
             memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver
+            volume_driver, cgroup_parent
         )
         return self.create_container_from_config(config, name)
 
@@ -737,7 +738,7 @@ class Client(clientbase.ClientBase):
               dns=None, dns_search=None, volumes_from=None, network_mode=None,
               restart_policy=None, cap_add=None, cap_drop=None, devices=None,
               extra_hosts=None, read_only=None, pid_mode=None, ipc_mode=None,
-              security_opt=None, ulimits=None):
+              security_opt=None, ulimits=None, cgroup_parent=None):
 
         if utils.compare_version('1.10', self._version) < 0:
             if dns is not None:
@@ -775,6 +776,12 @@ class Client(clientbase.ClientBase):
                     'ulimits is only supported for API version >= 1.18'
                 )
 
+        if utils.compare_version('1.16', self._version) < 0:
+            if cgroup_parent is not None:
+                raise errors.InvalidVersion(
+                    'cgroup_parent is only supported for API version >= 1.16'
+                )
+
         start_config_kwargs = dict(
             binds=binds, port_bindings=port_bindings, lxc_conf=lxc_conf,
             publish_all_ports=publish_all_ports, links=links, dns=dns,
@@ -782,7 +789,8 @@ class Client(clientbase.ClientBase):
             cap_drop=cap_drop, volumes_from=volumes_from, devices=devices,
             network_mode=network_mode, restart_policy=restart_policy,
             extra_hosts=extra_hosts, read_only=read_only, pid_mode=pid_mode,
-            ipc_mode=ipc_mode, security_opt=security_opt, ulimits=ulimits
+            ipc_mode=ipc_mode, security_opt=security_opt, ulimits=ulimits,
+            cgroup_parent=cgroup_parent
         )
         start_config = None
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -390,7 +390,7 @@ def create_host_config(
     restart_policy=None, cap_add=None, cap_drop=None, devices=None,
     extra_hosts=None, read_only=None, pid_mode=None, ipc_mode=None,
     security_opt=None, ulimits=None, log_config=None, mem_limit=None,
-    memswap_limit=None
+    memswap_limit=None, cgroup_parent=None
 ):
     host_config = {}
 
@@ -495,6 +495,9 @@ def create_host_config(
     if lxc_conf is not None:
         host_config['LxcConf'] = lxc_conf
 
+    if cgroup_parent is not None:
+        host_config['CgroupParent'] = cgroup_parent
+
     if ulimits is not None:
         if not isinstance(ulimits, list):
             raise errors.DockerException(
@@ -551,7 +554,7 @@ def create_container_config(
     dns=None, volumes=None, volumes_from=None, network_disabled=False,
     entrypoint=None, cpu_shares=None, working_dir=None, domainname=None,
     memswap_limit=None, cpuset=None, host_config=None, mac_address=None,
-    labels=None, volume_driver=None
+    labels=None, volume_driver=None, cgroup_parent=None
 ):
     if isinstance(command, six.string_types):
         command = shlex.split(str(command))
@@ -672,4 +675,5 @@ def create_container_config(
         'MacAddress': mac_address,
         'Labels': labels,
         'VolumeDriver': volume_driver,
+        'CgroupParent': cgroup_parent,
     }

--- a/tests/test.py
+++ b/tests/test.py
@@ -492,6 +492,28 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 
+    def test_create_container_with_cgroup_parent(self):
+        try:
+            self.client.create_container('busybox', 'ls',
+                                         cgroup_parent='test')
+        except Exception as e:
+            self.fail('Command should not raise exception: {0}'.format(e))
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][0],
+                         url_prefix + 'containers/create')
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls"], "AttachStdin": false,
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false,
+                             "CgroupParent": "test"}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
     def test_create_container_with_working_dir(self):
         try:
             self.client.create_container('busybox', 'ls',


### PR DESCRIPTION
This change adds cgroup-parent support to docker-py, which will allow us to add cgroup-parent support inside compose.