### PR TITLE
replace on_failure with on-failure

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -152,7 +152,7 @@ class UpdateConfig(dict):
 class RestartConditionTypesEnum(object):
     _values = (
         'none',
-        'on_failure',
+        'on-failure',
         'any',
     )
     NONE, ON_FAILURE, ANY = _values


### PR DESCRIPTION
According to docker docs and docker-py docs, it should be on-failure.

Signed-off-by:  徐俊杰<roollingstone@gmail.com>