### PR TITLE
Fix documenation for parameter `domainname` in `create_container`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -228,6 +228,7 @@ arguments should be passed as part of the `host_config` dictionary.
 * image (str): The image to run
 * command (str or list): The command to be run in the container
 * hostname (str): Optional hostname for the container
+* domainname (str): Optional domain name to use for the container
 * user (str or int): Username or UID
 * detach (bool): Detached mode: run container in the background and print new
 container Id
@@ -247,7 +248,6 @@ from. Optionally a single string joining container id's with commas
 * name (str): A name for the container
 * entrypoint (str or list): An entrypoint
 * working_dir (str): Path to the working directory
-* domainname (str or list): Set custom DNS search domains
 * memswap_limit (int):
 * host_config (dict): A [HostConfig](hostconfig.md) dictionary
 * mac_address (str): The Mac Address to assign the container


### PR DESCRIPTION
Before it looked more like the description of the parameter `dns_search` which is correctly part of the host config. See https://docs.docker.com/engine/reference/api/docker_remote_api_v1.25/#/create-a-container for the original docker documentation for this parameter. 
