### PR TITLE
Allow a host to be passed for the IP portion of a port binding.

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -18,6 +18,7 @@ import os
 import os.path
 import json
 import shlex
+import socket
 import tarfile
 import tempfile
 import warnings
@@ -281,6 +282,15 @@ def _convert_port_binding(binding):
         result['HostPort'] = ''
     else:
         result['HostPort'] = str(result['HostPort'])
+
+    if result['HostIp']:
+        try:
+            # Try to convert a hostname (if provided) to an IPv4 address.  Port
+            # binding IPv6 addresses is not supported in docker, so using
+            # gethostbyname is sufficient.
+            result['HostIp'] = socket.gethostbyname(result['HostIp'])
+        except socket.gaierror:
+            pass
 
     return result
 

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -651,7 +651,8 @@ class CreateContainerTest(DockerClientTest):
                     '3333/udp': (3333,),
                     4444: ('127.0.0.1',),
                     5555: ('127.0.0.1', 5555),
-                    6666: [('127.0.0.1',), ('192.168.0.1',)]
+                    6666: [('127.0.0.1',), ('192.168.0.1',)],
+                    7777: ('localhost', 7777),
                 }
             )
         )
@@ -666,6 +667,7 @@ class CreateContainerTest(DockerClientTest):
         self.assertTrue('4444/tcp' in port_bindings)
         self.assertTrue('5555/tcp' in port_bindings)
         self.assertTrue('6666/tcp' in port_bindings)
+        self.assertTrue('7777/tcp' in port_bindings)
         self.assertEqual(
             [{"HostPort": "", "HostIp": ""}],
             port_bindings['1111/tcp']
@@ -687,6 +689,10 @@ class CreateContainerTest(DockerClientTest):
             port_bindings['5555/tcp']
         )
         self.assertEqual(len(port_bindings['6666/tcp']), 2)
+        self.assertEqual(
+            [{"HostPort": "7777", "HostIp": "127.0.0.1"}],
+            port_bindings['7777/tcp']
+        )
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
         self.assertEqual(


### PR DESCRIPTION
Previously, if a hostname were provided in place of an IP address in a port
binding definition, the docker daemon would simply ignore it and bind to all
interfaces instead of a specific one.  This change makes it so that a hostname
can be used in place of the IP.  The address for that host will be resolved
to an IP and then the IP is passed to the docker daemon.  This still requires
that the IP that it resolves to exists on the docker host.

This is particularly useful in situations where it is common to move containers
from one docker host to another.  One could have a docker-compose.yml, for
instance, that does not need to change (using the hostname in the 'ports'
definition).  When the container is to be moved to a new host, DNS can just be
updated to reflect the address on the new host to be used.  Then docker-compose
will use the right address when it's brought up on that host.

Signed-off-by: Tommy Beadle tbeadle@gmail.com
