### PR TITLE
Fix Mount bind type sanity check

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -80,7 +80,7 @@ class Mount(dict):
                 self['BindOptions'] = {
                     'Propagation': propagation
                 }
-            if any(labels, driver_config, no_copy):
+            if any([labels, driver_config, no_copy]):
                 raise errors.DockerError(
                     'Mount type is binding but volume options have been '
                     'provided.'


### PR DESCRIPTION
any() expects a single collection argument, not a list of arguments.