### PR TITLE
Add missing CheckDuplicate parameter to /networks/create API call

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -21,7 +21,8 @@ class NetworkApiMixin(object):
         return self._result(res, json=True)
 
     @minimum_version('1.21')
-    def create_network(self, name, driver=None, options=None, ipam=None):
+    def create_network(self, name, driver=None, options=None, ipam=None,
+                       check_duplicate=None):
         if options is not None and not isinstance(options, dict):
             raise TypeError('options must be a dictionary')
 
@@ -30,6 +31,7 @@ class NetworkApiMixin(object):
             'Driver': driver,
             'Options': options,
             'IPAM': ipam,
+            'CheckDuplicate': check_duplicate
         }
         url = self._url("/networks/create")
         res = self._post_json(url, data=data)


### PR DESCRIPTION
When set to True, this prevents creating more than one network with the same name (see https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-network)

Signed-off-by: Gabriel Féron <feron.gabriel@gmail.com>