### PR TITLE
Support unicode commands

### DIFF
--- a/docker/api/exec_api.py
+++ b/docker/api/exec_api.py
@@ -1,5 +1,3 @@
-import shlex
-
 import six
 
 from .. import errors
@@ -20,7 +18,7 @@ class ExecApiMixin(object):
                 'User-specific exec is not supported in API < 1.19'
             )
         if isinstance(cmd, six.string_types):
-            cmd = shlex.split(str(cmd))
+            cmd = utils.split_command(cmd)
 
         data = {
             'Container': container,

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -3,7 +3,7 @@ from .utils import (
     mkbuildcontext, tar, exclude_paths, parse_repository_tag, parse_host,
     kwargs_from_env, convert_filters, create_host_config,
     create_container_config, parse_bytes, ping_registry, parse_env_file,
-    version_lt, version_gte, decode_json_header
+    version_lt, version_gte, decode_json_header, split_command,
 ) # flake8: noqa
 
 from .types import Ulimit, LogConfig # flake8: noqa

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -673,6 +673,12 @@ def parse_env_file(env_file):
     return environment
 
 
+def split_command(command):
+    if six.PY2:
+        command = command.encode('utf-8')
+    return shlex.split(command)
+
+
 def create_container_config(
     version, image, command, hostname=None, user=None, detach=False,
     stdin_open=False, tty=False, mem_limit=None, ports=None, environment=None,
@@ -682,10 +688,10 @@ def create_container_config(
     labels=None, volume_driver=None
 ):
     if isinstance(command, six.string_types):
-        command = shlex.split(str(command))
+        command = split_command(command)
 
     if isinstance(entrypoint, six.string_types):
-        entrypoint = shlex.split(str(entrypoint))
+        entrypoint = split_command(entrypoint)
 
     if isinstance(environment, dict):
         environment = [

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -17,7 +17,8 @@ from docker.errors import DockerException
 from docker.utils import (
     parse_repository_tag, parse_host, convert_filters, kwargs_from_env,
     create_host_config, Ulimit, LogConfig, parse_bytes, parse_env_file,
-    exclude_paths, convert_volume_binds, decode_json_header, tar
+    exclude_paths, convert_volume_binds, decode_json_header, tar,
+    split_command,
 )
 from docker.utils.ports import build_port_bindings, split_port
 
@@ -387,6 +388,18 @@ class UtilsTest(base.BaseTestCase):
             data = base64.urlsafe_b64encode(json.dumps(obj))
         decoded_data = decode_json_header(data)
         self.assertEqual(obj, decoded_data)
+
+
+class SplitCommandTest(base.BaseTestCase):
+
+    @pytest.mark.skipif(six.PY2, reason="shlex doesn't support unicode in py2")
+    def test_split_command_with_unicode(self):
+        self.assertEqual(split_command('echo μ'), ['echo', 'μ'])
+
+    @pytest.mark.skipif(six.PY3, reason="shlex doesn't support unicode in py2")
+    def test_split_command_with_bytes(self):
+        expected = ['echo', u'μ'.encode('utf-8')]
+        self.assertEqual(split_command(u'echo μ'), expected)
 
 
 class PortsTest(base.BaseTestCase):


### PR DESCRIPTION
While debugging https://github.com/docker/compose/issues/2255 I can across this error on python2.

The docs claim that python >= 2.7.3 will support unicode in `shlex.split()`, but that is a lie in many cases because it attempts to import and use `cStringIO` which does not support unicode.