### PR TITLE
Always send a string for the user param in create_container

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -715,7 +715,7 @@ def create_container_config(
         'Hostname': hostname,
         'Domainname': domainname,
         'ExposedPorts': ports,
-        'User': '{0}'.format(user) if user else None,
+        'User': six.text_type(user) if user else None,
         'Tty': tty,
         'OpenStdin': stdin_open,
         'StdinOnce': stdin_once,

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -715,7 +715,7 @@ def create_container_config(
         'Hostname': hostname,
         'Domainname': domainname,
         'ExposedPorts': ports,
-        'User': user,
+        'User': '{0}'.format(user) if user else None,
         'Tty': tty,
         'OpenStdin': stdin_open,
         'StdinOnce': stdin_once,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1626,4 +1626,7 @@ class TestRegressions(BaseTestCase):
         self.client.stop(ctnr)
 
     def test_715(self):
-        self.client.create_container('busybox', 'true', user=1000)
+        ctnr = self.client.create_container('busybox', ['id', '-u'], user=1000)
+        self.client.start(ctnr)
+        self.client.wait(ctnr)
+        assert self.client.logs(ctnr) == '1000\n'

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1624,3 +1624,6 @@ class TestRegressions(BaseTestCase):
         ctnr = self.client.create_container('busybox', ['sleep', '2'])
         self.client.start(ctnr)
         self.client.stop(ctnr)
+
+    def test_715(self):
+        self.client.create_container('busybox', 'true', user=1000)


### PR DESCRIPTION
Fixes #715 