### PR TITLE
Pass stdin data on attach

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -10,15 +10,19 @@ from ..utils.utils import create_networking_config, create_endpoint_config
 class ContainerApiMixin(object):
     @utils.check_resource
     def attach(self, container, stdout=True, stderr=True,
-               stream=False, logs=False):
+               stdin=None, stream=False, logs=False):
         params = {
             'logs': logs and 1 or 0,
+            'stdin': stdin is not None and 1 or 0,
             'stdout': stdout and 1 or 0,
             'stderr': stderr and 1 or 0,
             'stream': stream and 1 or 0,
         }
         u = self._url("/containers/{0}/attach", container)
         response = self._post(u, params=params, stream=stream)
+
+        if stream and stdin is not None:
+            self._send_stdin(response, stdin)
 
         return self._get_result(container, stream, response)
 

--- a/docker/client.py
+++ b/docker/client.py
@@ -292,6 +292,19 @@ class Client(
         if hasattr(socket, "_sock") and hasattr(socket._sock, "settimeout"):
             socket._sock.settimeout(None)
 
+    def _send_stdin(self, response, stdin):
+        s = self._get_raw_response_socket(response)
+        self._disable_socket_timeout(s)
+
+        if six.PY3:
+            if type(stdin) == str:
+                stdin = stdin.encode("utf-8")
+
+        if six.PY3 and not self.base_url.startswith("https://"):
+            s._sock.sendall(stdin)
+        else:
+            s.sendall(stdin)
+
     def _get_result(self, container, stream, res):
         cont = self.inspect_container(container)
         return self._get_result_tty(stream, res, cont['Config']['Tty'])

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@ the entire backlog.
 * container (str): The container to attach to
 * stdout (bool): Get STDOUT
 * stderr (bool): Get STDERR
+* stdin (str or bytes): STDIN input
 * stream (bool): Return an iterator
 * logs (bool): Get all previous output
 

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -972,6 +972,51 @@ class AttachContainerTest(helpers.BaseTestCase):
         data = helpers.read_data(pty_stdout, next_size)
         self.assertEqual(data.decode('utf-8'), line)
 
+    def test_run_container_stdin_tty(self):
+        line = 'hi there and stuff and things, words!'
+        command = "cat -"
+        container = self.client.create_container(BUSYBOX, command,
+                                                 stdin_open=True, tty=True)
+        ident = container['Id']
+        self.tmp_containers.append(ident)
+
+        self.client.start(ident)
+
+        data = self.client.attach(ident, stdin=line, logs=True, stream=True)
+
+        output = "".join([next(data).decode("utf-8") for _ in
+                          range(len(line))])
+
+        self.assertEqual(output, line)
+
+    def test_run_container_stdin_string(self):
+        line = 'hi there and stuff and things, words!'
+        command = "cat -"
+        container = self.client.create_container(BUSYBOX, command,
+                                                 stdin_open=True, tty=False)
+        ident = container['Id']
+        self.tmp_containers.append(ident)
+
+        self.client.start(ident)
+
+        data = self.client.attach(ident, stdin=line, logs=True, stream=True)
+        output = next(data).decode("utf-8")
+        self.assertEqual(output, line)
+
+    def test_run_container_stdin_bytes(self):
+        line = b'hi there and stuff and things, words!'
+        command = "cat -"
+        container = self.client.create_container(BUSYBOX, command,
+                                                 stdin_open=True, tty=False)
+        ident = container['Id']
+        self.tmp_containers.append(ident)
+
+        self.client.start(ident)
+
+        data = self.client.attach(ident, stdin=line, logs=True, stream=True)
+        output = next(data)
+        self.assertEqual(output, line)
+
 
 class PauseTest(helpers.BaseTestCase):
     def test_pause_unpause(self):

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -1407,3 +1407,74 @@ class ContainerTest(DockerClientTest):
             params={'ps_args': 'waux'},
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
+
+    def test_attach(self):
+        with mock.patch('docker.Client.inspect_container',
+                        fake_inspect_container):
+            out = self.client.attach(fake_api.FAKE_CONTAINER_ID)
+
+        fake_request.assert_called_with(
+            'POST',
+            url_prefix + 'containers/3cc2351ab11b/attach',
+            params={'logs': 0, 'stdin': 0, 'stderr': 1, 'stdout': 1,
+                    'stream': 0},
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            stream=False
+        )
+
+        self.assertEqual(
+            out,
+            'Flowering Nights\n(Sakuya Iyazoi)\n'.encode('ascii')
+        )
+
+    def test_attach_with_dict_instead_of_id(self):
+        with mock.patch('docker.Client.inspect_container',
+                        fake_inspect_container):
+            out = self.client.attach({'Id': fake_api.FAKE_CONTAINER_ID})
+
+        fake_request.assert_called_with(
+            'POST',
+            url_prefix + 'containers/3cc2351ab11b/attach',
+            params={'logs': 0, 'stdin': 0, 'stderr': 1, 'stdout': 1,
+                    'stream': 0},
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            stream=False
+        )
+
+        self.assertEqual(
+            out,
+            'Flowering Nights\n(Sakuya Iyazoi)\n'.encode('ascii')
+        )
+
+    def test_attach_streaming(self):
+        with mock.patch('docker.Client.inspect_container',
+                        fake_inspect_container):
+            self.client.attach(fake_api.FAKE_CONTAINER_ID, stream=True)
+
+        fake_request.assert_called_with(
+            'POST',
+            url_prefix + 'containers/3cc2351ab11b/attach',
+            params={'logs': 0, 'stdin': 0, 'stderr': 1, 'stdout': 1,
+                    'stream': 1},
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            stream=True
+        )
+
+    def test_attach_stdin(self):
+        with mock.patch('docker.Client.inspect_container',
+                        fake_inspect_container):
+            out = self.client.attach(fake_api.FAKE_CONTAINER_ID, stdin="input")
+
+        fake_request.assert_called_with(
+            'POST',
+            url_prefix + 'containers/3cc2351ab11b/attach',
+            params={'logs': 0, 'stdin': 1, 'stderr': 1, 'stdout': 1,
+                    'stream': 0},
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            stream=False
+        )
+
+        self.assertEqual(
+            out,
+            'Flowering Nights\n(Sakuya Iyazoi)\n'.encode('ascii')
+        )

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -231,6 +231,13 @@ def get_fake_logs():
     return status_code, response
 
 
+def post_fake_attach():
+    status_code = 200
+    response = (b'\x01\x00\x00\x00\x00\x00\x00\x11Flowering Nights\n'
+                b'\x01\x00\x00\x00\x00\x00\x00\x10(Sakuya Iyazoi)\n')
+    return status_code, response
+
+
 def get_fake_diff():
     status_code = 200
     response = [{'Path': '/test', 'Kind': 1}]
@@ -474,6 +481,8 @@ fake_responses = {
     get_fake_wait,
     '{1}/{0}/containers/3cc2351ab11b/logs'.format(CURRENT_VERSION, prefix):
     get_fake_logs,
+    '{1}/{0}/containers/3cc2351ab11b/attach'.format(CURRENT_VERSION, prefix):
+    post_fake_attach,
     '{1}/{0}/containers/3cc2351ab11b/changes'.format(CURRENT_VERSION, prefix):
     get_fake_diff,
     '{1}/{0}/containers/3cc2351ab11b/export'.format(CURRENT_VERSION, prefix):


### PR DESCRIPTION
Currently, there is no simple way of passing in `stdin` content into an attached container. The implementation provided by #239 did not work for me. This PR adds an additional parameter where one can pass in string or byte data to be written into the `stdin` of an attached container. 

In addition, this PR also contains: 
- Simple documentation for `stdin`
- Integration tests for `stdin`
- Unit tests for `attach`
