### PR TITLE
Resolve path traversal in .dockerignore patterns

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -199,6 +199,9 @@ def get_paths(root, exclude_patterns, include_patterns, has_exceptions=False):
 
 def match_path(path, pattern):
     pattern = pattern.rstrip('/')
+    if pattern:
+        pattern = os.path.relpath(pattern)
+
     pattern_components = pattern.split('/')
     path_components = path.split('/')[:len(pattern_components)]
     return fnmatch('/'.join(path_components), pattern)

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -802,6 +802,9 @@ class ExcludePathsTest(base.BaseTestCase):
     def test_single_filename(self):
         assert self.exclude(['a.py']) == self.all_paths - set(['a.py'])
 
+    def test_single_filename_leading_dot_slash(self):
+        assert self.exclude(['./a.py']) == self.all_paths - set(['a.py'])
+
     # As odd as it sounds, a filename pattern with a trailing slash on the
     # end *will* result in that file being excluded.
     def test_single_filename_trailing_slash(self):
@@ -830,6 +833,11 @@ class ExcludePathsTest(base.BaseTestCase):
 
     def test_single_subdir_single_filename(self):
         assert self.exclude(['foo/a.py']) == self.all_paths - set(['foo/a.py'])
+
+    def test_single_subdir_with_path_traversal(self):
+        assert self.exclude(['foo/whoops/../a.py']) == self.all_paths - set([
+            'foo/a.py',
+        ])
 
     def test_single_subdir_wildcard_filename(self):
         assert self.exclude(['foo/*.py']) == self.all_paths - set([


### PR DESCRIPTION
We were failing to match `.dockerignore` patterns such as `./a.py`, as reported in https://github.com/docker/compose/issues/1607#issuecomment-218765317. I've checked, and Engine does indeed support both `.` and `..` traversal in patterns.