### PR TITLE
Implements #935 - Insert IPv4 and IPv6 call in /networks/id/connect

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -1,6 +1,8 @@
 import json
 
+from ..errors import InvalidVersion
 from ..utils import check_resource, minimum_version, normalize_links
+from ..utils import version_lt
 
 
 class NetworkApiMixin(object):
@@ -48,6 +50,7 @@ class NetworkApiMixin(object):
     @check_resource
     @minimum_version('1.21')
     def connect_container_to_network(self, container, net_id,
+                                     ipv4_address=None, ipv6_address=None,
                                      aliases=None, links=None):
         data = {
             "Container": container,
@@ -56,6 +59,21 @@ class NetworkApiMixin(object):
                 "Links": normalize_links(links) if links else None,
             },
         }
+
+        # IPv4 or IPv6 or neither:
+        if ipv4_address or ipv6_address:
+            if version_lt(self._version, '1.22'):
+                raise InvalidVersion('IP address assignment is not '
+                                     'supported in API version < 1.22')
+
+            data['EndpointConfig']['IPAMConfig'] = dict()
+            if ipv4_address:
+                data['EndpointConfig']['IPAMConfig']['IPv4Address'] = \
+                    ipv4_address
+            if ipv6_address:
+                data['EndpointConfig']['IPAMConfig']['IPv6Address'] = \
+                    ipv6_address
+
         url = self._url("/networks/{0}/connect", net_id)
         res = self._post_json(url, data=data)
         self._raise_for_status(res)

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -235,3 +235,51 @@ class TestNetworks(helpers.BaseTestCase):
         )
 
         self.execute(container, ['nslookup', 'bar'])
+
+    @requires_api_version('1.22')
+    def test_connect_with_ipv4_address(self):
+        net_name, net_id = self.create_network()
+
+        container = self.create_and_start(
+            host_config=self.client.create_host_config(network_mode=net_name))
+
+        self.client.disconnect_container_from_network(container, net_name)
+        self.client.connect_container_to_network(
+            container, net_name,
+            ipv4_address='192.168.0.1')
+
+        container_data = self.client.inspect_container(container)
+        self.assertEqual(
+            container_data['NetworkSettings']['Networks'][net_name]
+                          ['IPAMConfig']['IPv4Address'],
+            '192.168.0.1')
+
+        self.create_and_start(
+            name='docker-py-test-upstream',
+            host_config=self.client.create_host_config(network_mode=net_name))
+
+        self.execute(container, ['nslookup', 'bar'])
+
+    @requires_api_version('1.22')
+    def test_connect_with_ipv6_address(self):
+        net_name, net_id = self.create_network()
+
+        container = self.create_and_start(
+            host_config=self.client.create_host_config(network_mode=net_name))
+
+        self.client.disconnect_container_from_network(container, net_name)
+        self.client.connect_container_to_network(
+            container, net_name,
+            ipv6_address='2001:389::1')
+
+        container_data = self.client.inspect_container(container)
+        self.assertEqual(
+            container_data['NetworkSettings']['Networks'][net_name]
+                          ['IPAMConfig']['IPv6Address'],
+            '2001:389::1')
+
+        self.create_and_start(
+            name='docker-py-test-upstream',
+            host_config=self.client.create_host_config(network_mode=net_name))
+
+        self.execute(container, ['nslookup', 'bar'])


### PR DESCRIPTION
Requires API 1.22

Unit tests passed, had some trouble running integration tests:
E   APIError: 400 Client Error: Bad Request ("client is newer than server (client API version: 1.22, server API version: 1.21)")

Docker version:
Client:
 Version:      1.11.0-dev
 API version:  1.23
 Go version:   go1.5.3
 Git commit:   415dd86
 Built:        Sun Feb  7 21:47:30 2016
 OS/Arch:      linux/amd64

Server:
 Version:      1.11.0-dev
 API version:  1.23
 Go version:   go1.5.3
 Git commit:   415dd86
 Built:        Sun Feb  7 21:47:30 2016
 OS/Arch:      linux/amd64
