### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ pip freeze | grep docker-py && python --version && docker version
 - If possible, steps or a code snippet to reproduce the issue
 
 To save yourself time, please be sure to check our
-[documentation](http://docker-py.readthedocs.org/) and use the
+[documentation](https://docker-py.readthedocs.io/) and use the
 [search function](https://github.com/docker/docker-py/search) to find out if
 it has already been addressed, or is currently being looked at.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Documentation
 
 [![Documentation Status](https://readthedocs.org/projects/docker-py/badge/?version=latest)](https://readthedocs.org/projects/docker-py/?badge=latest)
 
-[Read the full documentation here](http://docker-py.readthedocs.org/en/latest/).
+[Read the full documentation here](https://docker-py.readthedocs.io/en/latest/).
 The source is available in the `docs/` directory.
 
 

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -213,7 +213,7 @@ Change Log
 ### Features
 
 * Added `utils.parse_env_file` to support env-files.
-  See [docs](http://docker-py.readthedocs.org/en/latest/api/#create_container)
+  See [docs](https://docker-py.readthedocs.io/en/latest/api/#create_container)
   for usage.
 * Added support for arbitrary log drivers
 * Added support for URL paths in the docker host URL (`base_url`)
@@ -577,7 +577,7 @@ Change Log
 ### Documentation
 
 * Added new MkDocs documentation. Currently hosted on
-  [ReadTheDocs](http://docker-py.readthedocs.org/en/latest/)
+  [ReadTheDocs](https://docker-py.readthedocs.io/en/latest/)
 
 ### Miscellaneous
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: docker-py Documentation
 site_description: An API client for Docker written in Python
 site_favicon: favicon_whale.png
-site_url: http://docker-py.readthedocs.org
+site_url: https://docker-py.readthedocs.io
 repo_url: https://github.com/docker/docker-py/
 theme: readthedocs
 pages:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.