### PR TITLE
Move cpu_shares and cpuset_cpu to HostConfig when API >= 1.18

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -620,7 +620,7 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
                        device_write_bps=None, device_read_iops=None,
                        device_write_iops=None, oom_kill_disable=False,
                        shm_size=None, sysctls=None, version=None, tmpfs=None,
-                       oom_score_adj=None):
+                       oom_score_adj=None, cpu_shares=None, cpuset_cpus=None):
 
     host_config = {}
 
@@ -803,6 +803,21 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
 
         host_config['CpuPeriod'] = cpu_period
 
+    if cpu_shares:
+        if version_lt(version, '1.18'):
+            raise host_config_version_error('cpu_shares', '1.18')
+
+        if not isinstance(cpu_shares, int):
+            raise host_config_type_error('cpu_shares', cpu_shares, 'int')
+
+        host_config['CpuShares'] = cpu_shares
+
+    if cpuset_cpus:
+        if version_lt(version, '1.18'):
+            raise host_config_version_error('cpuset_cpus', '1.18')
+
+        host_config['CpuSetCpus'] = cpuset_cpus
+
     if blkio_weight:
         if not isinstance(blkio_weight, int):
             raise host_config_type_error('blkio_weight', blkio_weight, 'int')
@@ -975,6 +990,14 @@ def create_container_config(
             'labels were only introduced in API version 1.18'
         )
 
+    if cpuset is not None or cpu_shares is not None:
+        if version_gte(version, '1.18'):
+            warnings.warn(
+                'The cpuset_cpus and cpu_shares options have been moved to '
+                'host_config in API version 1.18, and will be removed',
+                DeprecationWarning
+            )
+
     if stop_signal is not None and compare_version('1.21', version) < 0:
         raise errors.InvalidVersion(
             'stop_signal was only introduced in API version 1.21'
@@ -1004,6 +1027,7 @@ def create_container_config(
 
     if mem_limit is not None:
         mem_limit = parse_bytes(mem_limit)
+
     if memswap_limit is not None:
         memswap_limit = parse_bytes(memswap_limit)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -245,7 +245,6 @@ from. Optionally a single string joining container id's with commas
 * network_disabled (bool): Disable networking
 * name (str): A name for the container
 * entrypoint (str or list): An entrypoint
-* cpu_shares (int): CPU shares (relative weight)
 * working_dir (str): Path to the working directory
 * domainname (str or list): Set custom DNS search domains
 * memswap_limit (int):

--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -109,6 +109,8 @@ for example:
 * cpu_group (int): The length of a CPU period in microseconds.
 * cpu_period (int): Microseconds of CPU time that the container can get in a
   CPU period.
+* cpu_shares (int): CPU shares (relative weight)
+* cpuset_cpus (str): CPUs in which to allow execution (0-3, 0,1)
 * blkio_weight: Block IO weight (relative weight), accepts a weight value between 10 and 1000.
 * blkio_weight_device: Block IO weight (relative device weight) in the form of:
   `[{"Path": "device_path", "Weight": weight}]`

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -1101,11 +1101,38 @@ class ContainerUpdateTest(helpers.BaseTestCase):
         container = self.client.create_container(
             BUSYBOX, 'top', host_config=self.client.create_host_config(
                 mem_limit=old_mem_limit
-            ), cpu_shares=102
+            )
         )
         self.tmp_containers.append(container)
         self.client.start(container)
         self.client.update_container(container, mem_limit=new_mem_limit)
         inspect_data = self.client.inspect_container(container)
         self.assertEqual(inspect_data['HostConfig']['Memory'], new_mem_limit)
-        self.assertEqual(inspect_data['HostConfig']['CpuShares'], 102)
+
+
+class ContainerCPUTest(helpers.BaseTestCase):
+    @requires_api_version('1.18')
+    def test_container_cpu_shares(self):
+        cpu_shares = 512
+        container = self.client.create_container(
+            BUSYBOX, 'ls', host_config=self.client.create_host_config(
+                cpu_shares=cpu_shares
+            )
+        )
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        inspect_data = self.client.inspect_container(container)
+        self.assertEqual(inspect_data['HostConfig']['CpuShares'], 512)
+
+    @requires_api_version('1.18')
+    def test_container_cpuset(self):
+        cpuset_cpus = "0,1"
+        container = self.client.create_container(
+            BUSYBOX, 'ls', host_config=self.client.create_host_config(
+                cpuset_cpus=cpuset_cpus
+            )
+        )
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        inspect_data = self.client.inspect_container(container)
+        self.assertEqual(inspect_data['HostConfig']['CpusetCpus'], cpuset_cpus)

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -286,6 +286,33 @@ class CreateContainerTest(DockerClientTest):
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 
+    @requires_api_version('1.18')
+    def test_create_container_with_host_config_cpu_shares(self):
+        self.client.create_container(
+            'busybox', 'ls', host_config=self.client.create_host_config(
+                cpu_shares=512
+            )
+        )
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][1],
+                         url_prefix + 'containers/create')
+
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls"], "AttachStdin": false,
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false,
+                             "HostConfig": {
+                                "CpuShares": 512,
+                                "NetworkMode": "default"
+                             }}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
     def test_create_container_with_cpuset(self):
         self.client.create_container('busybox', 'ls',
                                      cpuset='0,1')
@@ -303,6 +330,33 @@ class CreateContainerTest(DockerClientTest):
                              "NetworkDisabled": false,
                              "Cpuset": "0,1",
                              "CpusetCpus": "0,1"}'''))
+        self.assertEqual(args[1]['headers'],
+                         {'Content-Type': 'application/json'})
+
+    @requires_api_version('1.18')
+    def test_create_container_with_host_config_cpuset(self):
+        self.client.create_container(
+            'busybox', 'ls', host_config=self.client.create_host_config(
+                cpuset_cpus='0,1'
+            )
+        )
+
+        args = fake_request.call_args
+        self.assertEqual(args[0][1],
+                         url_prefix + 'containers/create')
+
+        self.assertEqual(json.loads(args[1]['data']),
+                         json.loads('''
+                            {"Tty": false, "Image": "busybox",
+                             "Cmd": ["ls"], "AttachStdin": false,
+                             "AttachStderr": true,
+                             "AttachStdout": true, "OpenStdin": false,
+                             "StdinOnce": false,
+                             "NetworkDisabled": false,
+                             "HostConfig": {
+                                "CpuSetCpus": "0,1",
+                                "NetworkMode": "default"
+                             }}'''))
         self.assertEqual(args[1]['headers'],
                          {'Content-Type': 'application/json'})
 


### PR DESCRIPTION
This PR moves the `cpu_share` and `cpuset_cpus` options to `HostConfig`, per the Docker remote API >= 1.18.

Previously `cpu_share` and `cpuset` arguments were passed into `create_container` as kwargs. I've added an InvalidVersion exception there, when the API version is < 1.18 and these arguments are passed. I can't seem to find documentation for < 1.18 to know if this should be a warning instead?

I should also note I've renamed `cpuset` to `cpuset_cpus` to match the existing `container_update` functionality, which is already expecting these being in `HostConfig`. 

Related issues: #1030, docker/compose#3284, docker/swarm#1983