### PR TITLE
~~remove~~ document ipaddress dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ if sys.platform == 'win32':
 
 extras_require = {
     ':python_version < "3.5"': 'backports.ssl_match_hostname >= 3.5',
+    # While not imported explicitly, the ipaddress module is required for
+    # ssl_match_hostname to verify hosts match with certificates via
+    # ServerAltname: https://pypi.python.org/pypi/backports.ssl_match_hostname
     ':python_version < "3.3"': 'ipaddress >= 1.0.16',
 }
 


### PR DESCRIPTION
EDIT: instead document it

~~as it's not being used anymore:~~

```
$ grep -R "import" . | grep "ipaddress"

$ grep -R "ipaddress" --exclude-dir .git .
./requirements.txt:ipaddress==1.0.16 ; python_version < '3.3'
./setup.py:    ':python_version < "3.3"': 'ipaddress >= 1.0.16',
```

~~it looks like it was used only in ssl_match_hostname module~~

```
git rev-list --all | xargs git grep ipaddress | grep import
d80e75f5eaca18c19257c13b91aae1a2493449d5:docker/ssladapter/ssl_match_hostname.py:import ipaddress
...
```