### PR TITLE
Add support for Block IO constraints in HostConfig

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -612,8 +612,12 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
                        security_opt=None, ulimits=None, log_config=None,
                        mem_limit=None, memswap_limit=None, mem_swappiness=None,
                        cgroup_parent=None, group_add=None, cpu_quota=None,
-                       cpu_period=None, oom_kill_disable=False, shm_size=None,
-                       version=None, tmpfs=None, oom_score_adj=None):
+                       cpu_period=None, blkio_weight=None,
+                       blkio_weight_device=None, device_read_bps=None,
+                       device_write_bps=None, device_read_iops=None,
+                       device_write_iops=None, oom_kill_disable=False,
+                       shm_size=None, version=None, tmpfs=None,
+                       oom_score_adj=None):
 
     host_config = {}
 
@@ -788,6 +792,58 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
             raise host_config_version_error('cpu_period', '1.19')
 
         host_config['CpuPeriod'] = cpu_period
+
+    if blkio_weight:
+        if not isinstance(blkio_weight, int):
+            raise host_config_type_error('blkio_weight', blkio_weight, 'int')
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('blkio_weight', '1.22')
+        host_config["BlkioWeight"] = blkio_weight
+
+    if blkio_weight_device:
+        if not isinstance(blkio_weight_device, list):
+            raise host_config_type_error(
+                'blkio_weight_device', blkio_weight_device, 'list'
+            )
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('blkio_weight_device', '1.22')
+        host_config["BlkioWeightDevice"] = blkio_weight_device
+
+    if device_read_bps:
+        if not isinstance(device_read_bps, list):
+            raise host_config_type_error(
+                'device_read_bps', device_read_bps, 'list'
+            )
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('device_read_bps', '1.22')
+        host_config["BlkioDeviceReadBps"] = device_read_bps
+
+    if device_write_bps:
+        if not isinstance(device_write_bps, list):
+            raise host_config_type_error(
+                'device_write_bps', device_write_bps, 'list'
+            )
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('device_write_bps', '1.22')
+        host_config["BlkioDeviceWriteBps"] = device_write_bps
+
+    if device_read_iops:
+        if not isinstance(device_read_iops, list):
+            raise host_config_type_error(
+                'device_read_iops', device_read_iops, 'list'
+            )
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('device_read_iops', '1.22')
+        host_config["BlkioDeviceReadIOps"] = device_read_iops
+
+    if device_write_iops:
+        if not isinstance(device_write_iops, list):
+            raise host_config_type_error(
+                'device_write_iops', device_write_iops, 'list'
+            )
+        if version_lt(version, '1.22'):
+            raise host_config_version_error('device_write_iops', '1.22')
+        host_config["BlkioDeviceWriteIOps"] = device_write_iops
 
     if tmpfs:
         if version_lt(version, '1.22'):

--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -109,6 +109,14 @@ for example:
 * cpu_group (int): The length of a CPU period in microseconds.
 * cpu_period (int): Microseconds of CPU time that the container can get in a
   CPU period.
+* blkio_weight: Block IO weight (relative weight), accepts a weight value between 10 and 1000.
+* blkio_weight_device: Block IO weight (relative device weight) in the form of:
+  `[{"Path": "device_path", "Weight": weight}]`
+* device_read_bps: Limit read rate (bytes per second) from a device in the form of:
+  `[{"Path": "device_path", "Rate": rate}]`
+* device_write_bps: Limit write rate (bytes per second) from a device.
+* device_read_iops: Limit read rate (IO per second) from a device.
+* device_write_iops: Limit write rate (IO per second) from a device.
 * group_add (list): List of additional group names and/or IDs that the
   container process will run as.
 * devices (list): Host device bindings. See [host devices](host-devices.md)

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -64,6 +64,25 @@ class HostConfigTest(base.BaseTestCase):
         config = create_host_config(version='1.20', cpu_period=1999)
         self.assertEqual(config.get('CpuPeriod'), 1999)
 
+    def test_create_host_config_with_blkio_constraints(self):
+        blkio_rate = [{"Path": "/dev/sda", "Rate": 1000}]
+        config = create_host_config(version='1.22',
+                                    blkio_weight=1999,
+                                    blkio_weight_device=blkio_rate,
+                                    device_read_bps=blkio_rate,
+                                    device_write_bps=blkio_rate,
+                                    device_read_iops=blkio_rate,
+                                    device_write_iops=blkio_rate)
+
+        self.assertEqual(config.get('BlkioWeight'), 1999)
+        self.assertTrue(config.get('BlkioWeightDevice') is blkio_rate)
+        self.assertTrue(config.get('BlkioDeviceReadBps') is blkio_rate)
+        self.assertTrue(config.get('BlkioDeviceWriteBps') is blkio_rate)
+        self.assertTrue(config.get('BlkioDeviceReadIOps') is blkio_rate)
+        self.assertTrue(config.get('BlkioDeviceWriteIOps') is blkio_rate)
+        self.assertEqual(blkio_rate[0]['Path'], "/dev/sda")
+        self.assertEqual(blkio_rate[0]['Rate'], 1000)
+
     def test_create_host_config_with_shm_size(self):
         config = create_host_config(version='1.22', shm_size=67108864)
         self.assertEqual(config.get('ShmSize'), 67108864)


### PR DESCRIPTION
Block IO constraint support was added to docker by https://github.com/docker/docker/pull/13959 and https://github.com/docker/docker/pull/14466 and https://github.com/docker/docker/pull/15879

This adds support for Block IO constraint options according to:
- Docker Remote API v1.22: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.22/#create-a-container
- Docker run reference  https://docs.docker.com/engine/reference/run/#block-io-bandwidth-blkio-constraint

These options were added to `create_host_config`:
    - blkio-weight
    - blkio-weight-device
    - device-read-bps
    - device-write-bps
    - device-read-iops
    - device-write-iops

Signed-off-by: yunzhu-li <contact@yunzhu.li>