### PR TITLE
remove tempfile.mkdtemp in VolumeBindTest for non-auto-creating non-e…

### DIFF
--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -379,8 +379,7 @@ class VolumeBindTest(helpers.BaseTestCase):
         self.mount_dest = '/mnt'
 
         # Get a random pathname - we don't need it to exist locally
-        self.mount_origin = tempfile.mkdtemp()
-        shutil.rmtree(self.mount_origin)
+        self.mount_origin = '/tmp'
         self.filename = 'shared.txt'
 
         self.run_with_volume(


### PR DESCRIPTION
remove tempfile.mkdtemp(change to '/tmp') in VolumeBindTest,if docker don't create the host path automatically,we must keep the host path exist.
https://github.com/docker/docker/pull/19537 for detail

Signed-off-by: yangshukui <yangshukui@huawei.com>