### PR TITLE
Move methods/classes used by all integration tests to helpers.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ integration-dind: build build-py3
 integration-dind-ssl: build-dind-certs build build-py3
 	docker run -d --name dpy-dind-certs dpy-dind-certs
 	docker run -d --env="DOCKER_HOST=tcp://localhost:2375" --env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --volumes-from dpy-dind-certs --name dpy-dind-ssl -v /tmp --privileged dockerswarm/dind:1.9.0 docker daemon --tlsverify --tlscacert=/certs/ca.pem --tlscert=/certs/server-cert.pem --tlskey=/certs/server-key.pem -H tcp://0.0.0.0:2375
-	docker run --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --link=dpy-dind-ssl:docker docker-py py.test tests/integration_test.py
-	docker run --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --link=dpy-dind-ssl:docker docker-py3 py.test tests/integration_test.py
+	docker run --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --link=dpy-dind-ssl:docker docker-py py.test tests/integration
+	docker run --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --link=dpy-dind-ssl:docker docker-py3 py.test tests/integration
 	docker rm -vf dpy-dind-ssl dpy-dind-certs
 
 flake8: build

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,15 @@
 import os
 import os.path
+import shutil
 import tarfile
 import tempfile
+import unittest
+
+import docker
+import six
+
+BUSYBOX = 'busybox:buildroot-2014.02'
+EXEC_DRIVER = []
 
 
 def make_tree(dirs, files):
@@ -35,3 +43,82 @@ def untar_file(tardata, filename):
         result = f.read()
         f.close()
     return result
+
+
+def exec_driver_is_native():
+    global EXEC_DRIVER
+    if not EXEC_DRIVER:
+        c = docker_client()
+        EXEC_DRIVER = c.info()['ExecutionDriver']
+        c.close()
+    return EXEC_DRIVER.startswith('native')
+
+
+def docker_client(**kwargs):
+    return docker.Client(**docker_client_kwargs(**kwargs))
+
+
+def docker_client_kwargs(**kwargs):
+    client_kwargs = docker.utils.kwargs_from_env(assert_hostname=False)
+    client_kwargs.update(kwargs)
+    return client_kwargs
+
+
+class BaseTestCase(unittest.TestCase):
+    tmp_imgs = []
+    tmp_containers = []
+    tmp_folders = []
+    tmp_volumes = []
+
+    def setUp(self):
+        if six.PY2:
+            self.assertRegex = self.assertRegexpMatches
+            self.assertCountEqual = self.assertItemsEqual
+        self.client = docker_client(timeout=60)
+        self.tmp_imgs = []
+        self.tmp_containers = []
+        self.tmp_folders = []
+        self.tmp_volumes = []
+        self.tmp_networks = []
+
+    def tearDown(self):
+        for img in self.tmp_imgs:
+            try:
+                self.client.remove_image(img)
+            except docker.errors.APIError:
+                pass
+        for container in self.tmp_containers:
+            try:
+                self.client.stop(container, timeout=1)
+                self.client.remove_container(container)
+            except docker.errors.APIError:
+                pass
+        for network in self.tmp_networks:
+            try:
+                self.client.remove_network(network)
+            except docker.errors.APIError:
+                pass
+        for folder in self.tmp_folders:
+            shutil.rmtree(folder)
+
+        for volume in self.tmp_volumes:
+            try:
+                self.client.remove_volume(volume)
+            except docker.errors.APIError:
+                pass
+
+        self.client.close()
+
+    def run_container(self, *args, **kwargs):
+        container = self.client.create_container(*args, **kwargs)
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        exitcode = self.client.wait(container)
+
+        if exitcode != 0:
+            output = self.client.logs(container)
+            raise Exception(
+                "Container exited with code {}:\n{}"
+                .format(exitcode, output))
+
+        return container

--- a/tests/integration/build_test.py
+++ b/tests/integration/build_test.py
@@ -6,11 +6,11 @@ import tempfile
 
 import six
 
-from . import api_test
+from .. import helpers
 from ..base import requires_api_version
 
 
