### PR TITLE
Fix bind volume from host with Unicode path

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -249,7 +249,7 @@ def convert_volume_binds(binds):
                 mode = 'rw'
 
             result.append('{0}:{1}:{2}'.format(
-                k, v['bind'], mode
+                k.encode('utf8'), v['bind'].encode('utf8'), mode
             ))
         else:
             result.append('{0}:{1}:rw'.format(k, v))


### PR DESCRIPTION
If the binds key is unicode. It will occurs exception as following:
```
  File "/home/vagrant/.local/share/virtualenvs/qnap/local/lib/python2.7/site-packages/docker/utils/utils.py", line 461, in create_host_config
    host_config['Binds'] = convert_volume_binds(binds)
  File "/home/vagrant/.local/share/virtualenvs/qnap/local/lib/python2.7/site-packages/docker/utils/utils.py", line 208, in convert_volume_binds
    k, v['bind'], mode
```