### PR TITLE
Remove not exists file in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include test-requirements.txt
 include requirements.txt
-include requirements3.txt
 include README.md
 include LICENSE
 recursive-include tests *.py


### PR DESCRIPTION
Should be remove in MANIFEST.in
Or it will shows warning message when doing ``pip install docker-py``

    warning: no files found matching 'requirements3.txt'