### PR TITLE
Support SOCKS proxy from HTTP[S]_PROXY env vars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.5.3
+requests[socks]==2.10.0
 six>=1.4.0
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'requests >= 2.5.2',
+    'requests[socks] >= 2.10.0',
     'six >= 1.4.0',
     'websocket-client >= 0.32.0',
 ]


### PR DESCRIPTION
Related: docker/compose#3376

The recent release of [Requests 2.10.0](kennethreitz/requests#2953) with [this update](shazow/urllib3#762) to [urllib3](https://github.com/shazow/urllib3/blob/master/CHANGES.rst#114-2015-12-29)
means that docker-py can support a SOCKS proxy configured
via the HTTP[S]_PROXY environment variables.
We simply need to update the version of requests to
2.10.0, with the 'socks' extra, and the rest just works.
