### PR TITLE
Add support for shm_size.

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -556,7 +556,8 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
                        security_opt=None, ulimits=None, log_config=None,
                        mem_limit=None, memswap_limit=None, mem_swappiness=None,
                        cgroup_parent=None, group_add=None, cpu_quota=None,
-                       cpu_period=None, oom_kill_disable=False, version=None):
+                       cpu_period=None, oom_kill_disable=False, shm_size=None,
+                       version=None):
 
     host_config = {}
 
@@ -588,6 +589,12 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
             )
 
         host_config['MemorySwappiness'] = mem_swappiness
+
+    if shm_size is not None:
+        if isinstance(shm_size, six.string_types):
+            shm_size = parse_bytes(shm_size)
+
+        host_config['ShmSize'] = shm_size
 
     if pid_mode not in (None, 'host'):
         raise host_config_value_error('pid_mode', pid_mode)

--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -103,6 +103,7 @@ for example:
   allowed to consume.
 * mem_swappiness (int): Tune a container's memory swappiness behavior.
   Accepts number between 0 and 100.
+* shm_size (str or int): Size of /dev/shm. (e.g. `'1G'`)
 * cpu_group (int): The length of a CPU period in microseconds.
 * cpu_period (int): Microseconds of CPU time that the container can get in a
   CPU period.

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -64,6 +64,14 @@ class HostConfigTest(base.BaseTestCase):
         config = create_host_config(version='1.20', cpu_period=1999)
         self.assertEqual(config.get('CpuPeriod'), 1999)
 
+    def test_create_host_config_with_shm_size(self):
+        config = create_host_config(version='1.22', shm_size=67108864)
+        self.assertEqual(config.get('ShmSize'), 67108864)
+
+    def test_create_host_config_with_shm_size_in_mb(self):
+        config = create_host_config(version='1.22', shm_size='64M')
+        self.assertEqual(config.get('ShmSize'), 67108864)
+
     def test_create_host_config_with_oom_kill_disable(self):
         config = create_host_config(version='1.20', oom_kill_disable=True)
         self.assertEqual(config.get('OomKillDisable'), True)


### PR DESCRIPTION
--shm-size was added to Docker in 1.10 via docker/docker#16168.  See docker/compose#2823 for more details.

Signed-off-by: Spencer Rinehart <anubis@overthemonkey.com>