### PR TITLE
Change default value of NetworkMode to 'bridge'

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -646,7 +646,7 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
     if network_mode:
         host_config['NetworkMode'] = network_mode
     elif network_mode is None and compare_version('1.19', version) > 0:
-        host_config['NetworkMode'] = 'default'
+        host_config['NetworkMode'] = 'bridge'
 
     if restart_policy:
         if not isinstance(restart_policy, dict):

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -49,7 +49,7 @@ class HostConfigTest(base.BaseTestCase):
 
     def test_create_host_config_no_options_newer_api_version(self):
         config = create_host_config(version='1.20')
-        self.assertEqual(config['NetworkMode'], 'default')
+        self.assertEqual(config['NetworkMode'], 'bridge')
 
     def test_create_host_config_invalid_cpu_cfs_types(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
This is a Fix for Docker API >= 1.19.

The default network is 'bridge' according to :

https://docs.docker.com/engine/userguide/networking/default_network/

and 'default' not listed as a valid option for the Remote API:

https://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/

Signed-off-by: Daniel Rice <drice304@gmail.com>