### PR TITLE
Re-enable stdout/stderr capturing in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --tb=short -rxs -s
+addopts = --tb=short -rxs


### PR DESCRIPTION
It was disabled in https://github.com/docker/docker-py/commit/7f3692ceeda92ca3690394822cbd3c99378c0d7e, probably for debugging purposes.