### PR TITLE
Add @dnephin and @mnowster as maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,5 @@
 Joffrey F <joffrey@docker.com> (@shin-)
 Maxime Petazzoni <maxime.petazzoni@bulix.org> (@mpetazzoni)
 Aanand Prasad <aanand@docker.com> (@aanand)
+Daniel Nephin <dnephin@gmail.com> (@dnephin)
+Mazz Mosley <mazz@houseofmnowster.com> (@mnowster)


### PR DESCRIPTION
@dnephin I'm not actually sure what the right email to use for you is. I've gone with the same one that's in your commits, which is consistent with [MAINTAINERS in docker/compose](https://github.com/docker/compose/blob/master/MAINTAINERS).
