### PR TITLE
Adjust test_create_network_with_ipam_config

### DIFF
--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -69,9 +69,9 @@ class TestNetworks(helpers.BaseTestCase):
 
         assert ipam.pop('Options', None) is None
 
-        assert ipam == {
-            'Driver': 'default',
-            'Config': [{
+        assert ipam['Driver'] == 'default'
+
+        assert ipam['Config'] == [{
                 'Subnet': "172.28.0.0/16",
                 'IPRange': "172.28.5.0/24",
                 'Gateway': "172.28.5.254",
@@ -80,8 +80,7 @@ class TestNetworks(helpers.BaseTestCase):
                     "b": "172.28.1.6",
                     "c": "172.28.1.7",
                 },
-            }],
-        }
+            }]
 
     @requires_api_version('1.21')
     def test_create_network_with_host_driver_fails(self):


### PR DESCRIPTION
This is related to the change in https://github.com/docker/docker/pull/26880
in which docker-py run as part of experimental CI cathes the API change.

IPAM now also includes `Data` besides `Config`, therefore the raw equality check can no longer be performed the way it was done before.

Signed-off-by: Alessandro Boch <aboch@docker.com>