### PR TITLE
makes it possible to have '=' in the env file

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -834,7 +834,7 @@ def parse_env_file(env_file):
             if line[0] == '#':
                 continue
 
-            parse_line = line.strip().split('=')
+            parse_line = line.strip().split('=', 1)
             if len(parse_line) == 2:
                 k, v = parse_line
                 environment[k] = v

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -355,6 +355,14 @@ class ParseEnvFileTest(base.BaseTestCase):
                          {'USER': 'jdoe', 'PASS': 'secret'})
         os.unlink(env_file)
 
+    def test_parse_env_file_with_equals_character(self):
+        env_file = self.generate_tempfile(
+            file_content='USER=jdoe\nPASS=sec==ret')
+        get_parse_env_file = parse_env_file(env_file)
+        self.assertEqual(get_parse_env_file,
+                         {'USER': 'jdoe', 'PASS': 'sec==ret'})
+        os.unlink(env_file)
+
     def test_parse_env_file_commented_line(self):
         env_file = self.generate_tempfile(
             file_content='USER=jdoe\n#PASS=secret')


### PR DESCRIPTION
note: the docker command like --env-file also allows '=' in the env file