### PR TITLE
Add support for DNS Search to create container

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -100,7 +100,8 @@ class ContainerApiMixin(object):
                          cpu_shares=None, working_dir=None, domainname=None,
                          memswap_limit=None, cpuset=None, host_config=None,
                          mac_address=None, labels=None, volume_driver=None,
-                         stop_signal=None, networking_config=None):
+                         stop_signal=None, networking_config=None,
+                         dns_search=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -112,10 +113,10 @@ class ContainerApiMixin(object):
 
         config = self.create_container_config(
             image, command, hostname, user, detach, stdin_open,
-            tty, mem_limit, ports, environment, dns, volumes, volumes_from,
-            network_disabled, entrypoint, cpu_shares, working_dir, domainname,
-            memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver, stop_signal, networking_config,
+            tty, mem_limit, ports, environment, dns, dns_search, volumes,
+            volumes_from, network_disabled, entrypoint, cpu_shares,
+            working_dir, domainname, memswap_limit, cpuset, host_config,
+            mac_address, labels, volume_driver, stop_signal, networking_config,
         )
         return self.create_container_from_config(config, name)
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -874,10 +874,11 @@ def format_environment(environment):
 def create_container_config(
     version, image, command, hostname=None, user=None, detach=False,
     stdin_open=False, tty=False, mem_limit=None, ports=None, environment=None,
-    dns=None, volumes=None, volumes_from=None, network_disabled=False,
-    entrypoint=None, cpu_shares=None, working_dir=None, domainname=None,
-    memswap_limit=None, cpuset=None, host_config=None, mac_address=None,
-    labels=None, volume_driver=None, stop_signal=None, networking_config=None,
+    dns=None, dns_search=None, volumes=None, volumes_from=None,
+    network_disabled=False, entrypoint=None, cpu_shares=None, working_dir=None,
+    domainname=None, memswap_limit=None, cpuset=None, host_config=None,
+    mac_address=None, labels=None, volume_driver=None, stop_signal=None,
+    networking_config=None,
 ):
     if isinstance(command, six.string_types):
         command = split_command(command)
@@ -989,6 +990,7 @@ def create_container_config(
         'Env': environment,
         'Cmd': command,
         'Dns': dns,
+        'DnsSearch': dns_search,
         'Image': image,
         'Volumes': volumes,
         'VolumesFrom': volumes_from,

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,6 +242,7 @@ from. Optionally a single string joining container id's with commas
 * labels (dict or list): A dictionary of name-value labels (e.g. `{"label1": "value1", "label2": "value2"}`) or a list of names of labels to set with empty values (e.g. `["label1", "label2"]`)
 * volume_driver (str): The name of a volume driver/plugin.
 * stop_signal (str): The stop signal to use to stop the container (e.g. `SIGINT`).
+* dns_search (list): DNS search domains
 
 **Returns** (dict): A dictionary with an image 'Id' key and a 'Warnings' key.
 


### PR DESCRIPTION
Currently, only the client.start api accepts the dns_search parameter. This commit makes the client.create_container api method also accept dns_search. The Ansible core module for docker uses client.create_container so this is necessary to support the dns_search argument over there.