### PR TITLE
Re-add docker.utils.types module for backwards compatibility

### DIFF
--- a/docker/utils/types.py
+++ b/docker/utils/types.py
@@ -1,0 +1,7 @@
+# Compatibility module. See https://github.com/docker/docker-py/issues/1196
+
+import warnings
+
+from ..types import Ulimit, LogConfig  # flake8: noqa
+
+warnings.warn('docker.utils.types is now docker.types', ImportWarning)


### PR DESCRIPTION
Fixes #1196 