### PR TITLE
Clean up duplicate network

### DIFF
--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -280,6 +280,7 @@ class TestNetworks(helpers.BaseTestCase):
         with self.assertRaises(docker.errors.APIError):
             self.client.create_network(net_name, check_duplicate=True)
         self.client.create_network(net_name, check_duplicate=False)
+        self.tmp_networks.append(net_name)
 
     @requires_api_version('1.22')
     def test_connect_with_links(self):


### PR DESCRIPTION
Fixes #1047.

It's not entirely satisfactory, as it relies on the cleanup working in a particular way.  However `client.create_network()` does not return the ID cleanly in the previous call (it returns something like `{"u'Warning': u'Network with name dockerpy845377 (id : 3d8a876ff38eaa6df14d37a40922046b1274fb685c5cf25abfe71c94531e1c41) already exists', u'Id': u'4cf5bbce6cb471730fbd962c5391392c3708dc4bfc3b720ec44c047c38e2f5ef'"}`)