-class BuildTest(api_test.BaseTestCase):
+class BuildTest(helpers.BaseTestCase):
     def test_build_streaming(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+
+import json
+import sys
+import warnings
+
+import docker.errors
+import pytest
+
+from ..helpers import BUSYBOX
+from ..helpers import docker_client
+
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_test_session():
+    warnings.simplefilter('error')
+    c = docker_client()
+    try:
+        c.inspect_image(BUSYBOX)
+    except docker.errors.NotFound:
+        print("\npulling {0}".format(BUSYBOX), file=sys.stderr)
+        for data in c.pull(BUSYBOX, stream=True):
+            data = json.loads(data.decode('utf-8'))
+            status = data.get("status")
+            progress = data.get("progress")
+            detail = "{0} - {1}".format(status, progress)
+            print(detail, file=sys.stderr)
+
+        # Double make sure we now have busybox
+        c.inspect_image(BUSYBOX)
+    c.close()

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -1041,7 +1041,7 @@ class PauseTest(helpers.BaseTestCase):
         self.assertEqual(state['Paused'], False)
 
 
-class GetContainerStatsTest(api_test.BaseTestCase):
+class GetContainerStatsTest(helpers.BaseTestCase):
     @requires_api_version('1.19')
     def test_get_container_stats_no_stream(self):
         container = self.client.create_container(

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -9,14 +9,13 @@ import docker
 import pytest
 import six
 
-from . import api_test
 from ..base import requires_api_version
 from .. import helpers
 
-BUSYBOX = api_test.BUSYBOX
+BUSYBOX = helpers.BUSYBOX
 
 
-class ListContainersTest(api_test.BaseTestCase):
+class ListContainersTest(helpers.BaseTestCase):
     def test_list_containers(self):
         res0 = self.client.containers(all=True)
         size = len(res0)
@@ -36,7 +35,7 @@ class ListContainersTest(api_test.BaseTestCase):
         self.assertIn('Status', retrieved)
 
 
-class CreateContainerTest(api_test.BaseTestCase):
+class CreateContainerTest(helpers.BaseTestCase):
 
     def test_create(self):
         res = self.client.create_container(BUSYBOX, 'true')
@@ -161,7 +160,7 @@ class CreateContainerTest(api_test.BaseTestCase):
         self.assertCountEqual(info['HostConfig']['VolumesFrom'], vol_names)
 
     def create_container_readonly_fs(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         ctnr = self.client.create_container(
@@ -368,7 +367,7 @@ class CreateContainerTest(api_test.BaseTestCase):
         self.assertIn('MemorySwappiness', host_config)
 
 
-class VolumeBindTest(api_test.BaseTestCase):
+class VolumeBindTest(helpers.BaseTestCase):
     def setUp(self):
         super(VolumeBindTest, self).setUp()
 
@@ -458,7 +457,7 @@ class VolumeBindTest(api_test.BaseTestCase):
 
 
 @requires_api_version('1.20')
-class ArchiveTest(api_test.BaseTestCase):
+class ArchiveTest(helpers.BaseTestCase):
     def test_get_file_archive_from_container(self):
         data = 'The Maid and the Pocket Watch of Blood'
         ctnr = self.client.create_container(
@@ -538,7 +537,7 @@ class ArchiveTest(api_test.BaseTestCase):
         self.assertIn('bar/', results)
 
 
-class RenameContainerTest(api_test.BaseTestCase):
+class RenameContainerTest(helpers.BaseTestCase):
     def test_rename_container(self):
         version = self.client.version()['Version']
         name = 'hong_meiling'
@@ -554,7 +553,7 @@ class RenameContainerTest(api_test.BaseTestCase):
             self.assertEqual('/{0}'.format(name), inspect['Name'])
 
 
-class StartContainerTest(api_test.BaseTestCase):
+class StartContainerTest(helpers.BaseTestCase):
     def test_start_container(self):
         res = self.client.create_container(BUSYBOX, 'true')
         self.assertIn('Id', res)
@@ -608,7 +607,7 @@ class StartContainerTest(api_test.BaseTestCase):
             self.assertEqual(exitcode, 0, msg=cmd)
 
 
-class WaitTest(api_test.BaseTestCase):
+class WaitTest(helpers.BaseTestCase):
     def test_wait(self):
         res = self.client.create_container(BUSYBOX, ['sleep', '3'])
         id = res['Id']
@@ -636,7 +635,7 @@ class WaitTest(api_test.BaseTestCase):
         self.assertEqual(inspect['State']['ExitCode'], exitcode)
 
 
-class LogsTest(api_test.BaseTestCase):
+class LogsTest(helpers.BaseTestCase):
     def test_logs(self):
         snippet = 'Flowering Nights (Sakuya Iyazoi)'
         container = self.client.create_container(
@@ -708,7 +707,7 @@ Line2'''
         self.assertEqual(logs, ''.encode(encoding='ascii'))
 
 
-class DiffTest(api_test.BaseTestCase):
+class DiffTest(helpers.BaseTestCase):
     def test_diff(self):
         container = self.client.create_container(BUSYBOX, ['touch', '/test'])
         id = container['Id']
@@ -736,7 +735,7 @@ class DiffTest(api_test.BaseTestCase):
         self.assertEqual(test_diff[0]['Kind'], 1)
 
 
-class StopTest(api_test.BaseTestCase):
+class StopTest(helpers.BaseTestCase):
     def test_stop(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -747,7 +746,7 @@ class StopTest(api_test.BaseTestCase):
         self.assertIn('State', container_info)
         state = container_info['State']
         self.assertIn('ExitCode', state)
-        if api_test.exec_driver_is_native():
+        if helpers.exec_driver_is_native():
             self.assertNotEqual(state['ExitCode'], 0)
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False)
@@ -763,13 +762,13 @@ class StopTest(api_test.BaseTestCase):
         self.assertIn('State', container_info)
         state = container_info['State']
         self.assertIn('ExitCode', state)
-        if api_test.exec_driver_is_native():
+        if helpers.exec_driver_is_native():
             self.assertNotEqual(state['ExitCode'], 0)
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False)
 
 
-class KillTest(api_test.BaseTestCase):
+class KillTest(helpers.BaseTestCase):
     def test_kill(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -780,7 +779,7 @@ class KillTest(api_test.BaseTestCase):
         self.assertIn('State', container_info)
         state = container_info['State']
         self.assertIn('ExitCode', state)
-        if api_test.exec_driver_is_native():
+        if helpers.exec_driver_is_native():
             self.assertNotEqual(state['ExitCode'], 0)
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False)
@@ -795,7 +794,7 @@ class KillTest(api_test.BaseTestCase):
         self.assertIn('State', container_info)
         state = container_info['State']
         self.assertIn('ExitCode', state)
-        if api_test.exec_driver_is_native():
+        if helpers.exec_driver_is_native():
             self.assertNotEqual(state['ExitCode'], 0)
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False)
@@ -817,7 +816,7 @@ class KillTest(api_test.BaseTestCase):
         self.assertEqual(state['Running'], False, state)
 
 
-class PortTest(api_test.BaseTestCase):
+class PortTest(helpers.BaseTestCase):
     def test_port(self):
 
         port_bindings = {
@@ -848,7 +847,7 @@ class PortTest(api_test.BaseTestCase):
         self.client.kill(id)
 
 
-class ContainerTopTest(api_test.BaseTestCase):
+class ContainerTopTest(helpers.BaseTestCase):
     def test_top(self):
         container = self.client.create_container(
             BUSYBOX, ['sleep', '60'])
@@ -883,7 +882,7 @@ class ContainerTopTest(api_test.BaseTestCase):
         self.client.kill(id)
 
 
-class RestartContainerTest(api_test.BaseTestCase):
+class RestartContainerTest(helpers.BaseTestCase):
     def test_restart(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -924,7 +923,7 @@ class RestartContainerTest(api_test.BaseTestCase):
         self.client.kill(id)
 
 
-class RemoveContainerTest(api_test.BaseTestCase):
+class RemoveContainerTest(helpers.BaseTestCase):
     def test_remove(self):
         container = self.client.create_container(BUSYBOX, ['true'])
         id = container['Id']
@@ -946,7 +945,7 @@ class RemoveContainerTest(api_test.BaseTestCase):
         self.assertEqual(len(res), 0)
 
 
-class AttachContainerTest(api_test.BaseTestCase):
+class AttachContainerTest(helpers.BaseTestCase):
     def test_run_container_streaming(self):
         container = self.client.create_container(BUSYBOX, '/bin/sh',
                                                  detach=True, stdin_open=True)
@@ -1013,7 +1012,7 @@ class AttachContainerTest(api_test.BaseTestCase):
             del pty_stdout._response
 
 
-class PauseTest(api_test.BaseTestCase):
+class PauseTest(helpers.BaseTestCase):
     def test_pause_unpause(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']

--- a/tests/integration/exec_test.py
+++ b/tests/integration/exec_test.py
@@ -1,13 +1,13 @@
 import pytest
 
-from . import api_test
+from .. import helpers
 
-BUSYBOX = api_test.BUSYBOX
+BUSYBOX = helpers.BUSYBOX
 
 
-class ExecTest(api_test.BaseTestCase):
+class ExecTest(helpers.BaseTestCase):
     def test_execute_command(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         container = self.client.create_container(BUSYBOX, 'cat',
@@ -23,7 +23,7 @@ class ExecTest(api_test.BaseTestCase):
         self.assertEqual(exec_log, b'hello\n')
 
     def test_exec_command_string(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         container = self.client.create_container(BUSYBOX, 'cat',
@@ -39,7 +39,7 @@ class ExecTest(api_test.BaseTestCase):
         self.assertEqual(exec_log, b'hello world\n')
 
     def test_exec_command_as_user(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         container = self.client.create_container(BUSYBOX, 'cat',
@@ -55,7 +55,7 @@ class ExecTest(api_test.BaseTestCase):
         self.assertEqual(exec_log, b'default\n')
 
     def test_exec_command_as_root(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         container = self.client.create_container(BUSYBOX, 'cat',
@@ -71,7 +71,7 @@ class ExecTest(api_test.BaseTestCase):
         self.assertEqual(exec_log, b'root\n')
 
     def test_exec_command_streaming(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         container = self.client.create_container(BUSYBOX, 'cat',
@@ -89,7 +89,7 @@ class ExecTest(api_test.BaseTestCase):
         self.assertEqual(res, b'hello\nworld\n')
 
     def test_exec_inspect(self):
-        if not api_test.exec_driver_is_native():
+        if not helpers.exec_driver_is_native():
             pytest.skip('Exec driver not native')
 
         container = self.client.create_container(BUSYBOX, 'cat',

--- a/tests/integration/image_test.py
+++ b/tests/integration/image_test.py
@@ -14,12 +14,12 @@ from six.moves import socketserver
 
 import docker
 
-from . import api_test
+from .. import helpers
 
-BUSYBOX = api_test.BUSYBOX
+BUSYBOX = helpers.BUSYBOX
 
 
-class ListImagesTest(api_test.BaseTestCase):
+class ListImagesTest(helpers.BaseTestCase):
     def test_images(self):
         res1 = self.client.images(all=True)
         self.assertIn('Id', res1[0])
@@ -37,7 +37,7 @@ class ListImagesTest(api_test.BaseTestCase):
         self.assertEqual(type(res1[0]), six.text_type)
 
 
-class PullImageTest(api_test.BaseTestCase):
+class PullImageTest(helpers.BaseTestCase):
     def test_pull(self):
         try:
             self.client.remove_image('hello-world')
@@ -70,7 +70,7 @@ class PullImageTest(api_test.BaseTestCase):
         self.assertIn('Id', img_info)
 
 
-class CommitTest(api_test.BaseTestCase):
+class CommitTest(helpers.BaseTestCase):
     def test_commit(self):
         container = self.client.create_container(BUSYBOX, ['touch', '/test'])
         id = container['Id']
@@ -91,7 +91,7 @@ class CommitTest(api_test.BaseTestCase):
         self.assertEqual(img['Parent'], busybox_id)
 
 
-class RemoveImageTest(api_test.BaseTestCase):
+class RemoveImageTest(helpers.BaseTestCase):
     def test_remove(self):
         container = self.client.create_container(BUSYBOX, ['touch', '/test'])
         id = container['Id']
@@ -107,7 +107,7 @@ class RemoveImageTest(api_test.BaseTestCase):
         self.assertEqual(len(res), 0)
 
 
-class ImportImageTest(api_test.BaseTestCase):
+class ImportImageTest(helpers.BaseTestCase):
     '''Base class for `docker import` test cases.'''
 
     TAR_SIZE = 512 * 1024

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -3,12 +3,12 @@ import random
 import docker
 import pytest
 
-from . import api_test
+from .. import helpers
 from ..base import requires_api_version
 
 
 @requires_api_version('1.21')
-class TestNetworks(api_test.BaseTestCase):
+class TestNetworks(helpers.BaseTestCase):
     def create_network(self, *args, **kwargs):
         net_name = u'dockerpy{}'.format(random.getrandbits(24))[:14]
         net_id = self.client.create_network(net_name, *args, **kwargs)['Id']

--- a/tests/integration/regression_test.py
+++ b/tests/integration/regression_test.py
@@ -4,12 +4,12 @@ import random
 import docker
 import six
 
-from . import api_test
+from .. import helpers
 
-BUSYBOX = api_test.BUSYBOX
+BUSYBOX = helpers.BUSYBOX
 
 
-class TestRegressions(api_test.BaseTestCase):
+class TestRegressions(helpers.BaseTestCase):
     def test_443_handle_nonchunked_response_in_stream(self):
         dfile = io.BytesIO()
         with self.assertRaises(docker.errors.APIError) as exc:

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -1,12 +1,12 @@
 import docker
 import pytest
 
-from . import api_test
+from .. import helpers
 from ..base import requires_api_version
 
 
 @requires_api_version('1.21')
-class TestVolumes(api_test.BaseTestCase):
+class TestVolumes(helpers.BaseTestCase):
     def test_create_volume(self):
         name = 'perfectcherryblossom'
         self.tmp_volumes.append(name)


### PR DESCRIPTION
Ensure setup_module is called in each file, making the test suite
not order dependent.

Fixes #852 