### PR TITLE
Support requests versions from 2.11.1 onwards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.5.3
+requests==2.11.1
 six>=1.4.0
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'requests >= 2.5.2, < 2.11',
+    'requests >= 2.5.2, != 2.11.0',
     'six >= 1.4.0',
     'websocket-client >= 0.32.0',
     'docker-pycreds >= 0.2.1'


### PR DESCRIPTION
Bug #1155 has been fixed starting with requests 2.11.1 and excluding it from dependencies causes failures when using latest versions of both libs together in our project.