### PR TITLE
Fix auth.load_config bug calling parse_auth

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -172,7 +172,7 @@ def load_config(config_path=None):
             data = json.load(f)
             if data.get('auths'):
                 log.debug("Found 'auths' section")
-                return parse_auth(data)
+                return parse_auth(data['auths'])
             else:
                 log.debug("Couldn't find 'auths' section")
                 f.seek(0)

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -287,3 +287,32 @@ class LoadConfigTest(base.Cleanup, base.BaseTestCase):
             self.assertEqual(cfg['password'], 'izayoi')
             self.assertEqual(cfg['email'], 'sakuya@scarlet.net')
             self.assertEqual(cfg.get('auth'), None)
+
+    def test_load_config_custom_config_env_with_auths(self):
+        folder = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, folder)
+
+        dockercfg_path = os.path.join(folder, 'config.json')
+        registry = 'https://your.private.registry.io'
+        auth_ = base64.b64encode(b'sakuya:izayoi').decode('ascii')
+        config = {
+            'auths': {
+                registry: {
+                    'auth': '{0}'.format(auth_),
+                    'email': 'sakuya@scarlet.net'
+                }
+            }
+        }
+
+        with open(dockercfg_path, 'w') as f:
+            json.dump(config, f)
+
+        with mock.patch.dict(os.environ, {'DOCKER_CONFIG': folder}):
+            cfg = auth.load_config(None)
+            assert registry in cfg
+            self.assertNotEqual(cfg[registry], None)
+            cfg = cfg[registry]
+            self.assertEqual(cfg['username'], 'sakuya')
+            self.assertEqual(cfg['password'], 'izayoi')
+            self.assertEqual(cfg['email'], 'sakuya@scarlet.net')
+            self.assertEqual(cfg.get('auth'), None)


### PR DESCRIPTION
When load_config found and auths section it didn't call parse_auth only with
the auths section. Instead it called parse_auth with all the configuration.

There is also a test to check this case

Signed-off-by: Alejandro Brito Monedero <alejandro.monedero@gmail.com>