### PR TITLE
Update `Client.create_volume` to use new endpoint

### DIFF
--- a/docker/api/volume.py
+++ b/docker/api/volume.py
@@ -12,7 +12,7 @@ class VolumeApiMixin(object):
 
     @utils.minimum_version('1.21')
     def create_volume(self, name, driver=None, driver_opts=None):
-        url = self._url('/volumes')
+        url = self._url('/volumes/create')
         if driver_opts is not None and not isinstance(driver_opts, dict):
             raise TypeError('driver_opts must be a dictionary')
 

--- a/tests/fake_api.py
+++ b/tests/fake_api.py
@@ -529,7 +529,7 @@ fake_responses = {
     get_fake_events,
     ('{1}/{0}/volumes'.format(CURRENT_VERSION, prefix), 'GET'):
     get_fake_volume_list,
-    ('{1}/{0}/volumes'.format(CURRENT_VERSION, prefix), 'POST'):
+    ('{1}/{0}/volumes/create'.format(CURRENT_VERSION, prefix), 'POST'):
     get_fake_volume,
     ('{1}/{0}/volumes/{2}'.format(
         CURRENT_VERSION, prefix, FAKE_VOLUME_NAME

--- a/tests/test.py
+++ b/tests/test.py
@@ -2208,7 +2208,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         args = fake_request.call_args
 
         self.assertEqual(args[0][0], 'POST')
-        self.assertEqual(args[0][1], url_prefix + 'volumes')
+        self.assertEqual(args[0][1], url_prefix + 'volumes/create')
         self.assertEqual(json.loads(args[1]['data']), {'Name': name})
 
     @base.requires_api_version('1.21')
@@ -2219,7 +2219,7 @@ class DockerClientTest(Cleanup, base.BaseTestCase):
         args = fake_request.call_args
 
         self.assertEqual(args[0][0], 'POST')
-        self.assertEqual(args[0][1], url_prefix + 'volumes')
+        self.assertEqual(args[0][1], url_prefix + 'volumes/create')
         data = json.loads(args[1]['data'])
         self.assertIn('Driver', data)
         self.assertEqual(data['Driver'], driver_name)


### PR DESCRIPTION
New API endpoint is POST /volumes/create (previously just /volumes)
Since the feature is yet unreleased (RC), no fallback strategy is
implemented.

Fixes #819 
