### PR TITLE
create_host_config now needs version

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -794,6 +794,7 @@ class Client(clientbase.ClientBase):
                     DeprecationWarning
                 )
             start_config = utils.create_host_config(**start_config_kwargs)
+            start_config['version'] = self._version
 
         url = self._url("/containers/{0}/start".format(container))
         res = self._post_json(url, data=start_config)

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -27,6 +27,7 @@ from datetime import datetime
 import requests
 import six
 
+from .. constants import DEFAULT_DOCKER_API_VERSION
 from .. import errors
 from .. import tls
 from .types import Ulimit, LogConfig
@@ -389,6 +390,7 @@ def parse_bytes(s):
 
 
 def create_host_config(
+    version=DEFAULT_DOCKER_API_VERSION,
     binds=None, port_bindings=None, lxc_conf=None,
     publish_all_ports=False, links=None, privileged=False,
     dns=None, dns_search=None, volumes_from=None, network_mode=None,
@@ -434,7 +436,8 @@ def create_host_config(
     if network_mode:
         host_config['NetworkMode'] = network_mode
     elif network_mode is None:
-        host_config['NetworkMode'] = 'default'
+        if compare_version('1.19', version) > 0:
+            host_config['NetworkMode'] = 'default'
 
     if restart_policy:
         host_config['RestartPolicy'] = restart_policy

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -147,6 +147,14 @@ class UtilsTest(base.BaseTestCase):
         empty_config = create_host_config(network_mode='')
         self.assertEqual(empty_config, {})
 
+    def test_latest_api_version_network_mode_set_to_default(self):
+        config = create_host_config(version='1.20')
+        self.assertEqual(config['NetworkMode'], 'default')
+
+    def test_older_api_version_network_mode_not_set(self):
+        config = create_host_config(version='1.19')
+        self.assertFalse('NetworkMode' in config)
+
     def test_create_host_config_dict_ulimit(self):
         ulimit_dct = {'name': 'nofile', 'soft': 8096}
         config = create_host_config(ulimits=[ulimit_dct])


### PR DESCRIPTION
When network_mode was introduced to have a default of 'default'
it broke backwards compatibility for API versions < 1.20

To fix this, we need to check a version, to do that, we need the
version passed in. To ensure this fix doesn't break backwards
compatibility itself, we use the DEFAULT_DOCKER_API_VERSION as
a default if version isn't passed in.

Fixes #714 