### PR TITLE
Use gzip to compress tar balls before sending.

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -46,7 +46,8 @@ class BuildApiMixin(object):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(bool, f.read().splitlines()))
-            context = utils.tar(path, exclude=exclude, dockerfile=dockerfile, gzip=True)
+            context = utils.tar(path, exclude=exclude, dockerfile=dockerfile,
+                gzip=True)
             encoding = 'gizp'
 
         if utils.compare_version('1.8', self._version) >= 0:

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -46,7 +46,8 @@ class BuildApiMixin(object):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(bool, f.read().splitlines()))
-            context = utils.tar(path, exclude=exclude, dockerfile=dockerfile)
+            context = utils.tar(path, exclude=exclude, dockerfile=dockerfile, gzip=True)
+            encoding = 'gizp'
 
         if utils.compare_version('1.8', self._version) >= 0:
             stream = True

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -91,10 +91,10 @@ def decode_json_header(header):
     return json.loads(data)
 
 
-def tar(path, exclude=None, dockerfile=None, fileobj=None):
+def tar(path, exclude=None, dockerfile=None, fileobj=None, gzip=False):
     if not fileobj:
         fileobj = tempfile.NamedTemporaryFile()
-    t = tarfile.open(mode='w', fileobj=fileobj)
+    t = tarfile.open(mode='w:gz' if gzip else 'w', fileobj=fileobj)
 
     root = os.path.abspath(path)
     exclude = exclude or []


### PR DESCRIPTION
Seems like a straightforward improvement to gzip our tarballs before sending them. For me, it greatly improved performance (reduced my own docker image from 120MB to 40MB).

Signed-off-by: Michael Sander <michael.sander@docketalarm.com
