### PR TITLE
Shorter stack traces in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,15 @@ unit-test-py3: build-py3
 	docker run docker-py3 py.test tests/test.py tests/utils_test.py
 
 integration-test: build
-	docker run -v /var/run/docker.sock:/var/run/docker.sock docker-py py.test -rxs tests/integration_test.py
+	docker run -v /var/run/docker.sock:/var/run/docker.sock docker-py py.test tests/integration_test.py
 
 integration-test-py3: build-py3
-	docker run -v /var/run/docker.sock:/var/run/docker.sock docker-py3 py.test -rxs tests/integration_test.py
+	docker run -v /var/run/docker.sock:/var/run/docker.sock docker-py3 py.test tests/integration_test.py
 
 integration-dind: build build-py3
 	docker run -d --name dpy-dind --privileged dockerswarm/dind:1.8.1 docker -d -H tcp://0.0.0.0:2375
-	docker run --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-py py.test -rxs tests/integration_test.py
-	docker run --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-py3 py.test -rxs tests/integration_test.py
+	docker run --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-py py.test tests/integration_test.py
+	docker run --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-py3 py.test tests/integration_test.py
 	docker rm -vf dpy-dind
 
 flake8: build

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -rxs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = -rxs
+addopts = --tb=short -rxs


### PR DESCRIPTION
We don't need the full-blown "here's the code of the massive library method that your error came from" report that py.test gives you by default.