### PR TITLE
Support to pass optional args to adapter

### DIFF
--- a/docker/clientbase.py
+++ b/docker/clientbase.py
@@ -19,7 +19,7 @@ from .tls import TLSConfig
 class ClientBase(requests.Session):
     def __init__(self, base_url=None, version=None,
                  timeout=constants.DEFAULT_TIMEOUT_SECONDS, tls=False,
-                 **adapter_kwargs):
+                 max_connections=1):
         super(ClientBase, self).__init__()
 
         if tls and not base_url.startswith('https://'):
@@ -35,7 +35,7 @@ class ClientBase(requests.Session):
         base_url = utils.parse_host(base_url)
         if base_url.startswith('http+unix://'):
             self._custom_adapter = unixconn.UnixAdapter(base_url, timeout,
-                                                        **adapter_kwargs)
+                                                        max_connections)
             self.mount('http+docker://', self._custom_adapter)
             self.base_url = 'http+docker://localunixsocket'
         else:
@@ -43,7 +43,7 @@ class ClientBase(requests.Session):
             if isinstance(tls, TLSConfig):
                 tls.configure_client(self)
             elif tls:
-                self._custom_adapter = ssladapter.SSLAdapter(**adapter_kwargs)
+                self._custom_adapter = ssladapter.SSLAdapter()
                 self.mount('https://', self._custom_adapter)
             self.base_url = base_url
 

--- a/docker/clientbase.py
+++ b/docker/clientbase.py
@@ -18,7 +18,8 @@ from .tls import TLSConfig
 
 class ClientBase(requests.Session):
     def __init__(self, base_url=None, version=None,
-                 timeout=constants.DEFAULT_TIMEOUT_SECONDS, tls=False):
+                 timeout=constants.DEFAULT_TIMEOUT_SECONDS, tls=False,
+                 **adapter_kwargs):
         super(ClientBase, self).__init__()
 
         if tls and not base_url.startswith('https://'):
@@ -33,7 +34,8 @@ class ClientBase(requests.Session):
 
         base_url = utils.parse_host(base_url)
         if base_url.startswith('http+unix://'):
-            self._custom_adapter = unixconn.UnixAdapter(base_url, timeout)
+            self._custom_adapter = unixconn.UnixAdapter(base_url, timeout,
+                                                        **adapter_kwargs)
             self.mount('http+docker://', self._custom_adapter)
             self.base_url = 'http+docker://localunixsocket'
         else:
@@ -41,7 +43,7 @@ class ClientBase(requests.Session):
             if isinstance(tls, TLSConfig):
                 tls.configure_client(self)
             elif tls:
-                self._custom_adapter = ssladapter.SSLAdapter()
+                self._custom_adapter = ssladapter.SSLAdapter(**adapter_kwargs)
                 self.mount('https://', self._custom_adapter)
             self.base_url = base_url
 

--- a/docker/unixconn/unixconn.py
+++ b/docker/unixconn/unixconn.py
@@ -57,17 +57,16 @@ class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
 
 class UnixAdapter(requests.adapters.HTTPAdapter):
-    def __init__(self, socket_url, timeout=60,
-                 maxsize=1, num_pools=10, **kwargs):
+    def __init__(self, socket_url, timeout=60, maxsize=1):
         socket_path = socket_url.replace('http+unix://', '')
         if not socket_path.startswith('/'):
             socket_path = '/' + socket_path
         self.socket_path = socket_path
         self.timeout = timeout
         self.maxsize = maxsize
-        self.pools = RecentlyUsedContainer(num_pools,
+        self.pools = RecentlyUsedContainer(10,
                                            dispose_func=lambda p: p.close())
-        super(UnixAdapter, self).__init__(**kwargs)
+        super(UnixAdapter, self).__init__()
 
     def get_connection(self, url, proxies=None):
         with self.pools.lock:

--- a/docker/unixconn/unixconn.py
+++ b/docker/unixconn/unixconn.py
@@ -43,9 +43,9 @@ class UnixHTTPConnection(httplib.HTTPConnection, object):
 
 
 class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
-    def __init__(self, base_url, socket_path, timeout=60):
+    def __init__(self, base_url, socket_path, timeout=60, maxsize=1):
         urllib3.connectionpool.HTTPConnectionPool.__init__(
-            self, 'localhost', timeout=timeout
+            self, 'localhost', timeout=timeout, maxsize=maxsize
         )
         self.base_url = base_url
         self.socket_path = socket_path
@@ -57,15 +57,17 @@ class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
 
 class UnixAdapter(requests.adapters.HTTPAdapter):
-    def __init__(self, socket_url, timeout=60):
+    def __init__(self, socket_url, timeout=60,
+                 maxsize=1, num_pools=10, **kwargs):
         socket_path = socket_url.replace('http+unix://', '')
         if not socket_path.startswith('/'):
             socket_path = '/' + socket_path
         self.socket_path = socket_path
         self.timeout = timeout
-        self.pools = RecentlyUsedContainer(10,
+        self.maxsize = maxsize
+        self.pools = RecentlyUsedContainer(num_pools,
                                            dispose_func=lambda p: p.close())
-        super(UnixAdapter, self).__init__()
+        super(UnixAdapter, self).__init__(**kwargs)
 
     def get_connection(self, url, proxies=None):
         with self.pools.lock:
@@ -75,7 +77,8 @@ class UnixAdapter(requests.adapters.HTTPAdapter):
 
             pool = UnixHTTPConnectionPool(url,
                                           self.socket_path,
-                                          self.timeout)
+                                          self.timeout,
+                                          self.maxsize)
             self.pools[url] = pool
 
         return pool


### PR DESCRIPTION
This patch enables to pass optional args to UnixAdapter and SSLAdapter.
For example, increasing `maxsize` in UnixHTTPConnectionPool leads to
suppress `Connection pool is full, discarding connection` warnings.

Signed-off-by: Wataru Takase wataru.takase@kek.jp
