### PR TITLE
Add a Progress Printer for Uploading

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -89,9 +89,7 @@ class BuildApiMixin(object):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(bool, f.read().splitlines()))
-            context = utils.tar(path, exclude=exclude, dockerfile=dockerfile, 
-                gzip=True)
-            encoding = 'gzip'
+            context = utils.tar(path, exclude=exclude, dockerfile=dockerfile)
 
         if utils.compare_version('1.8', self._version) >= 0:
             stream = True

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -46,7 +46,11 @@ class FileUploadBuffer(object):
         if not len(out):
             raise StopIteration
         return out
-        
+    
+    def __next__(self):
+        # For python 3
+        return self.next()
+    
     def read(self, *args, **kwargs):
         return self.chk_print(fn = lambda: self.file.read(*args, **kwargs))
         
@@ -84,7 +88,7 @@ class BuildApiMixin(object):
         else:
             dockerignore = os.path.join(path, '.dockerignore')
             # If there are a lot of files, this takes time. Tell the user.
-            log.debug('taring and gzipping files: %s'%path)
+            log.debug("taring files: %s" % path)
             exclude = None
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:


### PR DESCRIPTION
Uploading a docker file takes time. Adding a progress dialog reduces stress for everyone. Also, this commit adds a small 32k buffer for the upload. Previously, it was not really buffered, and we performing many thousands of unnecessary file reads, adding a significant overhead.

Signed-off-by: Michael Sander michael.sander@docketalarm.com
