### PR TITLE
Fix py2-ipaddress dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ requirements = [
     'websocket-client >= 0.32.0',
 ]
 
-if sys.version_info[0] == 2:
-    requirements.append('py2-ipaddress >= 3.4.1')
+extras_require = {
+    ':python_version < "3"': 'py2-ipaddress >= 3.4.1',
+}
 
 exec(open('docker/version.py').read())
 
@@ -32,6 +33,7 @@ setup(
     ],
     install_requires=requirements,
     tests_require=test_requirements,
+    extras_require=extras_require,
     zip_safe=False,
     test_suite='tests',
     classifiers=[


### PR DESCRIPTION
Rather than using a conditional to add the dependency to `install_requires` - which results in a hardcoded dependency in the resulting wheel, which will then fail to install on Python 3 - add it to `extras_require` with an environment marker.