### PR TITLE
Ensure assert_hostname is set on the pool connection

### DIFF
--- a/docker/ssladapter/ssladapter.py
+++ b/docker/ssladapter/ssladapter.py
@@ -46,6 +46,19 @@ class SSLAdapter(HTTPAdapter):
 
         self.poolmanager = PoolManager(**kwargs)
 
+    def get_connection(self, *args, **kwargs):
+        """
+        Ensure assert_hostname is set correctly on our pool
+
+        We already take care of a normal poolmanager via init_poolmanager
+
+        But we still need to take care of when there is a proxy poolmanager
+        """
+        conn = super(SSLAdapter, self).get_connection(*args, **kwargs)
+        if conn.assert_hostname != self.assert_hostname:
+            conn.assert_hostname = self.assert_hostname
+        return conn
+
     def can_override_ssl_version(self):
         urllib_ver = urllib3.__version__.split('-')[0]
         if urllib_ver is None:


### PR DESCRIPTION
If you have assert_hostname turned off and are using a proxy on your
computer then assert_hostname wasn't being properly set on the pool
connection and it was failing to connect to docker