### PR TITLE
Client side validation of build tag

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -29,6 +29,9 @@ class BuildApiMixin(object):
                     'Invalid container_limits key {0}'.format(key)
                 )
 
+        if tag and re.search(r'[^a-z0-9_\-./]+', tag):
+            raise AttributeError('Tag should only contain a-z0-9-_. .')
+
         if custom_context:
             if not fileobj:
                 raise TypeError("You must specify fileobj with custom_context")

--- a/tests/unit/build_test.py
+++ b/tests/unit/build_test.py
@@ -1,5 +1,6 @@
 import gzip
 import io
+import pytest
 
 import docker
 
@@ -103,3 +104,41 @@ class BuildTest(DockerClientTest):
                 'foo': 'bar'
             })
         )
+
+    def test_build_container_with_tag(self):
+        script = io.BytesIO('\n'.join([
+            'FROM busybox',
+            'MAINTAINER docker-py',
+            'RUN mkdir -p /tmp/test',
+            'EXPOSE 8080',
+            'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
+            ' /tmp/silence.tar.gz'
+        ]).encode('ascii'))
+
+        self.client.build(fileobj=script, tag='complex_tag-1.0')
+
+    def test_build_container_with_invalid_tag1(self):
+        script = io.BytesIO('\n'.join([
+            'FROM busybox',
+            'MAINTAINER docker-py',
+            'RUN mkdir -p /tmp/test',
+            'EXPOSE 8080',
+            'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
+            ' /tmp/silence.tar.gz'
+        ]).encode('ascii'))
+
+        with pytest.raises(AttributeError):
+            self.client.build(fileobj=script, tag='compleX_tag-1.0')
+
+    def test_build_container_with_invalid_tag2(self):
+        script = io.BytesIO('\n'.join([
+            'FROM busybox',
+            'MAINTAINER docker-py',
+            'RUN mkdir -p /tmp/test',
+            'EXPOSE 8080',
+            'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
+            ' /tmp/silence.tar.gz'
+        ]).encode('ascii'))
+
+        with pytest.raises(AttributeError):
+            self.client.build(fileobj=script, tag='complex!_tag-1.0')


### PR DESCRIPTION
Improve reporting of invalid tag error reported in #978.
Of course that will be better to have the server reporting
the appropriate error itself.
As mentioned by @shin-, this is a temporary mitigation.