### PR TITLE
Synthesize executable bit on Windows

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -18,6 +18,7 @@ import os
 import os.path
 import json
 import shlex
+import sys
 import tarfile
 import tempfile
 import warnings
@@ -100,7 +101,10 @@ def tar(path, exclude=None, dockerfile=None, fileobj=None):
     exclude = exclude or []
 
     for path in sorted(exclude_paths(root, exclude, dockerfile=dockerfile)):
-        t.add(os.path.join(root, path), arcname=path, recursive=False)
+        i = t.gettarinfo(os.path.join(root, path), arcname=path)
+        if sys.platform == 'win32':
+            i.mode = i.mode & 0o755 | 0o111
+        t.addfile(i)
 
     t.close()
     fileobj.seek(0)


### PR DESCRIPTION
Be consistent with `docker build`, which marks the files in the context tarball as executable. See also https://github.com/docker/docker/issues/11047.

Fixes #937.

This should work, but probably needs some massaging and tests before it can be merged.
