### PR TITLE
Pass X-Registry-Auth when building an image

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -18,7 +18,8 @@ class BuildApiMixin(object):
               custom_context=False, encoding=None, pull=False,
               forcerm=False, dockerfile=None, container_limits=None,
               decode=False, buildargs=None, gzip=False):
-        remote = context = headers = None
+        remote = context = None
+        headers = {}
         container_limits = container_limits or {}
         if path is None and fileobj is None:
             raise TypeError("Either path or fileobj needs to be provided.")
@@ -134,8 +135,7 @@ class BuildApiMixin(object):
                     ', '.join(repr(k) for k in self._auth_configs.keys())
                 )
             )
-            if headers is None:
-                headers = {}
+
             if utils.compare_version('1.19', self._version) >= 0:
                 headers['X-Registry-Config'] = auth.encode_header(
                     self._auth_configs

--- a/tests/unit/build_test.py
+++ b/tests/unit/build_test.py
@@ -122,7 +122,7 @@ class BuildTest(DockerClientTest):
             })
         )
 
-    def test__set_auth_headers_with_empty_dict_and_auth_configs(self):
+    def test_set_auth_headers_with_empty_dict_and_auth_configs(self):
         self.client._auth_configs = {
             'https://example.com': {
                 'user': 'example',
@@ -137,7 +137,7 @@ class BuildTest(DockerClientTest):
         self.client._set_auth_headers(headers)
         self.assertEqual(headers, expected_headers)
 
-    def test__set_auth_headers_with_dict_and_auth_configs(self):
+    def test_set_auth_headers_with_dict_and_auth_configs(self):
         self.client._auth_configs = {
             'https://example.com': {
                 'user': 'example',
@@ -154,7 +154,7 @@ class BuildTest(DockerClientTest):
         self.client._set_auth_headers(headers)
         self.assertEqual(headers, expected_headers)
 
-    def test__set_auth_headers_with_dict_and_no_auth_configs(self):
+    def test_set_auth_headers_with_dict_and_no_auth_configs(self):
         headers = {'foo': 'bar'}
         expected_headers = {
             'foo': 'bar'


### PR DESCRIPTION
This fixes a bug where X-Registry-Auth was not set because the `headers` variable in BuildApiMixin.build() did not get set properly by _set_auth_headers() if `headers` was `None` when `set_auth_headers()` got called.  This resulted in Dockerfiles with `FROM <private_registry>` to fail to authenticate.

* Initialize headers variable in BuildApiMixin.build() as a dict rather than as None.  This way the correct object gets passed to _set_auth_headers() even if no headers were set in build()

* Changing object from None to {} in BuildApiMixin._set_auth_headers() removed because it changes the object reference, so has no effect on calling code.

Signed-off-by: Justin Michalicek <jmichalicek@gmail.com>