### PR TITLE
Specify default value of stop's timeout

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -962,7 +962,7 @@ Stops a container. Similar to the `docker stop` command.
 
 * container (str): The container to stop
 * timeout (int): Timeout in seconds to wait for the container to stop before
-sending a `SIGKILL`
+sending a `SIGKILL`. Default: 10
 
 ## tag
 


### PR DESCRIPTION
I was using docker-py for a project and I needed to know the default value of the timeout option for the stop function of the docker api (in docker-py/api/container.py). It wasn't specified in the documentation so I decided to add it myself because other like me might need it.

Signed-off-by: Tom Lebreux <tomlebreux@hotmail.com>

