### PR TITLE
Normalise/fix networking API JSON keys

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -24,10 +24,10 @@ class NetworkApiMixin(object):
             raise TypeError('options must be a dictionary')
 
         data = {
-            'name': name,
-            'driver': driver,
-            'options': options,
-            'ipam': ipam,
+            'Name': name,
+            'Driver': driver,
+            'Options': options,
+            'IPAM': ipam,
         }
         url = self._url("/networks/create")
         res = self._post_json(url, data=data)

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -47,17 +47,17 @@ BYTE_UNITS = {
 def create_ipam_pool(subnet=None, iprange=None, gateway=None,
                      aux_addresses=None):
     return {
-        'subnet': subnet,
-        'iprange': iprange,
-        'gateway': gateway,
-        'auxaddresses': aux_addresses
+        'Subnet': subnet,
+        'IPRange': iprange,
+        'Gateway': gateway,
+        'AuxiliaryAddresses': aux_addresses
     }
 
 
 def create_ipam_config(driver='default', pool_configs=None):
     return {
-        'driver': driver,
-        'config': pool_configs or []
+        'Driver': driver,
+        'Config': pool_configs or []
     }
 
 

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -69,7 +69,7 @@ class NetworkTest(DockerClientTest):
 
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
-                {"name": "foo"})
+                {"Name": "foo"})
 
             opts = {
                 'com.docker.network.bridge.enable_icc': False,
@@ -79,7 +79,7 @@ class NetworkTest(DockerClientTest):
 
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
-                {"name": "foo", "driver": "bridge", "options": opts})
+                {"Name": "foo", "Driver": "bridge", "Options": opts})
 
             ipam_pool_config = create_ipam_pool(subnet="192.168.52.0/24",
                                                 gateway="192.168.52.254")
@@ -91,15 +91,15 @@ class NetworkTest(DockerClientTest):
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
                 {
-                    "name": "bar",
-                    "driver": "bridge",
-                    "ipam": {
-                        "driver": "default",
-                        "config": [{
-                            "iprange": None,
-                            "gateway": "192.168.52.254",
-                            "subnet": "192.168.52.0/24",
-                            "auxaddresses": None
+                    "Name": "bar",
+                    "Driver": "bridge",
+                    "IPAM": {
+                        "Driver": "default",
+                        "Config": [{
+                            "IPRange": None,
+                            "Gateway": "192.168.52.254",
+                            "Subnet": "192.168.52.0/24",
+                            "AuxiliaryAddresses": None,
                         }]
                     }
                 })

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -442,12 +442,12 @@ class UtilsTest(base.BaseTestCase):
 
         ipam_config = create_ipam_config(pool_configs=[ipam_pool])
         self.assertEqual(ipam_config, {
-            'driver': 'default',
-            'config': [{
-                'subnet': '192.168.52.0/24',
-                'gateway': '192.168.52.254',
-                'auxaddresses': None,
-                'iprange': None
+            'Driver': 'default',
+            'Config': [{
+                'Subnet': '192.168.52.0/24',
+                'Gateway': '192.168.52.254',
+                'AuxiliaryAddresses': None,
+                'IPRange': None,
             }]
         })
 


### PR DESCRIPTION
- Use CamelCase
- `auxaddresses` -> `AuxiliaryAddresses`
