### PR TITLE
Use url-safe base64 when encoding auth header

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -102,7 +102,7 @@ def decode_auth(auth):
 
 def encode_header(auth):
     auth_json = json.dumps(auth).encode('ascii')
-    return base64.b64encode(auth_json)
+    return base64.urlsafe_b64encode(auth_json)
 
 
 def parse_auth(entries):


### PR DESCRIPTION
Fixes #803 