### PR TITLE
1059-Fixing a bug with multiple json objects

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -251,8 +251,16 @@ class Client(
                 if decode:
                     if six.PY3:
                         data = data.decode('utf-8')
-                    data = json.loads(data)
-                yield data
+                    # remove the trailing newline
+                    data = data.strip()
+                    # split the data at any newlines
+                    data_list = data.split("\r\n")
+                    # load and yield each line seperately
+                    for data in data_list:
+                        data = json.loads(data)
+                        yield data
+                else:
+                    yield data
         else:
             # Response isn't chunked, meaning we probably
             # encountered an error immediately


### PR DESCRIPTION
This splits the text by CRLF and then json.loads each part
independently instead of attempting the parse the whole string.

Signed-off-by: Tristan Escalada <tristan@escalada.us>