### PR TITLE
Allow custom PID mode for the container

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -668,9 +668,7 @@ def create_host_config(binds=None, port_bindings=None, lxc_conf=None,
 
         host_config['ShmSize'] = shm_size
 
-    if pid_mode not in (None, 'host'):
-        raise host_config_value_error('pid_mode', pid_mode)
-    elif pid_mode:
+    if pid_mode:
         host_config['PidMode'] = pid_mode
 
     if ipc_mode:

--- a/docs/hostconfig.md
+++ b/docs/hostconfig.md
@@ -90,8 +90,7 @@ for example:
 * cap_drop (list of str): Drop kernel capabilities
 * extra_hosts (dict): custom host-to-IP mappings (host:ip)
 * read_only (bool): mount the container's root filesystem as read only
-* pid_mode (str): if set to "host", use the host PID namespace inside the
-  container
+* pid_mode (str): Set the PID namespace for the container
 * ipc_mode (str): Set the IPC mode for the container
 * security_opt (list): A list of string values to customize labels for MLS
   systems, such as SELinux.

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -365,9 +365,6 @@ class CreateContainerTest(helpers.BaseTestCase):
         self.assertRaises(TypeError,
                           self.client.create_host_config, mem_swappiness='40')
 
-        self.assertRaises(ValueError,
-                          self.client.create_host_config, pid_mode='40')
-
     def test_create_with_environment_variable_no_value(self):
         container = self.client.create_container(
             BUSYBOX,


### PR DESCRIPTION
Docker added support for sharing PID namespaces with other containers
since version 1.12 (see https://github.com/docker/docker/pull/22481).

This removes limitation to `host` only option.

Signed-off-by: Stepan Stipl stepan@stipl.net
