### PR TITLE
Force coverage dependency to a version supporting py3.2

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 mock==1.0.1
 pytest==2.7.2
+coverage==3.7.1
 pytest-cov==2.1.0


### PR DESCRIPTION
As per https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using

