### PR TITLE
Docs examples

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,8 +4,8 @@ To instantiate a `Client` class that will allow you to communicate with a
 Docker daemon, simply do:
 
 ```python
-from docker import Client
-c = Client(base_url='unix://var/run/docker.sock')
+>>> from docker import Client
+>>> cli = Client(base_url='unix://var/run/docker.sock')
 ```
 
 **Params**:
@@ -250,9 +250,9 @@ PASSWORD=secret
 The utility can be used as follows:
 
 ```python
->> import docker.utils
->> my_envs = docker.utils.parse_env_file('/path/to/file')
->> docker.utils.create_container_config('1.18', '_mongodb', 'foobar',  environment=my_envs)
+>>> import docker.utils
+>>> my_envs = docker.utils.parse_env_file('/path/to/file')
+>>> docker.utils.create_container_config('1.18', '_mongodb', 'foobar',  environment=my_envs)
 ```
 
 You can now use this with 'environment' for `create_container`.
@@ -392,9 +392,9 @@ a dict containing `stat` information on the specified `path`.
 
 ```python
 >>> import docker
->>> c = docker.Client()
->>> ctnr = c.create_container('busybox', 'true')
->>> strm, stat = c.get_archive(ctnr, '/bin/sh')
+>>> cli = docker.Client()
+>>> ctnr = cli.create_container('busybox', 'true')
+>>> strm, stat = cli.get_archive(ctnr, '/bin/sh')
 >>> print(stat)
 {u'linkTarget': u'', u'mode': 493, u'mtime': u'2015-09-16T12:34:23-07:00', u'name': u'sh', u'size': 962860}
 ```

--- a/docs/boot2docker.md
+++ b/docs/boot2docker.md
@@ -15,8 +15,8 @@ You can then instantiate `docker.Client` like this:
 from docker.client import Client
 from docker.utils import kwargs_from_env
 
-client = Client(**kwargs_from_env())
-print client.version()
+cli = Client(**kwargs_from_env())
+print cli.version()
 ```
 
 If you're encountering the following error:
@@ -33,6 +33,6 @@ from docker.utils import kwargs_from_env
 kwargs = kwargs_from_env()
 kwargs['tls'].assert_hostname = False
 
-client = Client(**kwargs)
-print client.version()
+cli = Client(**kwargs)
+print cli.version()
 ```

--- a/docs/host-devices.md
+++ b/docs/host-devices.md
@@ -5,8 +5,8 @@ the devices parameter in the `host_config` param in `Client.create_container`
 as shown below:
 
 ```python
-c.create_container(
-    'busybox', 'true', host_config=docker.utils.create_host_config(devices=[
+cli.create_container(
+    'busybox', 'true', host_config=cli.create_host_config(devices=[
         '/dev/sda:/dev/xvda:rwm'
     ])
 )

--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -114,7 +114,7 @@ for example:
 
 ```python
 >>> from docker import Client
->>> c = Client()
->>> c.create_host_config(privileged=True, cap_drop=['MKNOD'], volumes_from=['nostalgic_newton'])
+>>> cli = Client()
+>>> cli.create_host_config(privileged=True, cap_drop=['MKNOD'], volumes_from=['nostalgic_newton'])
 {'CapDrop': ['MKNOD'], 'LxcConf': None, 'Privileged': True, 'VolumesFrom': ['nostalgic_newton'], 'PublishAllPorts': False}
 ```

--- a/docs/port-bindings.md
+++ b/docs/port-bindings.md
@@ -4,9 +4,9 @@ open inside the container in the `Client().create_container()` method.
 Bindings are declared in the `host_config` parameter.
 
 ```python
-container_id = c.create_container(
+container_id = cli.create_container(
     'busybox', 'ls', ports=[1111, 2222],
-    host_config=docker.utils.create_host_config(port_bindings={
+    host_config=cli.create_host_config(port_bindings={
         1111: 4567,
         2222: None
     })
@@ -17,22 +17,22 @@ container_id = c.create_container(
 You can limit the host address on which the port will be exposed like such:
 
 ```python
-docker.utils.create_host_config(port_bindings={1111: ('127.0.0.1', 4567)})
+cli.create_host_config(port_bindings={1111: ('127.0.0.1', 4567)})
 ```
 
 Or without host port assignment:
 
 ```python
-docker.utils.create_host_config(port_bindings={1111: ('127.0.0.1',)})
+cli.create_host_config(port_bindings={1111: ('127.0.0.1',)})
 ```
 
 If you wish to use UDP instead of TCP (default), you need to declare ports
 as such in both the config and host config:
 
 ```python
-container_id = c.create_container(
+container_id = cli.create_container(
 	'busybox', 'ls', ports=[(1111, 'udp'), 2222],
-    host_config=docker.utils.create_host_config(port_bindings={
+    host_config=cli.create_host_config(port_bindings={
         '1111/udp': 4567, 2222: None
     })
 )

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -5,9 +5,9 @@ the `Client().create_container()` method, and declare mappings in the
 `host_config` section.
 
 ```python
-container_id = c.create_container(
+container_id = cli.create_container(
     'busybox', 'ls', volumes=['/mnt/vol1', '/mnt/vol2'],
-    host_config=docker.utils.create_host_config(binds={
+    host_config=cli.create_host_config(binds={
         '/home/user1/': {
             'bind': '/mnt/vol2',
             'mode': 'rw',
@@ -24,9 +24,9 @@ You can alternatively specify binds as a list. This code is equivalent to the
 example above:
 
 ```python
-container_id = c.create_container(
+container_id = cli.create_container(
     'busybox', 'ls', volumes=['/mnt/vol1', '/mnt/vol2'],
-    host_config=docker.utils.create_host_config(binds=[
+    host_config=cli.create_host_config(binds=[
         '/home/user1/:/mnt/vol2',
         '/var/www:/mnt/vol1:ro',
     ])


### PR DESCRIPTION
A couple of minor tidy ups to the examples in the docs, which make them more consistent, and avoid deprecation warnings.