### PR TITLE
Remove skip test

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -380,8 +380,6 @@ class CreateContainerWithLogConfigTest(BaseTestCase):
 
         assert expected_msg in str(excinfo.value)
 
-    @pytest.mark.skipif(True,
-                        reason="https://github.com/docker/docker/issues/15633")
     def test_valid_no_log_driver_specified(self):
         log_config = docker.utils.LogConfig(
             type="",


### PR DESCRIPTION
It has been reported that the bug, https://github.com/docker/docker/issues/15633, in docker has now been fixed so we can re-instate this test.
