### PR TITLE
Add healthcheck to create-container

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -115,7 +115,8 @@ class ContainerApiMixin(object):
                          cpu_shares=None, working_dir=None, domainname=None,
                          memswap_limit=None, cpuset=None, host_config=None,
                          mac_address=None, labels=None, volume_driver=None,
-                         stop_signal=None, networking_config=None):
+                         stop_signal=None, networking_config=None,
+                         healthcheck=None):
 
         if isinstance(volumes, six.string_types):
             volumes = [volumes, ]
@@ -130,7 +131,7 @@ class ContainerApiMixin(object):
             tty, mem_limit, ports, environment, dns, volumes, volumes_from,
             network_disabled, entrypoint, cpu_shares, working_dir, domainname,
             memswap_limit, cpuset, host_config, mac_address, labels,
-            volume_driver, stop_signal, networking_config,
+            volume_driver, stop_signal, networking_config, healthcheck,
         )
         return self.create_container_from_config(config, name)
 

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -366,7 +366,7 @@ class ContainerApiMixin(object):
             cap_drop=cap_drop, volumes_from=volumes_from, devices=devices,
             network_mode=network_mode, restart_policy=restart_policy,
             extra_hosts=extra_hosts, read_only=read_only, pid_mode=pid_mode,
-            ipc_mode=ipc_mode, security_opt=security_opt, ulimits=ulimits
+            ipc_mode=ipc_mode, security_opt=security_opt, ulimits=ulimits,
         )
         start_config = None
 

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -4,4 +4,5 @@ from .services import (
     ContainerSpec, DriverConfig, Mount, Resources, RestartPolicy, TaskTemplate,
     UpdateConfig
 )
+from .healthcheck import Healthcheck
 from .swarm import SwarmSpec, SwarmExternalCA

--- a/docker/types/healthcheck.py
+++ b/docker/types/healthcheck.py
@@ -1,0 +1,47 @@
+from .base import DictType
+
+
+class Healthcheck(DictType):
+    def __init__(self, **kwargs):
+        test = kwargs.get('test', kwargs.get('Test'))
+        interval = kwargs.get('interval', kwargs.get('Interval'))
+        timeout = kwargs.get('timeout', kwargs.get('Timeout'))
+        retries = kwargs.get('retries', kwargs.get('Retries'))
+        super(Healthcheck, self).__init__({
+            'Test': test,
+            'Interval': interval,
+            'Timeout': timeout,
+            'Retries': retries
+        })
+
+    @property
+    def test(self):
+        return self['Test']
+
+    @test.setter
+    def test(self, value):
+        self['Test'] = value
+
+    @property
+    def interval(self):
+        return self['Interval']
+
+    @interval.setter
+    def interval(self, value):
+        self['Interval'] = value
+
+    @property
+    def timeout(self):
+        return self['Timeout']
+
+    @timeout.setter
+    def timeout(self, value):
+        self['Timeout'] = value
+
+    @property
+    def retries(self):
+        return self['Retries']
+
+    @retries.setter
+    def retries(self, value):
+        self['Retries'] = value

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -6,7 +6,6 @@ from .utils import (
     create_host_config, create_container_config, parse_bytes, ping_registry,
     parse_env_file, version_lt, version_gte, decode_json_header, split_command,
     create_ipam_config, create_ipam_pool, parse_devices, normalize_links,
-    create_healthcheck, create_healthcheck_test_from_command,
 )
 
 from ..types import LogConfig, Ulimit

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -6,6 +6,7 @@ from .utils import (
     create_host_config, create_container_config, parse_bytes, ping_registry,
     parse_env_file, version_lt, version_gte, decode_json_header, split_command,
     create_ipam_config, create_ipam_pool, parse_devices, normalize_links,
+    create_healthcheck, create_healthcheck_test_from_command,
 )
 
 from ..types import LogConfig, Ulimit

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -53,22 +53,6 @@ def create_ipam_config(driver='default', pool_configs=None):
     }
 
 
-def create_healthcheck(test=None, interval=None, timeout=None, retries=None):
-    return {
-        'Test': test,
-        'Interval': interval,
-        'Timeout': timeout,
-        'Retries': retries,
-    }
-
-
-def create_healthcheck_test_from_command(command=None):
-    return [
-        'CMD-SHELL',
-        command
-    ]
-
-
 def mkbuildcontext(dockerfile):
     f = tempfile.NamedTemporaryFile()
     t = tarfile.open(mode='w', fileobj=f)
