### PR TITLE
Allow providing options when creating networks

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -19,10 +19,14 @@ class NetworkApiMixin(object):
         return self._result(res, json=True)
 
     @minimum_version('1.21')
-    def create_network(self, name, driver=None):
+    def create_network(self, name, driver=None, options=None):
+        if options is not None and not isinstance(options, dict):
+            raise TypeError('options must be a dictionary')
+
         data = {
             'name': name,
             'driver': driver,
+            'options': options
         }
         url = self._url("/networks/create")
         res = self._post_json(url, data=data)

--- a/docker/api/volume.py
+++ b/docker/api/volume.py
@@ -33,4 +33,3 @@ class VolumeApiMixin(object):
         url = self._url('/volumes/{0}', name)
         resp = self._delete(url)
         self._raise_for_status(resp)
-        return True

--- a/docs/api.md
+++ b/docs/api.md
@@ -780,8 +780,7 @@ Remove a volume. Similar to the `docker volume rm` command.
 
 * name (str): The volume's name
 
-**Returns** (bool): True on successful removal. Failure will raise a
-`docker.errors.APIError` exception.
+Failure to remove will raise a `docker.errors.APIError` exception.
 
 ## rename
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,6 +163,15 @@ non-running ones
   'Status': 'Up 1 seconds'}]
 ```
 
+## connect_container_to_network
+
+Connect a container to a network.
+
+**Params**:
+
+* container (str): container-id/name to be connected to the network
+* net_id (str): network id
+
 ## copy
 Identical to the `docker cp` command. Get files/folders from the container.
 **Deprecated for API version >= 1.20** &ndash; Consider using
@@ -259,6 +268,19 @@ The utility can be used as follows:
 You can now use this with 'environment' for `create_container`.
 
 
+## create_network
+
+Create a network, similar to the `docker network create` command.
+
+**Params**:
+
+* name (str): Name of the network
+* driver (str): Name of the driver used to create the network
+
+* options (dict): Driver options as a key-value dictionary
+
+**Returns** (dict): The created network reference object
+
 ## create_volume
 
 Create and register a named volume
@@ -290,6 +312,13 @@ Inspect changes on a container's filesystem.
 * container (str): The container to diff
 
 **Returns** (str):
+
+## disconnect_container_from_network
+
+**Params**:
+
+* container (str): container-id/name to be disconnected from a network
+* net_id (str): network id
 
 ## events
 
@@ -574,6 +603,16 @@ Identical to the `docker inspect` command, but only for images.
 **Returns** (dict): Nearly the same output as `docker inspect`, just as a
 single dict
 
+## inspect_network
+
+Retrieve network info by id.
+
+**Params**:
+
+* net_id (str): network id
+
+**Returns** (dict): Network information dictionary
+
 ## inspect_volume
 
 Retrieve volume info by name.
@@ -639,6 +678,19 @@ output as it happens.
 * tail (str or int): Output specified number of lines at the end of logs: `"all"` or `number`. Default `"all"`
 
 **Returns** (generator or str):
+
+## networks
+
+List networks currently registered by the docker daemon. Similar to the `docker networks ls` command.
+
+**Params**
+
+* names (list): List of names to filter by
+* ids (list): List of ids to filter by
+
+The above are combined to create a filters dict.
+
+**Returns** (dict): List of network objects.
 
 ## pause
 
@@ -771,6 +823,16 @@ Remove an image. Similar to the `docker rmi` command.
 * image (str): The image to remove
 * force (bool): Force removal of the image
 * noprune (bool): Do not delete untagged parents
+
+## remove_network
+
+Remove a network. Similar to the `docker network rm` command.
+
+**Params**:
+
+* net_id (str): The network's id
+
+Failure to remove will raise a `docker.errors.APIError` exception.
 
 ## remove_volume
 

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -47,8 +47,7 @@ class TestVolumes(helpers.BaseTestCase):
         name = 'shootthebullet'
         self.tmp_volumes.append(name)
         self.client.create_volume(name)
-        result = self.client.remove_volume(name)
-        self.assertTrue(result)
+        self.client.remove_volume(name)
 
     def test_remove_nonexistent_volume(self):
         name = 'shootthebullet'

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -70,11 +70,15 @@ class NetworkTest(DockerClientTest):
                 json.loads(post.call_args[1]['data']),
                 {"name": "foo"})
 
-            self.client.create_network('foo', 'bridge')
+            opts = {
+                'com.docker.network.bridge.enable_icc': False,
+                'com.docker.network.bridge.enable_ip_masquerade': False,
+            }
+            self.client.create_network('foo', 'bridge', opts)
 
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
-                {"name": "foo", "driver": "bridge"})
+                {"name": "foo", "driver": "bridge", "options": opts})
 
     @base.requires_api_version('1.21')
     def test_remove_network(self):

--- a/tests/unit/volume_test.py
+++ b/tests/unit/volume_test.py
@@ -89,8 +89,7 @@ class VolumeTest(DockerClientTest):
     @base.requires_api_version('1.21')
     def test_remove_volume(self):
         name = 'perfectcherryblossom'
-        result = self.client.remove_volume(name)
-        self.assertTrue(result)
+        self.client.remove_volume(name)
         args = fake_request.call_args
 
         self.assertEqual(args[0][0], 'DELETE')


### PR DESCRIPTION
Following the spec:

    http://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-network

I have added an options argument to create_network.

This opens up the possibility of creating isolated containers with no internet access programmatically. We require such facilities in https://github.com/jupyter/tmpnb/issues/187.