### PR TITLE
Cpuset extend to include cpuset-mems

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -95,8 +95,9 @@ class ContainerApiMixin(object):
                          dns=None, volumes=None, volumes_from=None,
                          network_disabled=False, name=None, entrypoint=None,
                          cpu_shares=None, working_dir=None, domainname=None,
-                         memswap_limit=None, cpuset=None, host_config=None,
-                         mac_address=None, labels=None, volume_driver=None):
+                         memswap_limit=None, cpuset=None, cpuset_cpus=None,
+                         cpuset_mems=None, host_config=None, mac_address=None,
+                         labels=None, volume_driver=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -110,8 +111,8 @@ class ContainerApiMixin(object):
             image, command, hostname, user, detach, stdin_open,
             tty, mem_limit, ports, environment, dns, volumes, volumes_from,
             network_disabled, entrypoint, cpu_shares, working_dir, domainname,
-            memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver
+            memswap_limit, cpuset, cpuset_cpus, cpuset_mems, host_config,
+            mac_address, labels, volume_driver
         )
         return self.create_container_from_config(config, name)
 

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -2,7 +2,7 @@ DEFAULT_DOCKER_API_VERSION = '1.20'
 DEFAULT_TIMEOUT_SECONDS = 60
 STREAM_HEADER_SIZE_BYTES = 8
 CONTAINER_LIMITS_KEYS = [
-    'memory', 'memswap', 'cpushares', 'cpusetcpus'
+    'memory', 'memswap', 'cpushares', 'cpusetcpus', 'cpusetmems'
 ]
 
 INSECURE_REGISTRY_DEPRECATION_WARNING = \

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -678,8 +678,8 @@ def create_container_config(
     stdin_open=False, tty=False, mem_limit=None, ports=None, environment=None,
     dns=None, volumes=None, volumes_from=None, network_disabled=False,
     entrypoint=None, cpu_shares=None, working_dir=None, domainname=None,
-    memswap_limit=None, cpuset=None, host_config=None, mac_address=None,
-    labels=None, volume_driver=None
+    memswap_limit=None, cpuset=None, cpuset_cpus=None, cpuset_mems=None,
+    host_config=None, mac_address=None, labels=None, volume_driver=None
 ):
     if isinstance(command, six.string_types):
         command = shlex.split(str(command))
@@ -796,7 +796,8 @@ def create_container_config(
         'Entrypoint': entrypoint,
         'CpuShares': cpu_shares,
         'Cpuset': cpuset,
-        'CpusetCpus': cpuset,
+        'CpusetCpus': cpuset or cpuset_cpus,
+        'CpusetMems': cpuset_mems,
         'WorkingDir': working_dir,
         'MemorySwap': memswap_limit,
         'HostConfig': host_config,

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,7 @@ correct value (e.g `gzip`).
     - memswap (int): Total memory (memory + swap), -1 to disable swap
     - cpushares (int): CPU shares (relative weight)
     - cpusetcpus (str): CPUs in which to allow execution, e.g., `"0-3"`, `"0,1"`
+    - cpusetmems (str): Memory nodes in which to allow execution, e.g., `"0-3"`, `"0,1"`
 * decode (bool): If set to `True`, the returned stream will be decoded into
   dicts on the fly. Default `False`.
 
@@ -217,6 +218,8 @@ from. Optionally a single string joining container id's with commas
 * name (str): A name for the container
 * entrypoint (str or list): An entrypoint
 * cpu_shares (int): CPU shares (relative weight)
+* cpuset_cpus (str): CPUs in which to allow execution, e.g., `"0-3"`, `"0,1"`
+* cpuset_mems (str): Memory nodes in which to allow execution, e.g., `"0-3"`, `"0,1"`
 * working_dir (str): Path to the working directory
 * domainname (str or list): Set custom DNS search domains
 * memswap_limit (int):

--- a/tests/test.py
+++ b/tests/test.py
@@ -548,6 +548,44 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 
+    def test_create_container_with_cpuset_cpus(self):
+        self.client.create_container('busybox', 'ls',
+                                     cpuset_cpus='0,1')
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][1],
+                         url_prefix + 'containers/create')
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls"], "AttachStdin": false,
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false,
+                             "CpusetCpus": "0,1"}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
+    def test_create_container_with_cpuset_mems(self):
+        self.client.create_container('busybox', 'ls',
+                                     cpuset_mems='0,1')
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][1],
+                         url_prefix + 'containers/create')
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls"], "AttachStdin": false,
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false,
+                             "CpusetMems": "0,1"}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
     def test_create_container_with_cgroup_parent(self):
         self.client.create_container(
             'busybox', 'ls', host_config=self.client.create_host_config(


### PR DESCRIPTION
Simple patch that allows the configuration of cpuset-mems for creating containers. I would also recommend deprecating, for consistency, the parameter **cpusets** in `create_container` and `create_container_config` since cpuset-cpus exists.

In my patch I have included support code that allows someone to define **cpuset** and it will also set **cpuset-cpus** until **cpuset** is deprecated. I have updated tests to support this.