@@ -1042,7 +1026,7 @@ def create_container_config(
             'stop_signal was only introduced in API version 1.21'
         )
 
-    if healthcheck is not None and compare_version('1.24', version) < 0:
+    if healthcheck is not None and version_lt(version, '1.24'):
         raise errors.InvalidVersion(
             'Health options were only introduced in API version 1.24'
         )

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -10,7 +10,6 @@ import warnings
 from distutils.version import StrictVersion
 from datetime import datetime
 from fnmatch import fnmatch
-from pytimeparse.timeparse import timeparse
 
 import requests
 import six
@@ -52,6 +51,22 @@ def create_ipam_config(driver='default', pool_configs=None):
         'Driver': driver,
         'Config': pool_configs or []
     }
+
+
+def create_healthcheck(test=None, interval=None, timeout=None, retries=None):
+    return {
+        'Test': test,
+        'Interval': interval,
+        'Timeout': timeout,
+        'Retries': retries,
+    }
+
+
+def create_healthcheck_test_from_command(command=None):
+    return [
+        'CMD-SHELL',
+        command
+    ]
 
 
 def mkbuildcontext(dockerfile):
@@ -990,8 +1005,6 @@ def format_environment(environment):
         return u'{key}={value}'.format(key=key, value=value)
     return [format_env(*var) for var in six.iteritems(environment)]
 
-def duration_from_string(duration_string):
-    return timeparse(duration_string) * 1000000000
 
 def create_container_config(
     version, image, command, hostname=None, user=None, detach=False,
@@ -1082,17 +1095,6 @@ def create_container_config(
         for vol in volumes:
             volumes_dict[vol] = {}
         volumes = volumes_dict
-
-    if isinstance(healthcheck, dict):
-        healthcheck = {
-            'Test': [
-                'CMD-SHELL',
-                healthcheck.get('command')
-            ],
-            'Interval': duration_from_string(healthcheck.get('interval')) if healthcheck.has_key('interval') else None,
-            'Timeout': duration_from_string(healthcheck.get('timeout')) if healthcheck.has_key('timeout') else None,
-            'Retries': healthcheck.get('retries')
-        }
 
     if volumes_from:
         if not isinstance(volumes_from, six.string_types):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests==2.5.3
 six>=1.4.0
-pytimeparse==1.1.5
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'
 ipaddress==1.0.16 ; python_version < '3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests==2.5.3
 six>=1.4.0
+pytimeparse==1.1.5
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'
 ipaddress==1.0.16 ; python_version < '3.3'

--- a/tests/integration/healthcheck_test.py
+++ b/tests/integration/healthcheck_test.py
@@ -1,0 +1,35 @@
+import time
+import docker
+
+from ..base import requires_api_version
+from .. import helpers
+
+
+class HealthcheckTest(helpers.BaseTestCase):
+
+    @requires_api_version('1.21')
+    def test_healthcheck(self):
+        healthcheck = docker.types.Healthcheck(
+            test=["CMD-SHELL",
+                  "foo.txt || (/bin/usleep 10000 && touch foo.txt)"],
+            interval=500000,
+            timeout=1000000000,
+            retries=1
+        )
+        container = self.client.create_container(helpers.BUSYBOX, 'cat',
+                                                 detach=True, stdin_open=True,
+                                                 healthcheck=healthcheck)
+        id = container['Id']
+        self.client.start(id)
+        self.tmp_containers.append(id)
+        res1 = self.client.inspect_container(id)
+        self.assertIn('State', res1)
+        self.assertIn('Health', res1['State'])
+        self.assertIn('Status', res1['State']['Health'])
+        self.assertEqual(res1['State']['Health']['Status'], "starting")
+        time.sleep(0.5)
+        res2 = self.client.inspect_container(id)
+        self.assertIn('State', res2)
+        self.assertIn('Health', res2['State'])
+        self.assertIn('Status', res2['State']['Health'])
+        self.assertEqual(res2['State']['Health']['Status'], "healthy")


### PR DESCRIPTION
Builds on work from PR #1152.  Differences include:
- Resolved the merge conflict
- pulled out the healthcheck into a separate file in docker/types
- added an integration test that exercises a healthcheck

I'm open to any suggestions to clean this up.
