### PR TITLE
docker client consistency: don't quote ':/'

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -14,6 +14,7 @@
 
 import json
 import struct
+from functools import partial
 
 import requests
 import requests.exceptions
@@ -156,7 +157,8 @@ class Client(
                     'instead'.format(arg, type(arg))
                 )
 
-        args = map(six.moves.urllib.parse.quote_plus, args)
+        quote_f = partial(six.moves.urllib.parse.quote_plus, safe="/:")
+        args = map(quote_f, args)
 
         if kwargs.get('versioned_api', True):
             return '{0}/v{1}{2}'.format(

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -159,9 +159,15 @@ class DockerApiTest(DockerClientTest):
             '{0}{1}'.format(url_prefix, 'hello/somename/world/someothername')
         )
 
-        url = self.client._url('/hello/{0}/world', '/some?name')
+        url = self.client._url('/hello/{0}/world', 'some?name')
         self.assertEqual(
-            url, '{0}{1}'.format(url_prefix, 'hello/%2Fsome%3Fname/world')
+            url, '{0}{1}'.format(url_prefix, 'hello/some%3Fname/world')
+        )
+
+        url = self.client._url("/images/{0}/push", "localhost:5000/image")
+        self.assertEqual(
+            url,
+            '{0}{1}'.format(url_prefix, 'images/localhost:5000/image/push')
         )
 
     def test_url_invalid_resource(self):


### PR DESCRIPTION
E.g.

docker client

`/v1.21/images/localhost:5000/busybox/push?tag=`

docker-py

`/v1.21/images/localhost%3A5000%2Fbusybox/push`

(this was brought up in our docker authz plugin: https://github.com/projectatomic/rhel-push-plugin/pull/8 I want to fix this in docker-py so other plugin developers don't get struck by this)