### PR TITLE
Send connection upgrade headers

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -15,10 +15,16 @@ class ContainerApiMixin(object):
             'logs': logs and 1 or 0,
             'stdout': stdout and 1 or 0,
             'stderr': stderr and 1 or 0,
-            'stream': stream and 1 or 0,
+            'stream': stream and 1 or 0
         }
+
+        headers = {
+            'Connection': 'Upgrade',
+            'Upgrade': 'tcp'
+        }
+
         u = self._url("/containers/{0}/attach", container)
-        response = self._post(u, params=params, stream=stream)
+        response = self._post(u, headers=headers, params=params, stream=stream)
 
         return self._get_result(container, stream, response)
 

--- a/docker/api/exec_api.py
+++ b/docker/api/exec_api.py
@@ -66,8 +66,16 @@ class ExecApiMixin(object):
             'Detach': detach
         }
 
+        headers = {} if detach else {
+            'Connection': 'Upgrade',
+            'Upgrade': 'tcp'
+        }
+
         res = self._post_json(
-            self._url('/exec/{0}/start', exec_id), data=data, stream=stream
+            self._url('/exec/{0}/start', exec_id),
+            headers=headers,
+            data=data,
+            stream=stream
         )
 
         if socket:

--- a/tests/unit/exec_test.py
+++ b/tests/unit/exec_test.py
@@ -51,8 +51,36 @@ class ExecTest(DockerClientTest):
             }
         )
 
-        self.assertEqual(args[1]['headers'],
-                         {'Content-Type': 'application/json'})
+        self.assertEqual(
+            args[1]['headers'], {
+                'Content-Type': 'application/json',
+                'Connection': 'Upgrade',
+                'Upgrade': 'tcp'
+            }
+        )
+
+    def test_exec_start_detached(self):
+        self.client.exec_start(fake_api.FAKE_EXEC_ID, detach=True)
+
+        args = fake_request.call_args
+        self.assertEqual(
+            args[0][1], url_prefix + 'exec/{0}/start'.format(
+                fake_api.FAKE_EXEC_ID
+            )
+        )
+
+        self.assertEqual(
+            json.loads(args[1]['data']), {
+                'Tty': False,
+                'Detach': True
+            }
+        )
+
+        self.assertEqual(
+            args[1]['headers'], {
+                'Content-Type': 'application/json'
+            }
+        )
 
     def test_exec_inspect(self):
         self.client.exec_inspect(fake_api.FAKE_EXEC_ID)


### PR DESCRIPTION
Fixes #1123

I'm all new to this codebase, so I'm not sure I did the things right.

I basically looked at [docker cli code](https://github.com/docker/docker/blob/07f580489908bf6a3373daac1473045406e1130d/vendor/src/github.com/docker/engine-api/client/hijack.go#L34) and found out where the `postHijacked` function is called:
 + `/attach` api calls https://github.com/docker/docker/blob/7fd53f7c711474791ce4292326e0b1dc7d4d6b0f/vendor/src/github.com/docker/engine-api/client/container_attach.go#L33
 + attached `/exec/ calls https://github.com/docker/docker/blob/7fd53f7c711474791ce4292326e0b1dc7d4d6b0f/vendor/src/github.com/docker/engine-api/client/container_exec.go#L33 and https://github.com/docker/docker/blob/6b4a46f28266031ce1a1315f17fb69113a06efe1/api/client/exec.go#L90

I tried to add a unit test for `attach` but couldn't find any to get inspiration from.