### PR TITLE
Add missing create_network params

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -284,9 +284,12 @@ Create a network, similar to the `docker network create` command.
 **Params**:
 
 * name (str): Name of the network
-* driver (str): Name of the driver used to create the network
-
+* driver (str): Name of the network driver plugin to use. Defaults to bridge driver
 * options (dict): Driver options as a key-value dictionary
+* ipam (dict): Optional custom IP scheme for the network
+* check_duplicate (bool): Requests daemon to check for networks with same name
+* internal (bool): Restrict external access to the network
+
 
 **Returns** (dict): The created network reference object
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -284,7 +284,7 @@ Create a network, similar to the `docker network create` command.
 **Params**:
 
 * name (str): Name of the network
-* driver (str): Name of the network driver plugin to use. Defaults to bridge driver
+* driver (str): Name of the network driver plugin to use.
 * options (dict): Driver options as a key-value dictionary
 * ipam (dict): Optional custom IP scheme for the network
 * check_duplicate (bool): Requests daemon to check for networks with same name


### PR DESCRIPTION
There some parameters in the API but not in docs.

```
 def create_network(self, name, driver=None, options=None, ipam=None, check_duplicate=None, internal=False):
```