### PR TITLE
Add support for changes param to ContainerApiMixin.commit

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -40,13 +40,14 @@ class ContainerApiMixin(object):
 
     @utils.check_resource
     def commit(self, container, repository=None, tag=None, message=None,
-               author=None, conf=None):
+               author=None, changes=None, conf=None):
         params = {
             'container': container,
             'repo': repository,
             'tag': tag,
             'comment': message,
-            'author': author
+            'author': author,
+            'changes': changes
         }
         u = self._url("/commit")
         return self._result(self._post_json(u, data=conf, params=params),

--- a/docs/api.md
+++ b/docs/api.md
@@ -123,6 +123,7 @@ Identical to the `docker commit` command.
 * tag (str): The tag to push
 * message (str): A commit message
 * author (str): The name of the author
+* changes (str): Dockerfile instructions to apply while committing
 * conf (dict): The configuration for the container. See the [Docker remote api](
 https://docs.docker.com/reference/api/docker_remote_api/) for full details.
 

--- a/tests/unit/image_test.py
+++ b/tests/unit/image_test.py
@@ -101,7 +101,8 @@ class ImageTest(DockerClientTest):
                 'comment': None,
                 'tag': None,
                 'container': '3cc2351ab11b',
-                'author': None
+                'author': None,
+                'changes': None
             },
             timeout=DEFAULT_TIMEOUT_SECONDS
         )


### PR DESCRIPTION
docker commit --changes was added to Docker in 1.6.0.

Signed-off-by: Dima Spivak <dima@spivak.ch>