### PR TITLE
Fix #627

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -96,7 +96,7 @@ def decode_auth(auth):
         auth = auth.encode('ascii')
     s = base64.b64decode(auth)
     login, pwd = s.split(b':', 1)
-    return login.decode('ascii'), pwd.decode('ascii')
+    return login.decode('utf8'), pwd.decode('utf8')
 
 
 def encode_header(auth):


### PR DESCRIPTION
Docker-py couldn't pull private images if the account have non ascii chars
in either user or password. It that case an exception ending with no auth
credentials.
Instead docker client (golang) don't suffer this issue.

Also add a test to check the login or password even with non ascii char have
a valid auth dictionary

Signed-off-by: Alejandro Brito Monedero <abrito@alea-soluciones.com>