### PR TITLE
Fix TLS regressions

### DIFF
--- a/docker/tls.py
+++ b/docker/tls.py
@@ -54,10 +54,15 @@ class TLSConfig(object):
 
     def configure_client(self, client):
         client.ssl_version = self.ssl_version
-        client.verify = self.verify
-        client.ca_cert = self.ca_cert
+
+        if self.verify and self.ca_cert:
+            client.verify = self.ca_cert
+        else:
+            client.verify = self.verify
+
         if self.cert:
             client.cert = self.cert
+
         client.mount('https://', ssladapter.SSLAdapter(
             ssl_version=self.ssl_version,
             assert_hostname=self.assert_hostname,

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -489,7 +489,7 @@ def kwargs_from_env(ssl_version=None, assert_hostname=None):
         verify=tls_verify,
         ssl_version=ssl_version,
         assert_hostname=assert_hostname,
-        assert_fingerprint=tls_verify)
+    )
 
     return params
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -194,7 +194,7 @@ class KwargsFromEnvTest(base.BaseTestCase):
         try:
             client = Client(**kwargs)
             self.assertEqual(kwargs['base_url'], client.base_url)
-            self.assertEqual(kwargs['tls'].verify, client.verify)
+            self.assertEqual(kwargs['tls'].ca_cert, client.verify)
             self.assertEqual(kwargs['tls'].cert, client.cert)
         except TypeError as e:
             self.fail(e)
@@ -213,7 +213,6 @@ class KwargsFromEnvTest(base.BaseTestCase):
         try:
             client = Client(**kwargs)
             self.assertEqual(kwargs['base_url'], client.base_url)
-            self.assertEqual(kwargs['tls'].ca_cert, client.ca_cert)
             self.assertEqual(kwargs['tls'].cert, client.cert)
             self.assertFalse(kwargs['tls'].verify)
         except TypeError as e:
@@ -238,7 +237,6 @@ class KwargsFromEnvTest(base.BaseTestCase):
         try:
             client = Client(**kwargs)
             self.assertEqual(kwargs['base_url'], client.base_url)
-            self.assertEqual(kwargs['tls'].ca_cert, client.ca_cert)
             self.assertEqual(kwargs['tls'].cert, client.cert)
             self.assertFalse(kwargs['tls'].verify)
         except TypeError as e:


### PR DESCRIPTION
- Set `verify` to the CA cert path if one has been specified, rather than `True`
- Don't set `assert_fingerprint`
