### PR TITLE
If TCP host is provided while TLS is enabled, convert to https

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -400,11 +400,12 @@ def parse_host(addr, platform=None, tls=False):
 
     if addr == 'tcp://':
         raise errors.DockerException(
-            "Invalid bind address format: {0}".format(addr))
+            "Invalid bind address format: {0}".format(addr)
+        )
     elif addr.startswith('unix://'):
         addr = addr[7:]
     elif addr.startswith('tcp://'):
-        proto = "http"
+        proto = 'http{0}'.format('s' if tls else '')
         addr = addr[6:]
     elif addr.startswith('https://'):
         proto = "https"

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -412,7 +412,12 @@ class ParseHostTest(base.BaseTestCase):
     def test_parse_host_tls(self):
         host_value = 'myhost.docker.net:3348'
         expected_result = 'https://myhost.docker.net:3348'
-        self.assertEqual(parse_host(host_value, None, True), expected_result)
+        assert parse_host(host_value, tls=True) == expected_result
+
+    def test_parse_host_tls_tcp_proto(self):
+        host_value = 'tcp://myhost.docker.net:3348'
+        expected_result = 'https://myhost.docker.net:3348'
+        assert parse_host(host_value, tls=True) == expected_result
 
 
 class ParseRepositoryTagTest(base.BaseTestCase):


### PR DESCRIPTION
Fixes the `tcp://` protocol issue mentioned in docker/compose#3139
