### PR TITLE
Synthesize execute permission bit

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import json
 import shlex
+import sys
 import tarfile
 import tempfile
 import warnings
@@ -92,7 +93,10 @@ def tar(path, exclude=None, dockerfile=None, fileobj=None, gzip=False):
     exclude = exclude or []
 
     for path in sorted(exclude_paths(root, exclude, dockerfile=dockerfile)):
-        t.add(os.path.join(root, path), arcname=path, recursive=False)
+        i = t.gettarinfo(os.path.join(root, path), arcname=path)
+        if sys.platform == 'win32':
+            i.mode = i.mode & 0o755 | 0o111
+        t.addfile(i)
 
     t.close()
     fileobj.seek(0)


### PR DESCRIPTION
This includes @seschwar's commit from #938 as well as a fix the empty file object that was causing tests to fail. Please let me know if there are any issues, thanks for maintaining this project!

Resolves #937 
Resolves #1206 

After this is merged, a version bump [here](https://github.com/docker/compose/blob/fc6791f3f0e3e8ae23d9b380398f39bea2e83101/requirements.txt#L4) and [here](https://github.com/docker/compose/blob/fc6791f3f0e3e8ae23d9b380398f39bea2e83101/setup.py#L37) should resolve docker/compose#3716.

---

It looks like this may depend on #1192, unless backward-compatibility with Python 2.6 is important. Backporting wouldn't be too difficult, but we'd have to add some complexity for wrangling the `IsADirectoryError` exception before we try to pass a file object with `TarFile.add()`. I can either rebase on top of d21feea or backport to Python 2.6, just let me know.