### PR TITLE
Don't set socket timeout if it's already disabled when streaming

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -291,14 +291,29 @@ class Client(
         """ Depending on the combination of python version and whether we're
         connecting over http or https, we might need to access _sock, which
         may or may not exist; or we may need to just settimeout on socket
-         itself, which also may or may not have settimeout on it.
+        itself, which also may or may not have settimeout on it. To avoid
+        missing the correct one, we try both.
 
-        To avoid missing the correct one, we try both.
+        We also do not want to set the timeout if it is already disabled, as
+        you run the risk of changing a socket that was non-blocking to
+        blocking, for example when using gevent.
         """
-        if hasattr(socket, "settimeout"):
-            socket.settimeout(None)
-        if hasattr(socket, "_sock") and hasattr(socket._sock, "settimeout"):
-            socket._sock.settimeout(None)
+        sockets = [socket, getattr(socket, '_sock', None)]
+
+        for s in sockets:
+            if not hasattr(s, 'settimeout'):
+                continue
+
+            timeout = -1
+
+            if hasattr(s, 'gettimeout'):
+                timeout = s.gettimeout()
+
+            # Don't change the timeout if it is already disabled.
+            if timeout is None or timeout == 0.0:
+                continue
+
+            s.settimeout(None)
 
     def _get_result(self, container, stream, res):
         cont = self.inspect_container(container)


### PR DESCRIPTION
#### Problem
When streaming responses, socket timeouts are set to `None` to avoid read timeouts.  Normally this is fine, but causes issues when using gevent.  When using gevent, the socket class will be patched to be non-blocking (ie `timeout == 0.0`).  If the timeout is set to `None` the socket becomes blocking again causing all greenlets to be blocked until the stream has finished.

#### Solution
The proposed fix is to only set the socket timeout if it isn't already disabled.

#### Reproduction Steps
test.py
```
from gevent import monkey
monkey.patch_all()

from datetime import datetime
import sys
import docker
import gevent

BUSYBOX = 'busybox:buildroot-2014.02'

def logs():
    for log in client.logs(container, stdout=True, stderr=True, stream=True):
        sys.stdout.write('[{}] log {}\n'.format(datetime.now().time(), log.strip()))
        sys.stdout.flush()

def ping():
    for i in xrange(0, 6):
        sys.stdout.write('[{}] ping {}\n'.format(datetime.now().time(), i))
        sys.stdout.flush()
        gevent.sleep(1)

if __name__ == '__main__':
    tls = docker.tls.TLSConfig(
        client_cert=(
            '/path/to/cert.pem',
            '/path/to/key.pem'
        ),
        verify='/path/to/ca.pem'
    )
    client = docker.Client(base_url='<docker_host>', tls=tls)

    client.pull(BUSYBOX)

    container = client.create_container(
        BUSYBOX,
        'sh -c "echo start; sleep 10; echo finish"',
        detach=True,
    )

    client.start(container)

    logs = gevent.spawn(logs)
    ping = gevent.spawn(ping)

    gevent.joinall([logs, ping], timeout=30)
```

Without these changes:
```
> python test.py
[10:02:20.749195] ping 0
[10:02:20.763980] log start
[10:02:30.751678] log finish
[10:02:30.772866] ping 1        <--- Gets blocked until logs have finished streaming (ie 10 secs)
[10:02:31.777957] ping 2
[10:02:32.781986] ping 3
[10:02:33.786190] ping 4
[10:02:34.790423] ping 5
```

With changes:
```
> python test.py
[10:02:48.505751] ping 0
[10:02:48.521915] log start
[10:02:49.510465] ping 1        <--- Allowed to run while streaming logs
[10:02:50.513776] ping 2
[10:02:51.517609] ping 3
[10:02:52.521996] ping 4
[10:02:53.526963] ping 5
[10:02:58.507385] log finish
```