### PR TITLE
UnixHTTPConnectionPool initialization error

### DIFF
--- a/docker/unixconn/unixconn.py
+++ b/docker/unixconn/unixconn.py
@@ -30,7 +30,8 @@ RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
 class UnixHTTPConnection(httplib.HTTPConnection, object):
     def __init__(self, base_url, unix_socket, timeout=60):
-        httplib.HTTPConnection.__init__(self, 'localhost', timeout=timeout)
+        super(UnixHTTPConnection, self).__init__(
+                'localhost', timeout=timeout)
         self.base_url = base_url
         self.unix_socket = unix_socket
         self.timeout = timeout
@@ -44,9 +45,8 @@ class UnixHTTPConnection(httplib.HTTPConnection, object):
 
 class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
     def __init__(self, base_url, socket_path, timeout=60):
-        urllib3.connectionpool.HTTPConnectionPool.__init__(
-            self, 'localhost', timeout=timeout
-        )
+        super(UnixHTTPConnectionPool, self).__init__(
+                'localhost', timeout=timeout)
         self.base_url = base_url
         self.socket_path = socket_path
         self.timeout = timeout


### PR DESCRIPTION
**Issue**

Hello, I work a lot with  [SaltStack](http://saltstack.com/)'s module ```dockerio``` that uses ```docker-py``` for the connection with Docker UNIX socket. Every Salt Minion lives in docker container with latest build ```Ubuntu 16.04``` and the most recent released versions of  ```SaltStack``` and ```docker-py```.  I rebuild the image approximately one time a month.

After last update (for a detailed version report see below) I found that interaction between ```docker-py``` and ```requests``` was violated, so SaltStack wasn't able to pull new images from Registry:

```yml
----------
          ID: restapi_image
    Function: docker.pulled
        Name: test-4.m.search.ro/mailpaas/restapi-validators
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1624, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1491, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/dockerio.py", line 410, in pulled
                  returned = pull(name, tag=tag, insecure_registry=insecure_registry)
                File "/usr/lib/python2.7/dist-packages/salt/modules/dockerio.py", line 1670, in pull
                  client = _get_client()
                File "/usr/lib/python2.7/dist-packages/salt/modules/dockerio.py", line 289, in _get_client
                  client._version = client.version()['ApiVersion']
                File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 1121, in version
                  return self._result(self._get(url), json=True)
                File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 106, in _get
                  return self.get(url, **self._set_request_timeout(kwargs))
                File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 480, in get
                  return self.request('GET', url, **kwargs)
                File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 468, in request
                  resp = self.send(prep, **send_kwargs)
                File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 576, in send
                  r = adapter.send(request, **kwargs)
                File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 343, in send
                  conn = self.get_connection(request.url, proxies)
                File "/usr/local/lib/python2.7/dist-packages/docker/unixconn/unixconn.py", line 79, in get_connection
                  self.timeout)
                File "/usr/local/lib/python2.7/dist-packages/docker/unixconn/unixconn.py", line 48, in __init__
                  self, 'localhost', timeout=timeout
              TypeError: unbound method __init__() must be called with HTTPConnectionPool instance as first argument (got UnixHTTPConnectionPool instance instead)
     Started: 12:50:03.030710
    Duration: 3.857 ms
     Changes:   
----------
          ID: restapi
    Function: docker.running
      Result: False
     Comment: One or more requisite failed: mailpaas.restapi.restapi_image
     Started: 
    Duration: 
     Changes:   
```

The proposed PR fixes this problem with a replacement of the explicit call of ```urllib3.connectionpool.HTTPConnectionPool.__init__``` with just a```super()``` invocation. I guess that the ```UnixHTTPConnection``` should be fixed in the same way as well. Also I would be gratefull if someone could explain why wasn't the ```super()``` used from the very beginning.

**Versions**
```
root@t-3:~# dpkg -l | grep 'docker'  
ii  lxc-docker-1.6.0              1.6.0                           amd64        Linux container runtime

root@t-3:~# dpkg -l | grep 'requests'
ii  python-requests               2.9.1-3                         all          elegant and simple HTTP library for Python2, built for human beings
ii  python3-requests              2.9.1-3                         all          elegant and simple HTTP library for Python3, built for human beings

root@t-3:~# pip freeze | grep docker
docker-py==1.7.2

root@t-3:~# salt-call --versions-report
Salt Version:
           Salt: 2015.8.7
 
Dependency Versions:
         Jinja2: 2.8
       M2Crypto: Not Installed
           Mako: Not Installed
         PyYAML: 3.11
          PyZMQ: 15.1.0
         Python: 2.7.11+ (default, Feb 22 2016, 16:38:42)
           RAET: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.5
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: 2.4.2
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libgit2: Not Installed
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed
 
System Versions:
           dist: Ubuntu 16.04 xenial
        machine: x86_64
        release: 4.0.4-1.el6.elrepo.x86_64
         system: Ubuntu 16.04 xenial
```