### PR TITLE
Drop support for python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 env:
     - TOX_ENV=py26
     - TOX_ENV=py27
-    - TOX_ENV=py32
     - TOX_ENV=py33
     - TOX_ENV=py34
     - TOX_ENV=flake8

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Topic :: Utilities',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, flake8
+envlist = py26, py27, py33, py34, flake8
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
Following in pip's tracks, dropping support for python 3.2: https://pip.pypa.io/en/stable/news/#release-notes