### PR TITLE
create tempfile in VolumeBindTest for non-auto-creating of docker

### DIFF
--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -381,6 +381,7 @@ class VolumeBindTest(helpers.BaseTestCase):
         # Get a random pathname - we don't need it to exist locally
         self.mount_origin = tempfile.mkdtemp()
         shutil.rmtree(self.mount_origin)
+        os.mkdir(self.mount_origin)
         self.filename = 'shared.txt'
 
         self.run_with_volume(


### PR DESCRIPTION
create tempfile in VolumeBindTestin ,if docker don't create the host path automatically,we must keep the host path exist.
https://github.com/docker/docker/pull/19953 for detail.

Signed-off-by: yangshukui <yangshukui@huawei.com>