### PR TITLE
Update types.py to support fluentd logging driver

### DIFF
--- a/docker/utils/types.py
+++ b/docker/utils/types.py
@@ -6,9 +6,11 @@ class LogConfigTypesEnum(object):
         'json-file',
         'syslog',
         'journald',
+        'gelf',
+        'fluentd',
         'none'
     )
-    JSON, SYSLOG, JOURNALD, NONE = _values
+    JSON, SYSLOG, JOURNALD, GELF, FLUENTD, NONE = _values
 
 
 class DictType(dict):


### PR DESCRIPTION
docker 1.8 now supports a fluentd logging driver - https://docs.docker.com/reference/logging/fluentd/?utm_content=buffer61fdd&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer