### PR TITLE
Implement support for network-scoped aliases

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from .. import errors
 from .. import utils
+from ..utils.utils import create_networking_config, create_endpoint_config
 
 
 class ContainerApiMixin(object):
@@ -98,7 +99,7 @@ class ContainerApiMixin(object):
                          cpu_shares=None, working_dir=None, domainname=None,
                          memswap_limit=None, cpuset=None, host_config=None,
                          mac_address=None, labels=None, volume_driver=None,
-                         stop_signal=None):
+                         stop_signal=None, networking_config=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -113,7 +114,7 @@ class ContainerApiMixin(object):
             tty, mem_limit, ports, environment, dns, volumes, volumes_from,
             network_disabled, entrypoint, cpu_shares, working_dir, domainname,
             memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver, stop_signal
+            volume_driver, stop_signal, networking_config,
         )
         return self.create_container_from_config(config, name)
 
@@ -138,6 +139,12 @@ class ContainerApiMixin(object):
             )
         kwargs['version'] = self._version
         return utils.create_host_config(*args, **kwargs)
+
+    def create_networking_config(self, *args, **kwargs):
+        return create_networking_config(*args, **kwargs)
+
+    def create_endpoint_config(self, *args, **kwargs):
+        return create_endpoint_config(self._version, *args, **kwargs)
 
     @utils.check_resource
     def diff(self, container):

--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -47,8 +47,13 @@ class NetworkApiMixin(object):
 
     @check_resource
     @minimum_version('1.21')
-    def connect_container_to_network(self, container, net_id):
-        data = {"container": container}
+    def connect_container_to_network(self, container, net_id, aliases=None):
+        data = {
+            "Container": container,
+            "EndpointConfig": {
+                "Aliases": aliases,
+            },
+        }
         url = self._url("/networks/{0}/connect", net_id)
         self._post_json(url, data=data)
 

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -4,7 +4,7 @@ from .utils import (
     kwargs_from_env, convert_filters, datetime_to_timestamp, create_host_config,
     create_container_config, parse_bytes, ping_registry, parse_env_file,
     version_lt, version_gte, decode_json_header, split_command,
-    create_ipam_config, create_ipam_pool
+    create_ipam_config, create_ipam_pool,
 ) # flake8: noqa
 
 from .types import Ulimit, LogConfig # flake8: noqa

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -715,6 +715,26 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
     return host_config
 
 
+def create_networking_config(endpoints_config=None):
+    networking_config = {}
+
+    if endpoints_config:
+        networking_config["EndpointsConfig"] = endpoints_config
+
+    return networking_config
+
+
+def create_endpoint_config(version, aliases=None):
+    endpoint_config = {}
+
+    if aliases:
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('endpoint_config.aliases', '1.22')
+        endpoint_config["Aliases"] = aliases
+
+    return endpoint_config
+
+
 def parse_env_file(env_file):
     """
     Reads a line-separated environment file.
@@ -752,7 +772,7 @@ def create_container_config(
     dns=None, volumes=None, volumes_from=None, network_disabled=False,
     entrypoint=None, cpu_shares=None, working_dir=None, domainname=None,
     memswap_limit=None, cpuset=None, host_config=None, mac_address=None,
-    labels=None, volume_driver=None, stop_signal=None
+    labels=None, volume_driver=None, stop_signal=None, networking_config=None,
 ):
     if isinstance(command, six.string_types):
         command = split_command(command)
@@ -878,6 +898,7 @@ def create_container_config(
         'WorkingDir': working_dir,
         'MemorySwap': memswap_limit,
         'HostConfig': host_config,
+        'NetworkingConfig': networking_config,
         'MacAddress': mac_address,
         'Labels': labels,
         'VolumeDriver': volume_driver,

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -147,7 +147,10 @@ class NetworkTest(DockerClientTest):
 
         with mock.patch('docker.Client.post', post):
             self.client.connect_container_to_network(
-                {'Id': container_id}, network_id)
+                {'Id': container_id},
+                network_id,
+                aliases=['foo', 'bar'],
+            )
 
         self.assertEqual(
             post.call_args[0][0],
@@ -155,7 +158,12 @@ class NetworkTest(DockerClientTest):
 
         self.assertEqual(
             json.loads(post.call_args[1]['data']),
-            {'container': container_id})
+            {
+                'Container': container_id,
+                'EndpointConfig': {
+                    'Aliases': ['foo', 'bar'],
+                },
+            })
 
     @base.requires_api_version('1.21')
     def test_disconnect_container_from_network(self):

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -18,8 +18,9 @@ from docker.utils import (
     parse_repository_tag, parse_host, convert_filters, kwargs_from_env,
     create_host_config, Ulimit, LogConfig, parse_bytes, parse_env_file,
     exclude_paths, convert_volume_binds, decode_json_header, tar,
-    split_command, create_ipam_config, create_ipam_pool
+    split_command, create_ipam_config, create_ipam_pool,
 )
+from docker.utils.utils import create_endpoint_config
 from docker.utils.ports import build_port_bindings, split_port
 
 from .. import base
@@ -68,6 +69,13 @@ class HostConfigTest(base.BaseTestCase):
         self.assertRaises(
             InvalidVersion, lambda: create_host_config(version='1.18.3',
                                                        oom_kill_disable=True))
+
+    def test_create_endpoint_config_with_aliases(self):
+        config = create_endpoint_config(version='1.22', aliases=['foo', 'bar'])
+        assert config == {'Aliases': ['foo', 'bar']}
+
+        with pytest.raises(InvalidVersion):
+            create_endpoint_config(version='1.21', aliases=['foo', 'bar'])
 
 
 class UlimitTest(base.BaseTestCase):


### PR DESCRIPTION
Missing docs, but network docs are already lacking. Will fill them out in a follow-up PR.