### PR TITLE
Fix for Client.from_env method

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -485,7 +485,8 @@ def parse_devices(devices):
     return device_list
 
 
-def kwargs_from_env(ssl_version=None, assert_hostname=None, environment=None):
+def kwargs_from_env(ssl_version=None, assert_hostname=None, environment=None,
+                    **params):
     if not environment:
         environment = os.environ
     host = environment.get('DOCKER_HOST')
@@ -501,8 +502,6 @@ def kwargs_from_env(ssl_version=None, assert_hostname=None, environment=None):
     else:
         tls_verify = tls_verify is not None
     enable_tls = cert_path or tls_verify
-
-    params = {}
 
     if host:
         params['base_url'] = (

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -25,6 +25,17 @@ class ClientTest(base.BaseTestCase):
         client = Client.from_env()
         self.assertEqual(client.base_url, "https://192.168.59.103:2376")
 
+    def test_from_env_version(self):
+        """Test that environment variables are passed through to
+        utils.kwargs_from_env(). KwargsFromEnvTest tests that environment
+        variables are parsed correctly."""
+        os.environ.update(DOCKER_HOST='tcp://192.168.59.103:2376',
+                          DOCKER_CERT_PATH=TEST_CERT_DIR,
+                          DOCKER_TLS_VERIFY='1')
+        client = Client.from_env(version='x.y.x')
+        self.assertEqual(client.base_url, "https://192.168.59.103:2376")
+        self.assertEqual(client.api_version, "x.y.x")
+
 
 class DisableSocketTest(base.BaseTestCase):
     class DummySocket(object):


### PR DESCRIPTION
It allows key-value parameters not used by `kwargs_from_env` function to be passed to the Client initialization method