### PR TITLE
Add support for sysctl when creating container

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -619,7 +619,7 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
                        blkio_weight_device=None, device_read_bps=None,
                        device_write_bps=None, device_read_iops=None,
                        device_write_iops=None, oom_kill_disable=False,
-                       shm_size=None, version=None, tmpfs=None,
+                       shm_size=None, sysctls=None, version=None, tmpfs=None,
                        oom_score_adj=None):
 
     host_config = {}
@@ -724,6 +724,13 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
             raise host_config_type_error('security_opt', security_opt, 'list')
 
         host_config['SecurityOpt'] = security_opt
+
+    if sysctls:
+        if not isinstance(sysctls, dict):
+            raise host_config_type_error('sysctls', sysctls, 'dict')
+        host_config['Sysctls'] = {}
+        for k, v in six.iteritems(sysctls):
+            host_config['Sysctls'][k] = six.text_type(v)
 
     if volumes_from is not None:
         if isinstance(volumes_from, six.string_types):

--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -123,6 +123,7 @@ for example:
   for more information.
 * tmpfs: Temporary filesystems to mouunt. See [Using tmpfs](tmpfs.md) for more
   information.
+* sysctls (dict): Kernel parameters to set in the container.
 
 **Returns** (dict) HostConfig dictionary
 

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -1074,6 +1074,33 @@ class CreateContainerTest(DockerClientTest):
             DEFAULT_TIMEOUT_SECONDS
         )
 
+    @requires_api_version('1.24')
+    def test_create_container_with_sysctl(self):
+        self.client.create_container(
+            'busybox', 'true',
+            host_config=self.client.create_host_config(
+                sysctls={
+                    'net.core.somaxconn': 1024,
+                    'net.ipv4.tcp_syncookies': '0',
+                }
+            )
+        )
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][1], url_prefix + 'containers/create')
+        expected_payload = self.base_create_payload()
+        expected_payload['HostConfig'] = self.client.create_host_config()
+        expected_payload['HostConfig']['Sysctls'] = {
+            'net.core.somaxconn': '1024', 'net.ipv4.tcp_syncookies': '0',
+        }
+        self.assertEqual(json.loads(args[1]['data']), expected_payload)
+        self.assertEqual(
+            args[1]['headers'], {'Content-Type': 'application/json'}
+        )
+        self.assertEqual(
+            args[1]['timeout'], DEFAULT_TIMEOUT_SECONDS
+        )
+
 
 class ContainerTest(DockerClientTest):
     def test_list_containers(self):


### PR DESCRIPTION
Implemented sysctl support for setting kernel parameters when creating a container.
Closes #1144

Signed-off-by: Jari Takkala <jtakkala@gmail.com>