### PR TITLE
allow custom ipam options when creating networks

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -19,14 +19,15 @@ class NetworkApiMixin(object):
         return self._result(res, json=True)
 
     @minimum_version('1.21')
-    def create_network(self, name, driver=None, options=None):
+    def create_network(self, name, driver=None, options=None, ipam=None):
         if options is not None and not isinstance(options, dict):
             raise TypeError('options must be a dictionary')
 
         data = {
             'name': name,
             'driver': driver,
-            'options': options
+            'options': options,
+            'ipam': ipam,
         }
         url = self._url("/networks/create")
         res = self._post_json(url, data=data)

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -4,7 +4,8 @@ from .utils import (
     kwargs_from_env, convert_filters, datetime_to_timestamp, create_host_config,
     create_container_config, parse_bytes, ping_registry, parse_env_file,
     version_lt, version_gte, decode_json_header, split_command,
-)  # flake8: noqa
+    create_ipam_config, create_ipam_pool
+) # flake8: noqa
 
 from .types import Ulimit, LogConfig # flake8: noqa
 from .decorators import check_resource, minimum_version  # flake8: noqa

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -44,6 +44,23 @@ BYTE_UNITS = {
 }
 
 
+def create_ipam_pool(subnet=None, iprange=None, gateway=None,
+                     aux_addresses=None):
+    return {
+        'subnet': subnet,
+        'iprange': iprange,
+        'gateway': gateway,
+        'auxaddresses': aux_addresses
+    }
+
+
+def create_ipam_config(driver='default', pool_configs=None):
+    return {
+        'driver': driver,
+        'config': pool_configs or []
+    }
+
+
 def mkbuildcontext(dockerfile):
     f = tempfile.NamedTemporaryFile()
     t = tarfile.open(mode='w', fileobj=f)

--- a/docs/networks.md
+++ b/docs/networks.md
@@ -1,0 +1,20 @@
+# Using Networks
+
+With the release of Docker 1.9 you can now manage custom networks.
+
+
+Here you can see how to create a network named ```network1``` using the ```bridge``` driver
+
+```python
+docker_client.create_network("network1", driver="bridge")
+```
+
+You can also create more advanced networks with custom IPAM configurations. For example, 
+setting the subnet to ```192.168.52.0/24``` and gateway to ```192.168.52.254```
+
+```python
+
+ipam_config = docker.utils.create_ipam_config(subnet='192.168.52.0/24', gateway='192.168.52.254')
+
+docker_client.create_network("network1", driver="bridge", ipam=ipam_config)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ pages:
 - Using TLS: tls.md
 - Host devices: host-devices.md
 - Host configuration: hostconfig.md
+- Network configuration: networks.md
 - Using with boot2docker: boot2docker.md
 - Change Log: change_log.md
 - Contributing: contributing.md

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -18,7 +18,7 @@ from docker.utils import (
     parse_repository_tag, parse_host, convert_filters, kwargs_from_env,
     create_host_config, Ulimit, LogConfig, parse_bytes, parse_env_file,
     exclude_paths, convert_volume_binds, decode_json_header, tar,
-    split_command,
+    split_command, create_ipam_config, create_ipam_pool
 )
 from docker.utils.ports import build_port_bindings, split_port
 
@@ -427,6 +427,21 @@ class UtilsTest(base.BaseTestCase):
             data = base64.urlsafe_b64encode(json.dumps(obj))
         decoded_data = decode_json_header(data)
         self.assertEqual(obj, decoded_data)
+
+    def test_create_ipam_config(self):
+        ipam_pool = create_ipam_pool(subnet='192.168.52.0/24',
+                                     gateway='192.168.52.254')
+
+        ipam_config = create_ipam_config(pool_configs=[ipam_pool])
+        self.assertEqual(ipam_config, {
+            'driver': 'default',
+            'config': [{
+                'subnet': '192.168.52.0/24',
+                'gateway': '192.168.52.254',
+                'auxaddresses': None,
+                'iprange': None
+            }]
+        })
 
 
 class SplitCommandTest(base.BaseTestCase):


### PR DESCRIPTION
This addresses issue #815 

These options are currently not documented but are still useful when creating networks.