### PR TITLE
Remove hard coded list of log driver types

### DIFF
--- a/docker/utils/types.py
+++ b/docker/utils/types.py
@@ -20,21 +20,17 @@ class DictType(dict):
 
 
 class LogConfig(DictType):
-    types = LogConfigTypesEnum
 
     def __init__(self, **kwargs):
-        type_ = kwargs.get('type', kwargs.get('Type'))
-        config = kwargs.get('config', kwargs.get('Config'))
-        if type_ not in self.types._values:
-            raise ValueError("LogConfig.type must be one of ({0})".format(
-                ', '.join(self.types._values)
-            ))
+        log_driver_type = kwargs.get('type', kwargs.get('Type'))
+        config = kwargs.get('config', kwargs.get('Config')) or {}
+
         if config and not isinstance(config, dict):
             raise ValueError("LogConfig.config must be a dictionary")
 
         super(LogConfig, self).__init__({
-            'Type': type_,
-            'Config': config or {}
+            'Type': log_driver_type,
+            'Config': config
         })
 
     @property
@@ -43,10 +39,6 @@ class LogConfig(DictType):
 
     @type.setter
     def type(self, value):
-        if value not in self.types._values:
-            raise ValueError("LogConfig.type must be one of {0}".format(
-                ', '.join(self.types._values)
-            ))
         self['Type'] = value
 
     @property

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -192,28 +192,18 @@ class UtilsTest(base.BaseTestCase):
         self.assertRaises(ValueError, lambda: Ulimit(name='hello', hard='456'))
 
     def test_create_host_config_dict_logconfig(self):
-        dct = {'type': LogConfig.types.SYSLOG, 'config': {'key1': 'val1'}}
-        config = create_host_config(
-            log_config=dct, version=DEFAULT_DOCKER_API_VERSION
-        )
+        dct = {'type': 'syslog', 'config': {'key1': 'val1'}}
+        config = create_host_config(log_config=dct)
         self.assertIn('LogConfig', config)
         self.assertTrue(isinstance(config['LogConfig'], LogConfig))
         self.assertEqual(dct['type'], config['LogConfig'].type)
 
     def test_create_host_config_obj_logconfig(self):
-        obj = LogConfig(type=LogConfig.types.SYSLOG, config={'key1': 'val1'})
-        config = create_host_config(
-            log_config=obj, version=DEFAULT_DOCKER_API_VERSION
-        )
+        obj = LogConfig(type='syslog', config={'key1': 'val1'})
+        config = create_host_config(log_config=obj)
         self.assertIn('LogConfig', config)
         self.assertTrue(isinstance(config['LogConfig'], LogConfig))
         self.assertEqual(obj, config['LogConfig'])
-
-    def test_logconfig_invalid_type(self):
-        self.assertRaises(ValueError, lambda: LogConfig(type='xxx', config={}))
-        self.assertRaises(ValueError, lambda: LogConfig(
-            type=LogConfig.types.JSON, config='helloworld'
-        ))
 
     def test_resolve_repository_name(self):
         # docker hub library image


### PR DESCRIPTION
This removes the hardcoded list of log drivers we allow as valid. Instead, let those values get passed to the daemon that already does it's own validation of whether a log driver is supported/valid or not.

This removes a bottleneck to supporting new/more log drivers as they get added into docker and the duplication of validation.

This PR will allow for this issue https://github.com/docker/compose/issues/1869 to be resolved.