### PR TITLE
1.10.3 release

### DIFF
--- a/docker/auth/auth.py
+++ b/docker/auth/auth.py
@@ -174,6 +174,15 @@ def parse_auth(entries, raise_on_error=False):
                     'Invalid configuration for registry {0}'.format(registry)
                 )
             return {}
+        if 'identitytoken' in entry:
+            log.debug('Found an IdentityToken entry for registry {0}'.format(
+                registry
+            ))
+            conf[registry] = {
+                'IdentityToken': entry['identitytoken']
+            }
+            continue  # Other values are irrelevant if we have a token, skip.
+
         if 'auth' not in entry:
             # Starting with engine v1.11 (API 1.23), an empty dictionary is
             # a valid value in the auths config.
@@ -182,13 +191,15 @@ def parse_auth(entries, raise_on_error=False):
                 'Auth data for {0} is absent. Client might be using a '
                 'credentials store instead.'
             )
-            return {}
+            conf[registry] = {}
+            continue
 
         username, password = decode_auth(entry['auth'])
         log.debug(
             'Found entry (registry={0}, username={1})'
             .format(repr(registry), repr(username))
         )
+
         conf[registry] = {
             'username': username,
             'password': password,

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -15,3 +15,4 @@ INSECURE_REGISTRY_DEPRECATION_WARNING = \
 IS_WINDOWS_PLATFORM = (sys.platform == 'win32')
 
 DEFAULT_USER_AGENT = "docker-py/{0}".format(version)
+DEFAULT_NUM_POOLS = 25

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -1,6 +1,7 @@
 import six
 import requests.adapters
 
+from .. import constants
 from .npipesocket import NpipeSocket
 
 if six.PY3:
@@ -33,9 +34,9 @@ class NpipeHTTPConnection(httplib.HTTPConnection, object):
 
 
 class NpipeHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
-    def __init__(self, npipe_path, timeout=60):
+    def __init__(self, npipe_path, timeout=60, maxsize=10):
         super(NpipeHTTPConnectionPool, self).__init__(
-            'localhost', timeout=timeout
+            'localhost', timeout=timeout, maxsize=maxsize
         )
         self.npipe_path = npipe_path
         self.timeout = timeout
@@ -47,11 +48,12 @@ class NpipeHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
 
 class NpipeAdapter(requests.adapters.HTTPAdapter):
-    def __init__(self, base_url, timeout=60):
+    def __init__(self, base_url, timeout=60,
+                 num_pools=constants.DEFAULT_NUM_POOLS):
         self.npipe_path = base_url.replace('npipe://', '')
         self.timeout = timeout
         self.pools = RecentlyUsedContainer(
-            10, dispose_func=lambda p: p.close()
+            num_pools, dispose_func=lambda p: p.close()
         )
         super(NpipeAdapter, self).__init__()
 

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "1.10.2"
+version = "1.10.3"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -1,6 +1,23 @@
 Change Log
 ==========
 
+1.10.3
+------
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/issues?q=milestone%3A1.10.3+is%3Aclosed)
+
+### Bugfixes
+
+* Fixed an issue where identity tokens in configuration files weren't handled
+  by the library.
+
+### Miscellaneous
+
+* Increased the default number of connection pools from 10 to 25. This number
+  can now be configured using the `num_pools` parameter in the `Client`
+  constructor.
+
+
 1.10.2
 ------
 

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -460,4 +460,28 @@ class LoadConfigTest(base.Cleanup, base.BaseTestCase):
             json.dump(config, f)
 
         cfg = auth.load_config(dockercfg_path)
-        assert cfg == {}
+        assert cfg == {'scarlet.net': {}}
+
+    def test_load_config_identity_token(self):
+        folder = tempfile.mkdtemp()
+        registry = 'scarlet.net'
+        token = '1ce1cebb-503e-7043-11aa-7feb8bd4a1ce'
+        self.addCleanup(shutil.rmtree, folder)
+        dockercfg_path = os.path.join(folder, 'config.json')
+        auth_entry = encode_auth({'username': 'sakuya'}).decode('ascii')
+        config = {
+            'auths': {
+                registry: {
+                    'auth': auth_entry,
+                    'identitytoken': token
+                }
+            }
+        }
+        with open(dockercfg_path, 'w') as f:
+            json.dump(config, f)
+
+        cfg = auth.load_config(dockercfg_path)
+        assert registry in cfg
+        cfg = cfg[registry]
+        assert 'IdentityToken' in cfg
+        assert cfg['IdentityToken'] == token


### PR DESCRIPTION
[List of PRs / issues for this release](https://github.com/docker/docker-py/issues?q=milestone%3A1.10.3+is%3Aclosed)

### Bugfixes

* Fixed an issue where identity tokens in configuration files weren't handled
  by the library.

### Miscellaneous

* Increased the default number of connection pools from 10 to 25. This number
  can now be configured using the `num_pools` parameter in the `Client`
  constructor.