### PR TITLE
Ignore not in swarm error when force leaving

### DIFF
--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -1,5 +1,6 @@
-from .. import utils
 import logging
+from six.moves import http_client
+from .. import utils
 log = logging.getLogger(__name__)
 
 
@@ -53,6 +54,9 @@ class SwarmApiMixin(object):
     def leave_swarm(self, force=False):
         url = self._url('/swarm/leave')
         response = self._post(url, params={'force': force})
+        # Ignore "this node is not part of a swarm" error
+        if force and response.status_code == http_client.NOT_ACCEPTABLE:
+            return True
         self._raise_for_status(response)
         return True
 

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -12,10 +12,7 @@ BUSYBOX = helpers.BUSYBOX
 class ServiceTest(helpers.BaseTestCase):
     def setUp(self):
         super(ServiceTest, self).setUp()
-        try:
-            self.client.leave_swarm(force=True)
-        except docker.errors.APIError:
-            pass
+        self.client.leave_swarm(force=True)
         self.client.init_swarm('eth0')
 
     def tearDown(self):
@@ -25,10 +22,7 @@ class ServiceTest(helpers.BaseTestCase):
                 self.client.remove_service(service['ID'])
             except docker.errors.APIError:
                 pass
-        try:
-            self.client.leave_swarm(force=True)
-        except docker.errors.APIError:
-            pass
+        self.client.leave_swarm(force=True)
 
     def get_service_name(self):
         return 'dockerpytest_{0:x}'.format(random.getrandbits(64))

--- a/tests/integration/swarm_test.py
+++ b/tests/integration/swarm_test.py
@@ -11,17 +11,11 @@ BUSYBOX = helpers.BUSYBOX
 class SwarmTest(helpers.BaseTestCase):
     def setUp(self):
         super(SwarmTest, self).setUp()
-        try:
-            self.client.leave_swarm(force=True)
-        except docker.errors.APIError:
-            pass
+        self.client.leave_swarm(force=True)
 
     def tearDown(self):
         super(SwarmTest, self).tearDown()
-        try:
-            self.client.leave_swarm(force=True)
-        except docker.errors.APIError:
-            pass
+        self.client.leave_swarm(force=True)
 
     @requires_api_version('1.24')
     def test_init_swarm_simple(self):
@@ -65,6 +59,7 @@ class SwarmTest(helpers.BaseTestCase):
         with pytest.raises(docker.errors.APIError) as exc_info:
             self.client.inspect_swarm()
         exc_info.value.response.status_code == 406
+        assert self.client.leave_swarm(force=True)
 
     @requires_api_version('1.24')
     def test_update_swarm(self):


### PR DESCRIPTION
Real errors were getting swallowed in these tests, producing
other confusing cascading errors. This makes it much easier to
make sure a node is not in a Swarm, while also handling other
errors correctly.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>