### PR TITLE
Split the entrypoint string to shell-like syntax.

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -564,6 +564,9 @@ def create_container_config(
     if isinstance(command, six.string_types):
         command = shlex.split(str(command))
 
+    if isinstance(entrypoint, six.string_types):
+        entrypoint = shlex.split(str(entrypoint))
+
     if isinstance(environment, dict):
         environment = [
             six.text_type('{0}={1}').format(k, v)

--- a/tests/test.py
+++ b/tests/test.py
@@ -428,7 +428,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
     def test_create_container_with_entrypoint(self):
         try:
             self.client.create_container('busybox', 'hello',
-                                         entrypoint='cowsay')
+                                         entrypoint='cowsay entry')
         except Exception as e:
             self.fail('Command should not raise exception: {0}'.format(e))
 
@@ -443,7 +443,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
                              "AttachStdout": true, "OpenStdin": false,
                              "StdinOnce": false,
                              "NetworkDisabled": false,
-                             "Entrypoint": "cowsay"}'''))
+                             "Entrypoint": ["cowsay", "entry"]}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 


### PR DESCRIPTION
If not doing shlex for  ```entrypoint```  parameter. 
 Jenkin image cannot start successful.