### PR TITLE
Fix #627

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -96,7 +96,7 @@ def decode_auth(auth):
         auth = auth.encode('ascii')
     s = base64.b64decode(auth)
     login, pwd = s.split(b':', 1)
-    return login.decode('ascii'), pwd.decode('ascii')
+    return login.decode('utf8'), pwd.decode('utf8')
 
 
 def encode_header(auth):

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -316,3 +316,33 @@ class LoadConfigTest(base.Cleanup, base.BaseTestCase):
             self.assertEqual(cfg['password'], 'izayoi')
             self.assertEqual(cfg['email'], 'sakuya@scarlet.net')
             self.assertEqual(cfg.get('auth'), None)
+
+    def test_load_config_custom_config_env_utf8(self):
+        folder = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, folder)
+
+        dockercfg_path = os.path.join(folder, 'config.json')
+        registry = 'https://your.private.registry.io'
+        auth_ = base64.b64encode(
+            b'sakuya\xc3\xa6:izayoi\xc3\xa6').decode('ascii')
+        config = {
+            'auths': {
+                registry: {
+                    'auth': '{0}'.format(auth_),
+                    'email': 'sakuya@scarlet.net'
+                }
+            }
+        }
+
+        with open(dockercfg_path, 'w') as f:
+            json.dump(config, f)
+
+        with mock.patch.dict(os.environ, {'DOCKER_CONFIG': folder}):
+            cfg = auth.load_config(None)
+            assert registry in cfg
+            self.assertNotEqual(cfg[registry], None)
+            cfg = cfg[registry]
+            self.assertEqual(cfg['username'], u'sakuyaæ')
+            self.assertEqual(cfg['password'], u'izayoiæ')
+            self.assertEqual(cfg['email'], 'sakuya@scarlet.net')
+            self.assertEqual(cfg.get('auth'), None)


### PR DESCRIPTION
Docker-py couldn't pull private images if your account have non ascii chars.
Instead docker pull command, didn't have that issue.

Also add a test to check when you have a login or password with an non ascii
char.

Signed-off-by: Alejandro Brito Monedero <alejandro.monedero@gmail.com>