### PR TITLE
Add support for non-stream stats of containers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 80
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -344,9 +344,14 @@ class ContainerApiMixin(object):
 
     @utils.minimum_version('1.17')
     @utils.check_resource
-    def stats(self, container, decode=None):
+    def stats(self, container, decode=None, stream=True):
         url = self._url("/containers/{0}/stats", container)
-        return self._stream_helper(self._get(url, stream=True), decode=decode)
+        if stream:
+            return self._stream_helper(self._get(url, stream=True),
+                                       decode=decode)
+        else:
+            return self._result(self._get(url, params={'stream': False}),
+                                json=True)
 
     @utils.check_resource
     def stop(self, container, timeout=10):

--- a/docs/api.md
+++ b/docs/api.md
@@ -873,6 +873,8 @@ This will stream statistics for a specific container.
 * container (str): The container to stream statistics for
 * decode (bool): If set to true, stream will be decoded into dicts on the
   fly. False by default.
+* stream (bool): If set to false, only the current stats will be returned
+  instead of a stream. True by default.
 
 ```python
 >>> from docker import Client

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -989,3 +989,20 @@ class PauseTest(api_test.BaseTestCase):
         self.assertEqual(state['Running'], True)
         self.assertIn('Paused', state)
         self.assertEqual(state['Paused'], False)
+
+
+class GetContainerStatsTest(BaseTestCase):
+    @requires_api_version('1.19')
+    def test_get_container_stats_no_stream(self):
+        container = self.client.create_container(
+            BUSYBOX, ['sleep', '60'],
+        )
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        response = self.client.stats(container, stream=0)
+        self.client.kill(container)
+
+        self.assertEquals(type(response), dict)
+        for key in ['read', 'network', 'precpu_stats', 'cpu_stats',
+                    'memory_stats', 'blkio_stats']:
+            self.assertIn(key, response)

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -991,7 +991,7 @@ class PauseTest(api_test.BaseTestCase):
         self.assertEqual(state['Paused'], False)
 
 
-class GetContainerStatsTest(BaseTestCase):
+class GetContainerStatsTest(api_test.BaseTestCase):
     @requires_api_version('1.19')
     def test_get_container_stats_no_stream(self):
         container = self.client.create_container(
@@ -1002,7 +1002,21 @@ class GetContainerStatsTest(BaseTestCase):
         response = self.client.stats(container, stream=0)
         self.client.kill(container)
 
-        self.assertEquals(type(response), dict)
+        self.assertEqual(type(response), dict)
         for key in ['read', 'network', 'precpu_stats', 'cpu_stats',
                     'memory_stats', 'blkio_stats']:
             self.assertIn(key, response)
+
+        @requires_api_version('1.17')
+        def test_get_container_stats_stream(self):
+            container = self.client.create_container(
+                BUSYBOX, ['sleep', '60'],
+            )
+            self.tmp_containers.append(container)
+            self.client.start(container)
+            stream = self.client.stats(container)
+            for chunk in stream:
+                self.assertEqual(type(chunk), dict)
+                for key in ['read', 'network', 'precpu_stats', 'cpu_stats',
+                            'memory_stats', 'blkio_stats']:
+                    self.assertIn(key, chunk)


### PR DESCRIPTION
Adds one more flag to the `stats` method for non-streaming responses.

Keeps default as streamed response for backwards compatibility.