### PR TITLE
1.10.1 release

### DIFF
--- a/docker/utils/types.py
+++ b/docker/utils/types.py
@@ -1,0 +1,7 @@
+# Compatibility module. See https://github.com/docker/docker-py/issues/1196
+
+import warnings
+
+from ..types import Ulimit, LogConfig  # flake8: noqa
+
+warnings.warn('docker.utils.types is now docker.types', ImportWarning)

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "1.10.0"
+version = "1.10.1"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+1.10.1
+------
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/issues?q=milestone%3A1.10.0+is%3Aclosed)
+
+### Bugfixes
+
+* The docker.utils.types module was removed in favor of docker.types, but some
+  applications imported it explicitly. It has been re-added with an import
+  warning advising to use the new module path.
+
 1.10.0
 ------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = 1
 
 [metadata]
-description_file = README.md
+description_file = README.rst


### PR DESCRIPTION
[List of PRs / issues for this release](https://github.com/docker/docker-py/issues?q=milestone%3A1.10.0+is%3Aclosed)

### Bugfixes

* The docker.utils.types module was removed in favor of docker.types, but some
  applications imported it explicitly. It has been re-added with an import
  warning advising to use the new module path.