### PR TITLE
Make ipaddress fully optional

### DIFF
--- a/docker/ssladapter/ssl_match_hostname.py
+++ b/docker/ssladapter/ssl_match_hostname.py
@@ -3,8 +3,12 @@
 # Changed to make code python 2.x compatible (unicode strings for ip_address
 # and 3.5-specific var assignment syntax)
 
-import ipaddress
 import re
+
+try:
+    import ipaddress as _ipaddress
+except ImportError:
+    _ipaddress = None
 
 try:
     from ssl import CertificateError
@@ -20,8 +24,10 @@ def _ipaddress_match(ipname, host_ip):
     RFC 6125 explicitly doesn't define an algorithm for this
     (section 1.7.2 - "Out of Scope").
     """
+    if not _ipaddress:
+        raise ImportError('ImportError: No module named ipaddress')
     # OpenSSL may add a trailing newline to a subjectAltName's IP address
-    ip = ipaddress.ip_address(six.text_type(ipname.rstrip()))
+    ip = _ipaddress.ip_address(six.text_type(ipname.rstrip()))
     return ip == host_ip
 
 
@@ -87,8 +93,10 @@ def match_hostname(cert, hostname):
         raise ValueError("empty or no certificate, match_hostname needs a "
                          "SSL socket or SSL context with either "
                          "CERT_OPTIONAL or CERT_REQUIRED")
+    if not _ipaddress:
+        raise ImportError('ImportError: No module named ipaddress')
     try:
-        host_ip = ipaddress.ip_address(six.text_type(hostname))
+        host_ip = _ipaddress.ip_address(six.text_type(hostname))
     except ValueError:
         # Not an IP address (common case)
         host_ip = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.5.3
 six>=1.4.0
 websocket-client==0.32.0
-py2-ipaddress==3.4.1 ; python_version < '3.2'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,5 @@ pytest==2.7.2
 coverage==3.7.1
 pytest-cov==2.1.0
 flake8==2.4.1
+py2-ipaddress==3.4.1 ; python_version < '3.2'
+setuptools>=20.0


### PR DESCRIPTION
* Fail only when ipaddress is actually used.
* Move the py2-ipaddress reference to test-requirements since we
  are already marking it as extras in setup.py

NOTE: there's at least a couple of implementations
- https://bitbucket.org/kwi/py2-ipaddress
- https://github.com/phihag/ipaddress
So, we should be okay if either one is present. Of course, we
would test and use py2-ipaddress as our preferred impl. So
we specify py2-ipaddress in our test-requirements.txt.