### PR TITLE
Handle 64-bit integer values in parse_bytes

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -486,6 +486,12 @@ def datetime_to_timestamp(dt):
     return delta.seconds + delta.days * 24 * 3600
 
 
+def longint(n):
+    if six.PY3:
+        return int(n)
+    return long(n)
+
+
 def parse_bytes(s):
     if len(s) == 0:
         s = 0
@@ -506,20 +512,21 @@ def parse_bytes(s):
 
         if suffix in units.keys() or suffix.isdigit():
             try:
-                digits = int(digits_part)
+                digits = longint(digits_part)
             except ValueError:
-                message = ('Failed converting the string value for'
-                           'memory ({0}) to a number.')
-                formatted_message = message.format(digits_part)
-                raise errors.DockerException(formatted_message)
+                raise errors.DockerException(
+                    'Failed converting the string value for memory ({0}) to'
+                    ' an integer.'.format(digits_part)
+                )
 
-            s = digits * units[suffix]
+            # Reconvert to long for the final result
+            s = longint(digits * units[suffix])
         else:
-            message = ('The specified value for memory'
-                       ' ({0}) should specify the units. The postfix'
-                       ' should be one of the `b` `k` `m` `g`'
-                       ' characters')
-            raise errors.DockerException(message.format(s))
+            raise errors.DockerException(
+                'The specified value for memory ({0}) should specify the'
+                ' units. The postfix should be one of the `b` `k` `m` `g`'
+                ' characters'.format(s)
+            )
 
     return s
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -5,6 +5,7 @@ import json
 import os
 import os.path
 import shutil
+import sys
 import tarfile
 import tempfile
 
@@ -465,14 +466,28 @@ class ParseDeviceTest(base.BaseTestCase):
         })
 
 
-class UtilsTest(base.BaseTestCase):
-    longMessage = True
+class ParseBytesTest(base.BaseTestCase):
+    def test_parse_bytes_valid(self):
+        self.assertEqual(parse_bytes("512MB"), 536870912)
+        self.assertEqual(parse_bytes("512M"), 536870912)
+        self.assertEqual(parse_bytes("512m"), 536870912)
 
-    def test_parse_bytes(self):
-        self.assertEqual(parse_bytes("512MB"), (536870912))
-        self.assertEqual(parse_bytes("512M"), (536870912))
+    def test_parse_bytes_invalid(self):
         self.assertRaises(DockerException, parse_bytes, "512MK")
         self.assertRaises(DockerException, parse_bytes, "512L")
+        self.assertRaises(DockerException, parse_bytes, "127.0.0.1K")
+
+    def test_parse_bytes_float(self):
+        self.assertRaises(DockerException, parse_bytes, "1.5k")
+
+    def test_parse_bytes_maxint(self):
+        self.assertEqual(
+            parse_bytes("{0}k".format(sys.maxsize)), sys.maxsize * 1024
+        )
+
+
+class UtilsTest(base.BaseTestCase):
+    longMessage = True
 
     def test_convert_filters(self):
         tests = [


### PR DESCRIPTION
Also ensure we are able to handle 64-bit integers in py2

Fixes #813 