### PR TITLE
docker-py can't push to a TLS-enabled registry without doing `login` 

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -76,13 +76,16 @@ def resolve_authconfig(authconfig, registry=None):
         log.debug("Found {0}".format(repr(registry)))
         return authconfig[registry]
 
+    response = {}
     for key, config in six.iteritems(authconfig):
         if resolve_index_name(key) == registry:
             log.debug("Found {0}".format(repr(key)))
-            return config
+            response = config
+    if not response:
+        log.debug("No entries found, using empty entry")
+        response = {registry: {}}
 
-    log.debug("No entry found")
-    return None
+    return response
 
 
 def convert_to_hostname(url):


### PR DESCRIPTION
When pushing images to a TLS-enabled distribution without authentication, docker-py doesn't populate `X-Registry-Auth` while `docker` client does.

## Steps to reproduce

1. Prepare certificates according to https://github.com/docker/distribution/blob/master/docs/insecure.md#using-self-signed-certificates

2. run the registry:
  ```
  $ docker run -d -p 5000:5000 --restart=always --name registry \
    -v `pwd`/certs:/certs \
    -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
    -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
    registry:2.3.1
  ```

3. push the image
  ```
  In [1]: c = docker.AutoVersionClient()

  In [2]: c.push("myregistrydomain.com:5000/testuser/busybox")
  ---------------------------------------------------------------------------
  APIError                                  Traceback (most recent call last)
  <ipython-input-2-319d56d71c10> in <module>()
  ----> 1 c.push("myregistrydomain.com:5000/testuser/busybox")
          global c.push = <bound method AutoVersionClient.push of <docker.client.AutoVersionClient object at 0x7f1e17c786d0>>

  /home/tt/g/docker-py/docker/api/image.py in push(self=<docker.client.AutoVersionClient object>, repository='myregistrydomain.com:5000/testuser/busybox', tag='', stream=False, insecure_registry=False, decode=False)
      240         )
      241
  --> 242         self._raise_for_status(response)
          self._raise_for_status = <bound method AutoVersionClient._raise_for_status of <docker.client.AutoVersionClient object at 0x7f1e17c786d0>>
          response = <Response [400]>
      243
      244         if stream:

  /home/tt/g/docker-py/docker/client.py in _raise_for_status(self=<docker.client.AutoVersionClient object>, response=<Response [400]>, explanation=None)
      152             if e.response.status_code == 404:
      153                 raise errors.NotFound(e, response, explanation=explanation)
  --> 154             raise errors.APIError(e, response, explanation=explanation)
          global errors.APIError = <class 'docker.errors.APIError'>
          e = HTTPError('400 Client Error: Bad Request',)
          response = <Response [400]>
          explanation = None
      155
      156     def _result(self, response, json=False, binary=False):

  APIError: 400 Client Error: Bad Request ("Bad parameters and missing X-Registry-Auth: EOF")
  > /home/tt/g/docker-py/docker/client.py(154)_raise_for_status()
      153                 raise errors.NotFound(e, response, explanation=explanation)
  --> 154             raise errors.APIError(e, response, explanation=explanation)
      155
  ```


## Expected result

```
$ docker push myregistrydomain.com:5000/testuser/busybox
The push refers to a repository [myregistrydomain.com:5000/testuser/busybox]
5f70bf18a086: Layer already exists
2c84284818d1: Layer already exists
latest: digest: sha256:9176b113ee7620cb59f5df4c8afa86e990529e3ca328fe15cbc499eeb64bedfd size: 711
```


## More info

The reason why this fails is that `docker` client sends authconfig with empty credentials:

```
[pid 26196] write(5, "POST /v1.23/images/myregistrydomain.com:5000/testuser/busybox/push?tag= HTTP/1.1\r\nHost: \r\nUser-Agent: Docker-Client/1.11.0 (linux)\r\
nContent-Length: 0\r\nContent-Type: text/plain\r\nX-Registry-Auth: eyJteXJlZ2lzdHJ5ZG9tYWluLmNvbTo1MDAwIjp7fX0=\r\n\r\n", 242 <unfinished ...>

In [11]: base64.b64decode("eyJteXJlZ2lzdHJ5ZG9tYWluLmNvbTo1MDAwIjp7fX0=")
Out[11]: '{"myregistrydomain.com:5000":{}}'
```

while docker-py doesn't set `X-Registry-Auth` at all. Engine expects `X-Registry-Auth` of course: https://github.com/docker/docker/blob/348d90276802aac6c76126f2fe6866c521190ecd/api/server/router/image/image_routes.go#L156 
