### PR TITLE
signal in Client.kill can be a string containing the signal's name

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -187,7 +187,9 @@ class ContainerApiMixin(object):
         url = self._url("/containers/{0}/kill", container)
         params = {}
         if signal is not None:
-            params['signal'] = int(signal)
+            if not isinstance(signal, six.string_types):
+                signal = int(signal)
+            params['signal'] = signal
         res = self._post(url, params=params)
 
         self._raise_for_status(res)

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -840,6 +840,36 @@ class KillTest(helpers.BaseTestCase):
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False, state)
 
+    def test_kill_with_signal_name(self):
+        id = self.client.create_container(BUSYBOX, ['sleep', '60'])
+        self.client.start(id)
+        self.tmp_containers.append(id)
+        self.client.kill(id, signal='SIGKILL')
+        exitcode = self.client.wait(id)
+        self.assertNotEqual(exitcode, 0)
+        container_info = self.client.inspect_container(id)
+        self.assertIn('State', container_info)
+        state = container_info['State']
+        self.assertIn('ExitCode', state)
+        self.assertNotEqual(state['ExitCode'], 0)
+        self.assertIn('Running', state)
+        self.assertEqual(state['Running'], False, state)
+
+    def test_kill_with_signal_integer(self):
+        id = self.client.create_container(BUSYBOX, ['sleep', '60'])
+        self.client.start(id)
+        self.tmp_containers.append(id)
+        self.client.kill(id, signal=9)
+        exitcode = self.client.wait(id)
+        self.assertNotEqual(exitcode, 0)
+        container_info = self.client.inspect_container(id)
+        self.assertIn('State', container_info)
+        state = container_info['State']
+        self.assertIn('ExitCode', state)
+        self.assertNotEqual(state['ExitCode'], 0)
+        self.assertIn('Running', state)
+        self.assertEqual(state['Running'], False, state)
+
 
 class PortTest(helpers.BaseTestCase):
     def test_port(self):

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -138,9 +138,11 @@ class TestNetworks(helpers.BaseTestCase):
         self.client.connect_container_to_network(
             container, net_id, aliases=['foo', 'bar'])
         container_data = self.client.inspect_container(container)
-        self.assertEqual(
-            container_data['NetworkSettings']['Networks'][net_name]['Aliases'],
-            ['foo', 'bar'])
+        aliases = (
+            container_data['NetworkSettings']['Networks'][net_name]['Aliases']
+        )
+        assert 'foo' in aliases
+        assert 'bar' in aliases
 
     @requires_api_version('1.21')
     def test_connect_on_container_create(self):
@@ -183,10 +185,11 @@ class TestNetworks(helpers.BaseTestCase):
         self.client.start(container)
 
         container_data = self.client.inspect_container(container)
-        self.assertEqual(
-            container_data['NetworkSettings']['Networks'][net_name]['Aliases'],
-            ['foo', 'bar']
+        aliases = (
+            container_data['NetworkSettings']['Networks'][net_name]['Aliases']
         )
+        assert 'foo' in aliases
+        assert 'bar' in aliases
 
     @requires_api_version('1.22')
     def test_create_with_ipv4_address(self):


### PR DESCRIPTION
Fixes issue introduced in #1071 