### PR TITLE
Use decode on push and pull operations.

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -148,7 +148,7 @@ class ImageApiMixin(object):
         self._raise_for_status(res)
 
     def pull(self, repository, tag=None, stream=False,
-             insecure_registry=False, auth_config=None):
+             insecure_registry=False, auth_config=None, decode=False):
         if insecure_registry:
             warnings.warn(
                 INSECURE_REGISTRY_DEPRECATION_WARNING.format('pull()'),
@@ -200,12 +200,12 @@ class ImageApiMixin(object):
         self._raise_for_status(response)
 
         if stream:
-            return self._stream_helper(response)
+            return self._stream_helper(response, decode=decode)
 
         return self._result(response)
 
     def push(self, repository, tag=None, stream=False,
-             insecure_registry=False):
+             insecure_registry=False, decode=False):
         if insecure_registry:
             warnings.warn(
                 INSECURE_REGISTRY_DEPRECATION_WARNING.format('push()'),
@@ -241,7 +241,7 @@ class ImageApiMixin(object):
         self._raise_for_status(response)
 
         if stream:
-            return self._stream_helper(response)
+            return self._stream_helper(response, decode=decode)
 
         return self._result(response)
 


### PR DESCRIPTION
Stream helper has the ability to decode the responses from strings to
JSON. This commit enables this functionality on push and pull operations.