### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,52 @@
-Joffrey F <joffrey@docker.com> (@shin-)
-Maxime Petazzoni <maxime.petazzoni@bulix.org> (@mpetazzoni)
-Aanand Prasad <aanand@docker.com> (@aanand)
-Daniel Nephin <dnephin@gmail.com> (@dnephin)
-Mazz Mosley <mazz@houseofmnowster.com> (@mnowster)
+# Docker-py maintainers file
+#
+# This file describes who runs the docker/docker-py project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"aanand",
+			"dnephin",
+			"mnowster",
+			"mpetazzoni",
+			"shin-",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.aanand]
+	Name = "Aanand Prasad"
+	Email = "aanand@docker.com"
+	GitHub = "aanand"
+
+	[people.dnephin]
+	Name = "Daniel Nephin"
+	Email = "dnephin@gmail.com"
+	GitHub = "dnephin"
+
+	[people.mnowster]
+	Name = "Mazz Mosley"
+	Email = "mazz@houseofmnowster.com"
+	GitHub = "mnowster"
+
+	[people.mpetazzoni]
+	Name = "Maxime Petazzoni"
+	Email = "maxime.petazzoni@bulix.org"
+	GitHub = "mpetazzoni"
+
+	[people.shin-]
+	Name = "Joffrey F"
+	Email = "joffrey@docker.com"
+	GitHub = "shin-"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321