### PR TITLE
Move BaseTestCase to BaseIntegrationTest

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -108,8 +108,10 @@ class Client(
 
     @classmethod
     def from_env(cls, **kwargs):
+        timeout = kwargs.pop('timeout', None)
         version = kwargs.pop('version', None)
-        return cls(version=version, **kwargs_from_env(**kwargs))
+        return cls(timeout=timeout, version=version,
+                   **kwargs_from_env(**kwargs))
 
     def _retrieve_server_version(self):
         try:

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,7 @@
 import sys
 import unittest
 
-import pytest
 import six
-
-import docker
 
 
 class BaseTestCase(unittest.TestCase):
@@ -12,15 +9,6 @@ class BaseTestCase(unittest.TestCase):
         if six.PY2 and sys.version_info[1] <= 6:
             return self.assertTrue(object in collection)
         return super(BaseTestCase, self).assertIn(object, collection)
-
-
-def requires_api_version(version):
-    return pytest.mark.skipif(
-        docker.utils.version_lt(
-            docker.constants.DEFAULT_DOCKER_API_VERSION, version
-        ),
-        reason="API version is too low (< {0})".format(version)
-    )
 
 
 class Cleanup(object):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,15 +1,8 @@
 import os
 import os.path
-import shutil
 import tarfile
 import tempfile
-import unittest
 
-import docker
-import six
-
-BUSYBOX = 'busybox:buildroot-2014.02'
-EXEC_DRIVER = []
 
 
 def make_tree(dirs, files):
@@ -43,88 +36,3 @@ def untar_file(tardata, filename):
         result = f.read()
         f.close()
     return result
-
-
-def docker_client(**kwargs):
-    return docker.Client(**docker_client_kwargs(**kwargs))
-
-
-def docker_client_kwargs(**kwargs):
-    client_kwargs = docker.utils.kwargs_from_env(assert_hostname=False)
-    client_kwargs.update(kwargs)
-    return client_kwargs
-
-
-class BaseTestCase(unittest.TestCase):
-    tmp_imgs = []
-    tmp_containers = []
-    tmp_folders = []
-    tmp_volumes = []
-
-    def setUp(self):
-        if six.PY2:
-            self.assertRegex = self.assertRegexpMatches
-            self.assertCountEqual = self.assertItemsEqual
-        self.client = docker_client(timeout=60)
-        self.tmp_imgs = []
-        self.tmp_containers = []
-        self.tmp_folders = []
-        self.tmp_volumes = []
-        self.tmp_networks = []
-
-    def tearDown(self):
-        for img in self.tmp_imgs:
-            try:
-                self.client.remove_image(img)
-            except docker.errors.APIError:
-                pass
-        for container in self.tmp_containers:
-            try:
-                self.client.stop(container, timeout=1)
-                self.client.remove_container(container)
-            except docker.errors.APIError:
-                pass
-        for network in self.tmp_networks:
-            try:
-                self.client.remove_network(network)
-            except docker.errors.APIError:
-                pass
-        for folder in self.tmp_folders:
-            shutil.rmtree(folder)
-
-        for volume in self.tmp_volumes:
-            try:
-                self.client.remove_volume(volume)
-            except docker.errors.APIError:
-                pass
-
-        self.client.close()
-
-    def run_container(self, *args, **kwargs):
-        container = self.client.create_container(*args, **kwargs)
-        self.tmp_containers.append(container)
-        self.client.start(container)
-        exitcode = self.client.wait(container)
-
-        if exitcode != 0:
-            output = self.client.logs(container)
-            raise Exception(
-                "Container exited with code {}:\n{}"
-                .format(exitcode, output))
-
-        return container
-
-    def create_and_start(self, image='busybox', command='top', **kwargs):
-        container = self.client.create_container(
-            image=image, command=command, **kwargs)
-        self.tmp_containers.append(container)
-        self.client.start(container)
-        return container
-
-    def execute(self, container, cmd, exit_code=0, **kwargs):
-        exc = self.client.exec_create(container, cmd, **kwargs)
-        output = self.client.exec_start(exc)
-        actual_exit_code = self.client.exec_inspect(exc)['ExitCode']
-        msg = "Expected `{}` to exit with code {} but returned {}:\n{}".format(
-            " ".join(cmd), exit_code, actual_exit_code, output)
-        assert actual_exit_code == exit_code, msg

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,8 @@ import os.path
 import tarfile
 import tempfile
 
+import docker
+import pytest
 
 
 def make_tree(dirs, files):
@@ -36,3 +38,12 @@ def untar_file(tardata, filename):
         result = f.read()
         f.close()
     return result
+
+
+def requires_api_version(version):
+    return pytest.mark.skipif(
+        docker.utils.version_lt(
+            docker.constants.DEFAULT_DOCKER_API_VERSION, version
+        ),
+        reason="API version is too low (< {0})".format(version)
+    )

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -1,0 +1,88 @@
+import shutil
+import unittest
+
+import docker
+import six
+
+
+BUSYBOX = 'busybox:buildroot-2014.02'
+
+
+class BaseIntegrationTest(unittest.TestCase):
+    """
+    A base class for integration test cases.
+
+    It sets up a Docker client and cleans up the Docker server after itself.
+    """
+    tmp_imgs = []
+    tmp_containers = []
+    tmp_folders = []
+    tmp_volumes = []
+
+    def setUp(self):
+        if six.PY2:
+            self.assertRegex = self.assertRegexpMatches
+            self.assertCountEqual = self.assertItemsEqual
+        self.client = docker.from_env(timeout=60)
+        self.tmp_imgs = []
+        self.tmp_containers = []
+        self.tmp_folders = []
+        self.tmp_volumes = []
+        self.tmp_networks = []
+
+    def tearDown(self):
+        for img in self.tmp_imgs:
+            try:
+                self.client.remove_image(img)
+            except docker.errors.APIError:
+                pass
+        for container in self.tmp_containers:
+            try:
+                self.client.stop(container, timeout=1)
+                self.client.remove_container(container)
+            except docker.errors.APIError:
+                pass
+        for network in self.tmp_networks:
+            try:
+                self.client.remove_network(network)
+            except docker.errors.APIError:
+                pass
+        for folder in self.tmp_folders:
+            shutil.rmtree(folder)
+
+        for volume in self.tmp_volumes:
+            try:
+                self.client.remove_volume(volume)
+            except docker.errors.APIError:
+                pass
+
+        self.client.close()
+
+    def run_container(self, *args, **kwargs):
+        container = self.client.create_container(*args, **kwargs)
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        exitcode = self.client.wait(container)
+
+        if exitcode != 0:
+            output = self.client.logs(container)
+            raise Exception(
+                "Container exited with code {}:\n{}"
+                .format(exitcode, output))
+
+        return container
+
+    def create_and_start(self, image='busybox', command='top', **kwargs):
+        container = self.client.create_container(
+            image=image, command=command, **kwargs)
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        return container
+
+    def execute(self, container, cmd, exit_code=0, **kwargs):
+        exc = self.client.exec_create(container, cmd, **kwargs)
+        output = self.client.exec_start(exc)
+        actual_exit_code = self.client.exec_inspect(exc)['ExitCode']
+        msg = "Expected `{}` to exit with code {} but returned {}:\n{}".format(
+            " ".join(cmd), exit_code, actual_exit_code, output)
+        assert actual_exit_code == exit_code, msg

--- a/tests/integration/build_test.py
+++ b/tests/integration/build_test.py
@@ -8,11 +8,11 @@ import six
 
 from docker import errors
 
-from .. import helpers
 from ..base import requires_api_version
+from .base import BaseIntegrationTest
 
 
-class BuildTest(helpers.BaseTestCase):
+class BuildTest(BaseIntegrationTest):
     def test_build_streaming(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',

--- a/tests/integration/build_test.py
+++ b/tests/integration/build_test.py
@@ -8,7 +8,7 @@ import six
 
 from docker import errors
 
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .base import BaseIntegrationTest
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,14 +7,13 @@ import warnings
 import docker.errors
 import pytest
 
-from ..helpers import BUSYBOX
-from ..helpers import docker_client
+from .base import BUSYBOX
 
 
 @pytest.fixture(autouse=True, scope='session')
 def setup_test_session():
     warnings.simplefilter('error')
-    c = docker_client()
+    c = docker.from_env()
     try:
         c.inspect_image(BUSYBOX)
     except docker.errors.NotFound:

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -8,7 +8,7 @@ from docker.utils.socket import read_exactly
 import pytest
 import six
 
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .. import helpers
 from .base import BaseIntegrationTest, BUSYBOX
 

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -10,11 +10,10 @@ import six
 
 from ..base import requires_api_version
 from .. import helpers
+from .base import BaseIntegrationTest, BUSYBOX
 
-BUSYBOX = helpers.BUSYBOX
 
-
-class ListContainersTest(helpers.BaseTestCase):
+class ListContainersTest(BaseIntegrationTest):
     def test_list_containers(self):
         res0 = self.client.containers(all=True)
         size = len(res0)
@@ -34,7 +33,7 @@ class ListContainersTest(helpers.BaseTestCase):
         self.assertIn('Status', retrieved)
 
 
-class CreateContainerTest(helpers.BaseTestCase):
+class CreateContainerTest(BaseIntegrationTest):
 
     def test_create(self):
         res = self.client.create_container(BUSYBOX, 'true')
@@ -398,7 +397,7 @@ class CreateContainerTest(helpers.BaseTestCase):
         assert config['HostConfig']['Tmpfs'] == tmpfs
 
 
-class VolumeBindTest(helpers.BaseTestCase):
+class VolumeBindTest(BaseIntegrationTest):
     def setUp(self):
         super(VolumeBindTest, self).setUp()
 
@@ -487,7 +486,7 @@ class VolumeBindTest(helpers.BaseTestCase):
 
 
 @requires_api_version('1.20')
-class ArchiveTest(helpers.BaseTestCase):
+class ArchiveTest(BaseIntegrationTest):
     def test_get_file_archive_from_container(self):
         data = 'The Maid and the Pocket Watch of Blood'
         ctnr = self.client.create_container(
@@ -567,7 +566,7 @@ class ArchiveTest(helpers.BaseTestCase):
         self.assertIn('bar/', results)
 
 
-class RenameContainerTest(helpers.BaseTestCase):
+class RenameContainerTest(BaseIntegrationTest):
     def test_rename_container(self):
         version = self.client.version()['Version']
         name = 'hong_meiling'
@@ -583,7 +582,7 @@ class RenameContainerTest(helpers.BaseTestCase):
             self.assertEqual('/{0}'.format(name), inspect['Name'])
 
 
-class StartContainerTest(helpers.BaseTestCase):
+class StartContainerTest(BaseIntegrationTest):
     def test_start_container(self):
         res = self.client.create_container(BUSYBOX, 'true')
         self.assertIn('Id', res)
@@ -637,7 +636,7 @@ class StartContainerTest(helpers.BaseTestCase):
             self.assertEqual(exitcode, 0, msg=cmd)
 
 
-class WaitTest(helpers.BaseTestCase):
+class WaitTest(BaseIntegrationTest):
     def test_wait(self):
         res = self.client.create_container(BUSYBOX, ['sleep', '3'])
         id = res['Id']
@@ -665,7 +664,7 @@ class WaitTest(helpers.BaseTestCase):
         self.assertEqual(inspect['State']['ExitCode'], exitcode)
 
 
-class LogsTest(helpers.BaseTestCase):
+class LogsTest(BaseIntegrationTest):
     def test_logs(self):
         snippet = 'Flowering Nights (Sakuya Iyazoi)'
         container = self.client.create_container(
@@ -737,7 +736,7 @@ Line2'''
         self.assertEqual(logs, ''.encode(encoding='ascii'))
 
 
-class DiffTest(helpers.BaseTestCase):
+class DiffTest(BaseIntegrationTest):
     def test_diff(self):
         container = self.client.create_container(BUSYBOX, ['touch', '/test'])
         id = container['Id']
@@ -765,7 +764,7 @@ class DiffTest(helpers.BaseTestCase):
         self.assertEqual(test_diff[0]['Kind'], 1)
 
 
-class StopTest(helpers.BaseTestCase):
+class StopTest(BaseIntegrationTest):
     def test_stop(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -792,7 +791,7 @@ class StopTest(helpers.BaseTestCase):
         self.assertEqual(state['Running'], False)
 
 
-class KillTest(helpers.BaseTestCase):
+class KillTest(BaseIntegrationTest):
     def test_kill(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -868,7 +867,7 @@ class KillTest(helpers.BaseTestCase):
         self.assertEqual(state['Running'], False, state)
 
 
-class PortTest(helpers.BaseTestCase):
+class PortTest(BaseIntegrationTest):
     def test_port(self):
 
         port_bindings = {
@@ -899,7 +898,7 @@ class PortTest(helpers.BaseTestCase):
         self.client.kill(id)
 
 
-class ContainerTopTest(helpers.BaseTestCase):
+class ContainerTopTest(BaseIntegrationTest):
     def test_top(self):
         container = self.client.create_container(
             BUSYBOX, ['sleep', '60'])
@@ -934,7 +933,7 @@ class ContainerTopTest(helpers.BaseTestCase):
         self.client.kill(id)
 
 
-class RestartContainerTest(helpers.BaseTestCase):
+class RestartContainerTest(BaseIntegrationTest):
     def test_restart(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -975,7 +974,7 @@ class RestartContainerTest(helpers.BaseTestCase):
         self.client.kill(id)
 
 
-class RemoveContainerTest(helpers.BaseTestCase):
+class RemoveContainerTest(BaseIntegrationTest):
     def test_remove(self):
         container = self.client.create_container(BUSYBOX, ['true'])
         id = container['Id']
@@ -997,7 +996,7 @@ class RemoveContainerTest(helpers.BaseTestCase):
         self.assertEqual(len(res), 0)
 
 
-class AttachContainerTest(helpers.BaseTestCase):
+class AttachContainerTest(BaseIntegrationTest):
     def test_run_container_streaming(self):
         container = self.client.create_container(BUSYBOX, '/bin/sh',
                                                  detach=True, stdin_open=True)
@@ -1028,7 +1027,7 @@ class AttachContainerTest(helpers.BaseTestCase):
         self.assertEqual(data.decode('utf-8'), line)
 
 
-class PauseTest(helpers.BaseTestCase):
+class PauseTest(BaseIntegrationTest):
     def test_pause_unpause(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
@@ -1057,7 +1056,7 @@ class PauseTest(helpers.BaseTestCase):
         self.assertEqual(state['Paused'], False)
 
 
-class GetContainerStatsTest(helpers.BaseTestCase):
+class GetContainerStatsTest(BaseIntegrationTest):
     @requires_api_version('1.19')
     def test_get_container_stats_no_stream(self):
         container = self.client.create_container(
@@ -1088,7 +1087,7 @@ class GetContainerStatsTest(helpers.BaseTestCase):
                     self.assertIn(key, chunk)
 
 
-class ContainerUpdateTest(helpers.BaseTestCase):
+class ContainerUpdateTest(BaseIntegrationTest):
     @requires_api_version('1.22')
     def test_update_container(self):
         old_mem_limit = 400 * 1024 * 1024
@@ -1135,7 +1134,7 @@ class ContainerUpdateTest(helpers.BaseTestCase):
         )
 
 
-class ContainerCPUTest(helpers.BaseTestCase):
+class ContainerCPUTest(BaseIntegrationTest):
     @requires_api_version('1.18')
     def test_container_cpu_shares(self):
         cpu_shares = 512

--- a/tests/integration/errors_test.py
+++ b/tests/integration/errors_test.py
@@ -1,13 +1,10 @@
 from docker.errors import APIError
-from .. import helpers
+from .base import BaseIntegrationTest, BUSYBOX
 
 
-class ErrorsTest(helpers.BaseTestCase):
+class ErrorsTest(BaseIntegrationTest):
     def test_api_error_parses_json(self):
-        container = self.client.create_container(
-            helpers.BUSYBOX,
-            ['sleep', '10']
-        )
+        container = self.client.create_container(BUSYBOX, ['sleep', '10'])
         self.client.start(container['Id'])
         with self.assertRaises(APIError) as cm:
             self.client.remove_container(container['Id'])

--- a/tests/integration/exec_test.py
+++ b/tests/integration/exec_test.py
@@ -1,12 +1,10 @@
 from docker.utils.socket import next_frame_size
 from docker.utils.socket import read_exactly
 
-from .. import helpers
-
-BUSYBOX = helpers.BUSYBOX
+from .base import BaseIntegrationTest, BUSYBOX
 
 
-class ExecTest(helpers.BaseTestCase):
+class ExecTest(BaseIntegrationTest):
     def test_execute_command(self):
         container = self.client.create_container(BUSYBOX, 'cat',
                                                  detach=True, stdin_open=True)

--- a/tests/integration/image_test.py
+++ b/tests/integration/image_test.py
@@ -14,12 +14,10 @@ from six.moves import socketserver
 
 import docker
 
-from .. import helpers
-
-BUSYBOX = helpers.BUSYBOX
+from .base import BaseIntegrationTest, BUSYBOX
 
 
-class ListImagesTest(helpers.BaseTestCase):
+class ListImagesTest(BaseIntegrationTest):
     def test_images(self):
         res1 = self.client.images(all=True)
         self.assertIn('Id', res1[0])
@@ -37,7 +35,7 @@ class ListImagesTest(helpers.BaseTestCase):
         self.assertEqual(type(res1[0]), six.text_type)
 
 
-class PullImageTest(helpers.BaseTestCase):
+class PullImageTest(BaseIntegrationTest):
     def test_pull(self):
         try:
             self.client.remove_image('hello-world')
@@ -70,7 +68,7 @@ class PullImageTest(helpers.BaseTestCase):
         self.assertIn('Id', img_info)
 
 
-class CommitTest(helpers.BaseTestCase):
+class CommitTest(BaseIntegrationTest):
     def test_commit(self):
         container = self.client.create_container(BUSYBOX, ['touch', '/test'])
         id = container['Id']
@@ -105,7 +103,7 @@ class CommitTest(helpers.BaseTestCase):
         assert img['Config']['Cmd'] == ['bash']
 
 
-class RemoveImageTest(helpers.BaseTestCase):
+class RemoveImageTest(BaseIntegrationTest):
     def test_remove(self):
         container = self.client.create_container(BUSYBOX, ['touch', '/test'])
         id = container['Id']
@@ -121,7 +119,7 @@ class RemoveImageTest(helpers.BaseTestCase):
         self.assertEqual(len(res), 0)
 
 
-class ImportImageTest(helpers.BaseTestCase):
+class ImportImageTest(BaseIntegrationTest):
     '''Base class for `docker import` test cases.'''
 
     TAR_SIZE = 512 * 1024

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -5,7 +5,7 @@ from docker.utils import create_ipam_config
 from docker.utils import create_ipam_pool
 import pytest
 
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .base import BaseIntegrationTest
 
 

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -5,11 +5,11 @@ from docker.utils import create_ipam_config
 from docker.utils import create_ipam_pool
 import pytest
 
-from .. import helpers
 from ..base import requires_api_version
+from .base import BaseIntegrationTest
 
 
-class TestNetworks(helpers.BaseTestCase):
+class TestNetworks(BaseIntegrationTest):
     def create_network(self, *args, **kwargs):
         net_name = u'dockerpy{}'.format(random.getrandbits(24))[:14]
         net_id = self.client.create_network(net_name, *args, **kwargs)['Id']

--- a/tests/integration/regression_test.py
+++ b/tests/integration/regression_test.py
@@ -4,12 +4,10 @@ import random
 import docker
 import six
 
-from .. import helpers
-
-BUSYBOX = helpers.BUSYBOX
+from .base import BaseIntegrationTest, BUSYBOX
 
 
-class TestRegressions(helpers.BaseTestCase):
+class TestRegressions(BaseIntegrationTest):
     def test_443_handle_nonchunked_response_in_stream(self):
         dfile = io.BytesIO()
         with self.assertRaises(docker.errors.APIError) as exc:

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -3,13 +3,10 @@ import random
 import docker
 
 from ..base import requires_api_version
-from .. import helpers
+from .base import BaseIntegrationTest
 
 
-BUSYBOX = helpers.BUSYBOX
-
-
-class ServiceTest(helpers.BaseTestCase):
+class ServiceTest(BaseIntegrationTest):
     def setUp(self):
         super(ServiceTest, self).setUp()
         self.client.leave_swarm(force=True)

--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -2,7 +2,7 @@ import random
 
 import docker
 
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .base import BaseIntegrationTest
 
 

--- a/tests/integration/swarm_test.py
+++ b/tests/integration/swarm_test.py
@@ -2,13 +2,10 @@ import docker
 import pytest
 
 from ..base import requires_api_version
-from .. import helpers
+from .base import BaseIntegrationTest
 
 
-BUSYBOX = helpers.BUSYBOX
-
-
-class SwarmTest(helpers.BaseTestCase):
+class SwarmTest(BaseIntegrationTest):
     def setUp(self):
         super(SwarmTest, self).setUp()
         self.client.leave_swarm(force=True)

--- a/tests/integration/swarm_test.py
+++ b/tests/integration/swarm_test.py
@@ -1,7 +1,7 @@
 import docker
 import pytest
 
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .base import BaseIntegrationTest
 
 

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -1,8 +1,7 @@
 import docker
 import pytest
 
-from .. import helpers
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .base import BaseIntegrationTest
 
 

--- a/tests/integration/volume_test.py
+++ b/tests/integration/volume_test.py
@@ -3,10 +3,11 @@ import pytest
 
 from .. import helpers
 from ..base import requires_api_version
+from .base import BaseIntegrationTest
 
 
 @requires_api_version('1.21')
-class TestVolumes(helpers.BaseTestCase):
+class TestVolumes(BaseIntegrationTest):
     def test_create_volume(self):
         name = 'perfectcherryblossom'
         self.tmp_volumes.append(name)

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -9,7 +9,7 @@ import pytest
 import six
 
 from . import fake_api
-from ..base import requires_api_version
+from ..helpers import requires_api_version
 from .api_test import (
     DockerClientTest, url_prefix, fake_request, DEFAULT_TIMEOUT_SECONDS,
     fake_inspect_container

--- a/tests/unit/network_test.py
+++ b/tests/unit/network_test.py
@@ -2,7 +2,7 @@ import json
 
 import six
 
-from .. import base
+from ..helpers import requires_api_version
 from .api_test import DockerClientTest, url_prefix, response
 from docker.utils import create_ipam_config, create_ipam_pool
 
@@ -13,7 +13,7 @@ except ImportError:
 
 
 class NetworkTest(DockerClientTest):
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_list_networks(self):
         networks = [
             {
@@ -49,7 +49,7 @@ class NetworkTest(DockerClientTest):
             filters = json.loads(get.call_args[1]['params']['filters'])
             self.assertEqual(filters, {'id': ['123']})
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_create_network(self):
         network_data = {
             "id": 'abc12345',
@@ -104,7 +104,7 @@ class NetworkTest(DockerClientTest):
                     }
                 })
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_remove_network(self):
         network_id = 'abc12345'
         delete = mock.Mock(return_value=response(status_code=200))
@@ -116,7 +116,7 @@ class NetworkTest(DockerClientTest):
         self.assertEqual(args[0][0],
                          url_prefix + 'networks/{0}'.format(network_id))
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_inspect_network(self):
         network_id = 'abc12345'
         network_name = 'foo'
@@ -138,7 +138,7 @@ class NetworkTest(DockerClientTest):
         self.assertEqual(args[0][0],
                          url_prefix + 'networks/{0}'.format(network_id))
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_connect_container_to_network(self):
         network_id = 'abc12345'
         container_id = 'def45678'
@@ -167,7 +167,7 @@ class NetworkTest(DockerClientTest):
                 },
             })
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_disconnect_container_from_network(self):
         network_id = 'abc12345'
         container_id = 'def45678'

--- a/tests/unit/volume_test.py
+++ b/tests/unit/volume_test.py
@@ -2,12 +2,12 @@ import json
 
 import pytest
 
-from .. import base
+from ..helpers import requires_api_version
 from .api_test import DockerClientTest, url_prefix, fake_request
 
 
 class VolumeTest(DockerClientTest):
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_list_volumes(self):
         volumes = self.client.volumes()
         self.assertIn('Volumes', volumes)
@@ -17,7 +17,7 @@ class VolumeTest(DockerClientTest):
         self.assertEqual(args[0][0], 'GET')
         self.assertEqual(args[0][1], url_prefix + 'volumes')
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_list_volumes_and_filters(self):
         volumes = self.client.volumes(filters={'dangling': True})
         assert 'Volumes' in volumes
@@ -29,7 +29,7 @@ class VolumeTest(DockerClientTest):
         assert args[1] == {'params': {'filters': '{"dangling": ["true"]}'},
                            'timeout': 60}
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_create_volume(self):
         name = 'perfectcherryblossom'
         result = self.client.create_volume(name)
@@ -43,7 +43,7 @@ class VolumeTest(DockerClientTest):
         self.assertEqual(args[0][1], url_prefix + 'volumes/create')
         self.assertEqual(json.loads(args[1]['data']), {'Name': name})
 
-    @base.requires_api_version('1.23')
+    @requires_api_version('1.23')
     def test_create_volume_with_labels(self):
         name = 'perfectcherryblossom'
         result = self.client.create_volume(name, labels={
@@ -53,13 +53,13 @@ class VolumeTest(DockerClientTest):
             {'com.example.some-label': 'some-value'}
         )
 
-    @base.requires_api_version('1.23')
+    @requires_api_version('1.23')
     def test_create_volume_with_invalid_labels(self):
         name = 'perfectcherryblossom'
         with pytest.raises(TypeError):
             self.client.create_volume(name, labels=1)
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_create_volume_with_driver(self):
         name = 'perfectcherryblossom'
         driver_name = 'sshfs'
@@ -72,7 +72,7 @@ class VolumeTest(DockerClientTest):
         self.assertIn('Driver', data)
         self.assertEqual(data['Driver'], driver_name)
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_create_volume_invalid_opts_type(self):
         with pytest.raises(TypeError):
             self.client.create_volume(
@@ -89,7 +89,7 @@ class VolumeTest(DockerClientTest):
                 'perfectcherryblossom', driver_opts=''
             )
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_inspect_volume(self):
         name = 'perfectcherryblossom'
         result = self.client.inspect_volume(name)
@@ -102,7 +102,7 @@ class VolumeTest(DockerClientTest):
         self.assertEqual(args[0][0], 'GET')
         self.assertEqual(args[0][1], '{0}volumes/{1}'.format(url_prefix, name))
 
-    @base.requires_api_version('1.21')
+    @requires_api_version('1.21')
     def test_remove_volume(self):
         name = 'perfectcherryblossom'
         self.client.remove_volume(name)


### PR DESCRIPTION
Because two things called `BaseTestCase` is quite confusing. I haven't bothered refactoring the other `BaseTestCase` because that disappears anyway when we drop Python 2.6 support in #1192.