### PR TITLE
Implemented dns_opt support (from api 1.21)

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -620,7 +620,7 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
                        device_write_bps=None, device_read_iops=None,
                        device_write_iops=None, oom_kill_disable=False,
                        shm_size=None, sysctls=None, version=None, tmpfs=None,
-                       oom_score_adj=None):
+                       oom_score_adj=None, dns_opt=None):
 
     host_config = {}
 
@@ -718,6 +718,12 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
 
     if dns is not None:
         host_config['Dns'] = dns
+
+    if dns_opt is not None:
+        if version_lt(version, '1.21'):
+            raise host_config_version_error('dns_opt', '1.21')
+
+        host_config['DnsOptions'] = dns_opt
 
     if security_opt is not None:
         if not isinstance(security_opt, list):

--- a/docs/api.md
+++ b/docs/api.md
@@ -239,6 +239,7 @@ where unit = b, k, m, or g)
 * environment (dict or list): A dictionary or a list of strings in the
 following format `["PASSWORD=xxx"]` or `{"PASSWORD": "xxx"}`.
 * dns (list): DNS name servers
+* dns_opt (list): Additional options to be added to the container's `resolv.conf` file
 * volumes (str or list):
 * volumes_from (str or list): List of container names or Ids to get volumes
 from. Optionally a single string joining container id's with commas

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -141,6 +141,19 @@ class HostConfigTest(base.BaseTestCase):
             TypeError, lambda: create_host_config(version='1.22',
                                                   oom_score_adj='100'))
 
+    def test_create_host_config_with_dns_opt(self):
+
+        tested_opts = ['use-vc', 'no-tld-query']
+        config = create_host_config(version='1.21', dns_opt=tested_opts)
+        dns_opts = config.get('DnsOptions')
+
+        self.assertTrue('use-vc' in dns_opts)
+        self.assertTrue('no-tld-query' in dns_opts)
+
+        self.assertRaises(
+            InvalidVersion, lambda: create_host_config(version='1.20',
+                                                       dns_opt=tested_opts))
+
     def test_create_endpoint_config_with_aliases(self):
         config = create_endpoint_config(version='1.22', aliases=['foo', 'bar'])
         assert config == {'Aliases': ['foo', 'bar']}


### PR DESCRIPTION
In the process of making a PR for docker-compose to implement [docker-compose:#3184](https://github.com/docker/compose/issues/3184), I realized the python client doesn't support `dns_opt`. This should fix that.
