### PR TITLE
Support version parameter in `Client.from_env`

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -114,7 +114,8 @@ class Client(
 
     @classmethod
     def from_env(cls, **kwargs):
-        return cls(**kwargs_from_env(**kwargs))
+        version = kwargs.pop('version', None)
+        return cls(version=version, **kwargs_from_env(**kwargs))
 
     def _retrieve_server_version(self):
         try:

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -25,6 +25,14 @@ class ClientTest(base.BaseTestCase):
         client = Client.from_env()
         self.assertEqual(client.base_url, "https://192.168.59.103:2376")
 
+    def test_from_env_with_version(self):
+        os.environ.update(DOCKER_HOST='tcp://192.168.59.103:2376',
+                          DOCKER_CERT_PATH=TEST_CERT_DIR,
+                          DOCKER_TLS_VERIFY='1')
+        client = Client.from_env(version='2.32')
+        self.assertEqual(client.base_url, "https://192.168.59.103:2376")
+        self.assertEqual(client._version, '2.32')
+
 
 class DisableSocketTest(base.BaseTestCase):
     class DummySocket(object):


### PR DESCRIPTION
Fixes #1075 