### PR TITLE
fix typo filter param for `volumes`

### DIFF
--- a/docker/api/volume.py
+++ b/docker/api/volume.py
@@ -5,7 +5,7 @@ class VolumeApiMixin(object):
     @utils.minimum_version('1.21')
     def volumes(self, filters=None):
         params = {
-            'filter': utils.convert_filters(filters) if filters else None
+            'filters': utils.convert_filters(filters) if filters else None
         }
         url = self._url('/volumes')
         return self._result(self._get(url, params=params), True)

--- a/tests/unit/volume_test.py
+++ b/tests/unit/volume_test.py
@@ -18,6 +18,18 @@ class VolumeTest(DockerClientTest):
         self.assertEqual(args[0][1], url_prefix + 'volumes')
 
     @base.requires_api_version('1.21')
+    def test_list_volumes_and_filters(self):
+        volumes = self.client.volumes(filters={'dangling': True})
+        assert 'Volumes' in volumes
+        assert len(volumes['Volumes']) == 2
+        args = fake_request.call_args
+
+        assert args[0][0] == 'GET'
+        assert args[0][1] == url_prefix + 'volumes'
+        assert args[1] == {'params': {'filters': '{"dangling": ["true"]}'},
+                           'timeout': 60}
+
+    @base.requires_api_version('1.21')
     def test_create_volume(self):
         name = 'perfectcherryblossom'
         result = self.client.create_volume(name)


### PR DESCRIPTION
https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#list-volumes

Signed-off-by: Nicolas Delaby <nicolas.delaby@lock8.me>