### PR TITLE
Add support for tmpfs

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -99,7 +99,7 @@ class ContainerApiMixin(object):
                          cpu_shares=None, working_dir=None, domainname=None,
                          memswap_limit=None, cpuset=None, host_config=None,
                          mac_address=None, labels=None, volume_driver=None,
-                         stop_signal=None, networking_config=None):
+                         stop_signal=None, networking_config=None, tmpfs=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -114,7 +114,7 @@ class ContainerApiMixin(object):
             tty, mem_limit, ports, environment, dns, volumes, volumes_from,
             network_disabled, entrypoint, cpu_shares, working_dir, domainname,
             memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver, stop_signal, networking_config,
+            volume_driver, stop_signal, networking_config, tmpfs
         )
         return self.create_container_from_config(config, name)
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -832,6 +832,7 @@ def create_container_config(
     entrypoint=None, cpu_shares=None, working_dir=None, domainname=None,
     memswap_limit=None, cpuset=None, host_config=None, mac_address=None,
     labels=None, volume_driver=None, stop_signal=None, networking_config=None,
+    tmpfs=None
 ):
     if isinstance(command, six.string_types):
         command = split_command(command)
@@ -850,6 +851,11 @@ def create_container_config(
     if stop_signal is not None and compare_version('1.21', version) < 0:
         raise errors.InvalidVersion(
             'stop_signal was only introduced in API version 1.21'
+        )
+
+    if tmpfs is not None and compare_version('1.22', version) < 0:
+        raise errors.InvalidVersion(
+            'tmpfs was only introduced in API version 1.22'
         )
 
     if compare_version('1.19', version) < 0:
@@ -899,6 +905,15 @@ def create_container_config(
         for vol in volumes:
             volumes_dict[vol] = {}
         volumes = volumes_dict
+
+    if isinstance(tmpfs, six.string_types):
+        tmpfs = [tmpfs, ]
+
+    if isinstance(tmpfs, list):
+        tmpfs_dict = {}
+        for tmpdir in tmpfs:
+            tmpfs_dict[tmpdir] = ''
+        tmpfs = tmpfs_dict
 
     if volumes_from:
         if not isinstance(volumes_from, six.string_types):
@@ -958,5 +973,6 @@ def create_container_config(
         'MacAddress': mac_address,
         'Labels': labels,
         'VolumeDriver': volume_driver,
-        'StopSignal': stop_signal
+        'StopSignal': stop_signal,
+        'Tmpfs': tmpfs
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -222,6 +222,7 @@ following format `["PASSWORD=xxx"]` or `{"PASSWORD": "xxx"}`.
 * volumes (str or list):
 * volumes_from (str or list): List of container names or Ids to get volumes
 from. Optionally a single string joining container id's with commas
+* tmpfs (str or list): Paths to mount tmpfs filesystems
 * network_disabled (bool): Disable networking
 * name (str): A name for the container
 * entrypoint (str or list): An entrypoint

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -225,6 +225,28 @@ class CreateContainerTest(DockerClientTest):
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 
+    @requires_api_version('1.22')
+    def test_create_container_with_tmpfs(self):
+        tmpfs_dest = '/tmpdir'
+
+        self.client.create_container('busybox', ['ls', tmpfs_dest],
+                                     tmpfs=tmpfs_dest)
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][1],
+                         url_prefix + 'containers/create')
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls", "/tmpdir"], "AttachStdin": false,
+                             "Tmpfs": {"/tmpdir": ""},
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
     def test_create_container_with_ports(self):
         self.client.create_container('busybox', 'ls',
                                      ports=[1111, (2222, 'udp'), (3333,)])


### PR DESCRIPTION
The ability to create a tmpfs mountpoint was introduced in Docker 1.10
(API version 1.22). This commit adds a tmpfs argument to
create_container() to implement this functionality.

This is a first-time commit to this project so please be sure to point out anything that I could do to make it better.