### PR TITLE
Remove references to "ExecutionDriver"

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -45,15 +45,6 @@ def untar_file(tardata, filename):
     return result
 
 
-def exec_driver_is_native():
-    global EXEC_DRIVER
-    if not EXEC_DRIVER:
-        c = docker_client()
-        EXEC_DRIVER = c.info()['ExecutionDriver']
-        c.close()
-    return EXEC_DRIVER.startswith('native') or EXEC_DRIVER == ''
-
-
 def docker_client(**kwargs):
     return docker.Client(**docker_client_kwargs(**kwargs))
 

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -159,9 +159,6 @@ class CreateContainerTest(helpers.BaseTestCase):
         self.assertCountEqual(info['HostConfig']['VolumesFrom'], vol_names)
 
     def create_container_readonly_fs(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         ctnr = self.client.create_container(
             BUSYBOX, ['mkdir', '/shrine'],
             host_config=self.client.create_host_config(
@@ -806,8 +803,7 @@ class KillTest(helpers.BaseTestCase):
         self.assertIn('State', container_info)
         state = container_info['State']
         self.assertIn('ExitCode', state)
-        if helpers.exec_driver_is_native():
-            self.assertNotEqual(state['ExitCode'], 0)
+        self.assertNotEqual(state['ExitCode'], 0)
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False)
 
@@ -821,8 +817,7 @@ class KillTest(helpers.BaseTestCase):
         self.assertIn('State', container_info)
         state = container_info['State']
         self.assertIn('ExitCode', state)
-        if helpers.exec_driver_is_native():
-            self.assertNotEqual(state['ExitCode'], 0)
+        self.assertNotEqual(state['ExitCode'], 0)
         self.assertIn('Running', state)
         self.assertEqual(state['Running'], False)
 

--- a/tests/integration/exec_test.py
+++ b/tests/integration/exec_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from docker.utils.socket import next_frame_size
 from docker.utils.socket import read_exactly
 
@@ -10,9 +8,6 @@ BUSYBOX = helpers.BUSYBOX
 
 class ExecTest(helpers.BaseTestCase):
     def test_execute_command(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         id = container['Id']
@@ -26,9 +21,6 @@ class ExecTest(helpers.BaseTestCase):
         self.assertEqual(exec_log, b'hello\n')
 
     def test_exec_command_string(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         id = container['Id']
@@ -42,9 +34,6 @@ class ExecTest(helpers.BaseTestCase):
         self.assertEqual(exec_log, b'hello world\n')
 
     def test_exec_command_as_user(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         id = container['Id']
@@ -58,9 +47,6 @@ class ExecTest(helpers.BaseTestCase):
         self.assertEqual(exec_log, b'default\n')
 
     def test_exec_command_as_root(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         id = container['Id']
@@ -74,9 +60,6 @@ class ExecTest(helpers.BaseTestCase):
         self.assertEqual(exec_log, b'root\n')
 
     def test_exec_command_streaming(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         id = container['Id']
@@ -92,9 +75,6 @@ class ExecTest(helpers.BaseTestCase):
         self.assertEqual(res, b'hello\nworld\n')
 
     def test_exec_start_socket(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         container_id = container['Id']
@@ -116,9 +96,6 @@ class ExecTest(helpers.BaseTestCase):
         self.assertEqual(data.decode('utf-8'), line)
 
     def test_exec_inspect(self):
-        if not helpers.exec_driver_is_native():
-            pytest.skip('Exec driver not native')
-
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)
         id = container['Id']


### PR DESCRIPTION
Docker no longer has an `ExecutionDriver` as of Docker 1.11.
The field in the `docker info` API will not be present in 1.13.

Found this while working on docker/docker#25721

Signed-off-by: Brian Goff <cpuguy83@gmail.com>