### PR TITLE
Name is not required when creating a docker volume

### DIFF
--- a/docker/api/volume.py
+++ b/docker/api/volume.py
@@ -38,7 +38,8 @@ class VolumeApiMixin(object):
         return self._result(self._get(url, params=params), True)
 
     @utils.minimum_version('1.21')
-    def create_volume(self, name, driver=None, driver_opts=None, labels=None):
+    def create_volume(self, name=None, driver=None, driver_opts=None,
+                      labels=None):
         """
         Create and register a named volume
 


### PR DESCRIPTION
The name of a volume isn't required when creating. See: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.25/#/create-a-volume

```
JSON parameters:

    Name - The new volume’s name. If not specified, Docker generates a name.
    Driver - Name of the volume driver to use. Defaults to local for the name.
    DriverOpts - A mapping of driver options and values. These options are passed directly to the driver and are driver specific.
    Labels - Labels to set on the volume, specified as a map: {"key":"value","key2":"value2"}

```
