### PR TITLE
Add support for passing healthcheck to create_container

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -115,7 +115,8 @@ class ContainerApiMixin(object):
                          cpu_shares=None, working_dir=None, domainname=None,
                          memswap_limit=None, cpuset=None, host_config=None,
                          mac_address=None, labels=None, volume_driver=None,
-                         stop_signal=None, networking_config=None):
+                         stop_signal=None, networking_config=None,
+                         healthcheck=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -130,7 +131,7 @@ class ContainerApiMixin(object):
             tty, mem_limit, ports, environment, dns, volumes, volumes_from,
             network_disabled, entrypoint, cpu_shares, working_dir, domainname,
             memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver, stop_signal, networking_config,
+            volume_driver, stop_signal, networking_config, healthcheck,
         )
         return self.create_container_from_config(config, name)
 

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -6,6 +6,7 @@ from .utils import (
     create_host_config, create_container_config, parse_bytes, ping_registry,
     parse_env_file, version_lt, version_gte, decode_json_header, split_command,
     create_ipam_config, create_ipam_pool, parse_devices, normalize_links,
+    create_healthcheck, create_healthcheck_test_from_command,
 )
 
 from .types import Ulimit, LogConfig

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -24,7 +24,6 @@ import warnings
 from distutils.version import StrictVersion
 from datetime import datetime
 from fnmatch import fnmatch
-from pytimeparse.timeparse import timeparse
 
 import requests
 import six
@@ -66,6 +65,22 @@ def create_ipam_config(driver='default', pool_configs=None):
         'Driver': driver,
         'Config': pool_configs or []
     }
+
+
+def create_healthcheck(test=None, interval=None, timeout=None, retries=None):
+    return {
+        'Test': test,
+        'Interval': interval,
+        'Timeout': timeout,
+        'Retries': retries,
+    }
+
+
+def create_healthcheck_test_from_command(command=None):
+    return [
+        'CMD-SHELL',
+        command
+    ]
 
 
 def mkbuildcontext(dockerfile):
@@ -953,8 +968,6 @@ def format_environment(environment):
         return '{key}={value}'.format(key=key, value=value)
     return [format_env(*var) for var in six.iteritems(environment)]
 
-def duration_from_string(duration_string):
-    return timeparse(duration_string) * 1000000000
 
 def create_container_config(
     version, image, command, hostname=None, user=None, detach=False,
@@ -1036,17 +1049,6 @@ def create_container_config(
         for vol in volumes:
             volumes_dict[vol] = {}
         volumes = volumes_dict
-
-    if isinstance(healthcheck, dict):
-        healthcheck = {
-            'Test': [
-                'CMD-SHELL',
-                healthcheck.get('command')
-            ],
-            'Interval': duration_from_string(healthcheck.get('interval')) if healthcheck.has_key('interval') else None,
-            'Timeout': duration_from_string(healthcheck.get('timeout')) if healthcheck.has_key('timeout') else None,
-            'Retries': healthcheck.get('retries')
-        }
 
     if volumes_from:
         if not isinstance(volumes_from, six.string_types):

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -24,6 +24,7 @@ import warnings
 from distutils.version import StrictVersion
 from datetime import datetime
 from fnmatch import fnmatch
+from pytimeparse.timeparse import timeparse
 
 import requests
 import six
@@ -952,6 +953,8 @@ def format_environment(environment):
         return '{key}={value}'.format(key=key, value=value)
     return [format_env(*var) for var in six.iteritems(environment)]
 
+def duration_from_string(duration_string):
+    return timeparse(duration_string) * 1000000000
 
 def create_container_config(
     version, image, command, hostname=None, user=None, detach=False,
@@ -960,6 +963,7 @@ def create_container_config(
     entrypoint=None, cpu_shares=None, working_dir=None, domainname=None,
     memswap_limit=None, cpuset=None, host_config=None, mac_address=None,
     labels=None, volume_driver=None, stop_signal=None, networking_config=None,
+    healthcheck=None,
 ):
     if isinstance(command, six.string_types):
         command = split_command(command)
@@ -978,6 +982,11 @@ def create_container_config(
     if stop_signal is not None and compare_version('1.21', version) < 0:
         raise errors.InvalidVersion(
             'stop_signal was only introduced in API version 1.21'
+        )
+
+    if healthcheck is not None and compare_version('1.24', version) < 0:
+        raise errors.InvalidVersion(
+            'Health options were only introduced in API version 1.24'
         )
 
     if compare_version('1.19', version) < 0:
@@ -1027,6 +1036,17 @@ def create_container_config(
         for vol in volumes:
             volumes_dict[vol] = {}
         volumes = volumes_dict
+
+    if isinstance(healthcheck, dict):
+        healthcheck = {
+            'Test': [
+                'CMD-SHELL',
+                healthcheck.get('command')
+            ],
+            'Interval': duration_from_string(healthcheck.get('interval')) if healthcheck.has_key('interval') else None,
+            'Timeout': duration_from_string(healthcheck.get('timeout')) if healthcheck.has_key('timeout') else None,
+            'Retries': healthcheck.get('retries')
+        }
 
     if volumes_from:
         if not isinstance(volumes_from, six.string_types):
@@ -1086,5 +1106,6 @@ def create_container_config(
         'MacAddress': mac_address,
         'Labels': labels,
         'VolumeDriver': volume_driver,
-        'StopSignal': stop_signal
+        'StopSignal': stop_signal,
+        'Healthcheck': healthcheck
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests==2.5.3
 six>=1.4.0
-pytimeparse==1.1.5
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'
 ipaddress==1.0.16 ; python_version < '3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests==2.5.3
 six>=1.4.0
+pytimeparse==1.1.5
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'
 ipaddress==1.0.16 ; python_version < '3.3'


### PR DESCRIPTION
I'm looking into adding healthcheck support to the Docker Compile yaml file.
This is an attempt at adding support for healthcheck into docker-py.

There are no tests yet so please don't merge - I'd just like to know whether I'm on the right lines and whether you'll consider merging this.

healthcheck should be passed into create_container like so:

```
{
  interval: "5s",
  timeout: "5s",
  command: "exit 0"
}
```

I've also made the necessary changes in my local docker compose repo to add support in the v2 yaml file and it is working fine.
