### PR TITLE
_url can take arbitrarily many arguments

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -111,21 +111,22 @@ class Client(
     def _delete(self, url, **kwargs):
         return self.delete(url, **self._set_request_timeout(kwargs))
 
-    def _url(self, pathfmt, resource_id=None, versioned_api=True):
-        if resource_id and not isinstance(resource_id, six.string_types):
-            raise ValueError(
-                'Expected a resource ID string but found {0} ({1}) '
-                'instead'.format(resource_id, type(resource_id))
-            )
-        elif resource_id:
-            resource_id = six.moves.urllib.parse.quote_plus(resource_id)
+    def _url(self, pathfmt, *args, **kwargs):
+        for arg in args:
+            if not isinstance(arg, six.string_types):
+                raise ValueError(
+                    'Expected a string but found {0} ({1}) '
+                    'instead'.format(arg, type(arg))
+                )
 
-        if versioned_api:
+        args = map(six.moves.urllib.parse.quote_plus, args)
+
+        if kwargs.get('versioned_api', True):
             return '{0}/v{1}{2}'.format(
-                self.base_url, self._version, pathfmt.format(resource_id)
+                self.base_url, self._version, pathfmt.format(*args)
             )
         else:
-            return '{0}{1}'.format(self.base_url, pathfmt.format(resource_id))
+            return '{0}{1}'.format(self.base_url, pathfmt.format(*args))
 
     def _raise_for_status(self, response, explanation=None):
         """Raises stored :class:`APIError`, if one occurred."""

--- a/tests/test.py
+++ b/tests/test.py
@@ -104,7 +104,9 @@ def fake_put(self, url, *args, **kwargs):
 def fake_delete(self, url, *args, **kwargs):
     return fake_request('DELETE', url, *args, **kwargs)
 
-url_prefix = 'http+docker://localunixsocket/v{0}/'.format(
+url_base = 'http+docker://localunixsocket/'
+url_prefix = '{0}v{1}/'.format(
+    url_base,
     docker.constants.DEFAULT_DOCKER_API_VERSION)
 
 
@@ -174,6 +176,11 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
             url, '{0}{1}'.format(url_prefix, 'hello/somename/world')
         )
 
+        url = self.client._url('/hello/{0}/world/{1}', 'somename', 'someothername')
+        self.assertEqual(
+            url, '{0}{1}'.format(url_prefix, 'hello/somename/world/someothername')
+        )
+
         url = self.client._url('/hello/{0}/world', '/some?name')
         self.assertEqual(
             url, '{0}{1}'.format(url_prefix, 'hello/%2Fsome%3Fname/world')
@@ -187,8 +194,9 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         url = self.client._url('/simple')
         self.assertEqual(url, '{0}{1}'.format(url_prefix, 'simple'))
 
-        url = self.client._url('/simple', None)
-        self.assertEqual(url, '{0}{1}'.format(url_prefix, 'simple'))
+    def test_url_unversioned_api(self):
+        url = self.client._url('/hello/{0}/world', 'somename', versioned_api=False)
+        self.assertEqual(url, '{0}{1}'.format(url_base, 'hello/somename/world'))
 
     #########################
     #   INFORMATION TESTS   #
@@ -199,6 +207,15 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'version',
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_version_no_api_version(self):
+        self.client.version(False)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_base + 'version',
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 


### PR DESCRIPTION
This is needed by the networking PR.

I removed a test case for when `None` is explicitly passed in. I don't think we'd ever do that, but am I mistaken?