### PR TITLE
Allow to specify ps_args when listing processes

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -325,9 +325,12 @@ class ContainerApiMixin(object):
         self._raise_for_status(res)
 
     @utils.check_resource
-    def top(self, container):
+    def top(self, container, ps_args=None):
         u = self._url("/containers/{0}/top", container)
-        return self._result(self._get(u), True)
+        params = {}
+        if ps_args is not None:
+            params['ps_args'] = ps_args
+        return self._result(self._get(u, params=params), True)
 
     @utils.check_resource
     def unpause(self, container):

--- a/docs/api.md
+++ b/docs/api.md
@@ -878,6 +878,7 @@ Display the running processes of a container.
 **Params**:
 
 * container (str): The container to inspect
+* ps_args (str): An optional arguments passed to ps (e.g., aux)
 
 **Returns** (str): The output of the top
 

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -383,6 +383,33 @@ def get_fake_stats():
     return status_code, response
 
 
+def get_fake_top():
+    return 200, {
+        'Processes': [
+            [
+                'root',
+                '26501',
+                '6907',
+                '0',
+                '10:32',
+                'pts/55',
+                '00:00:00',
+                'sleep 60',
+            ],
+        ],
+        'Titles': [
+            'UID',
+            'PID',
+            'PPID',
+            'C',
+            'STIME',
+            'TTY',
+            'TIME',
+            'CMD',
+        ],
+    }
+
+
 def get_fake_volume_list():
     status_code = 200
     response = {
@@ -462,6 +489,8 @@ fake_responses = {
 
     '{1}/{0}/containers/3cc2351ab11b/stats'.format(CURRENT_VERSION, prefix):
     get_fake_stats,
+    '{1}/{0}/containers/3cc2351ab11b/top'.format(CURRENT_VERSION, prefix):
+    get_fake_top,
     '{1}/{0}/containers/3cc2351ab11b/stop'.format(CURRENT_VERSION, prefix):
     post_fake_stop_container,
     '{1}/{0}/containers/3cc2351ab11b/kill'.format(CURRENT_VERSION, prefix):

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -786,6 +786,44 @@ class TestMacAddress(BaseTestCase):
         self.client.kill(id)
 
 
+class TestContainerTop(BaseTestCase):
+    def runTest(self):
+        container = self.client.create_container(
+            BUSYBOX, ['sleep', '60'])
+
+        id = container['Id']
+
+        self.client.start(container)
+        res = self.client.top(container['Id'])
+        print(res)
+        self.assertEqual(
+            res['Titles'],
+            ['UID', 'PID', 'PPID', 'C', 'STIME', 'TTY', 'TIME', 'CMD']
+        )
+        self.assertEqual(len(res['Processes']), 1)
+        self.assertEqual(res['Processes'][0][7], 'sleep 60')
+        self.client.kill(id)
+
+
+class TestContainerTopWithPsArgs(BaseTestCase):
+    def runTest(self):
+        container = self.client.create_container(
+            BUSYBOX, ['sleep', '60'])
+
+        id = container['Id']
+
+        self.client.start(container)
+        res = self.client.top(container['Id'], 'waux')
+        self.assertEqual(
+            res['Titles'],
+            ['USER', 'PID', '%CPU', '%MEM', 'VSZ', 'RSS',
+                'TTY', 'STAT', 'START', 'TIME', 'COMMAND'],
+        )
+        self.assertEqual(len(res['Processes']), 1)
+        self.assertEqual(res['Processes'][0][10], 'sleep 60')
+        self.client.kill(id)
+
+
 class TestRestart(BaseTestCase):
     def runTest(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])

--- a/tests/test.py
+++ b/tests/test.py
@@ -1713,6 +1713,26 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
             stream=True
         )
 
+    def test_container_top(self):
+        self.client.top(fake_api.FAKE_CONTAINER_ID)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'containers/3cc2351ab11b/top',
+            params={},
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_container_top_with_psargs(self):
+        self.client.top(fake_api.FAKE_CONTAINER_ID, 'waux')
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'containers/3cc2351ab11b/top',
+            params={'ps_args': 'waux'},
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
     ##################
     #  IMAGES TESTS  #
     ##################


### PR DESCRIPTION
Docker remote API allow to use custom option to ps for endpoint "top" (ps_args). Unfortunately docker-py does not allow to specify ps_args.

This pull request fix this issue by adding an optional ps_args argument