### PR TITLE
Fix syntax in README required by RST

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The latest stable version is always available on PyPi.
     pip install docker-py
 
 Documentation
-------------
+-------------
 
 [![Documentation Status](https://readthedocs.org/projects/docker-py/badge/?version=latest)](https://readthedocs.org/projects/docker-py/?badge=latest)
 


### PR DESCRIPTION
Before the readme is converted to rst it required an extra character to convert with no errors. Signed-off-by: Matthew Egan <matthewj.egan@hotmail.com>

I believe this fixes #1221

This is my first commit to this repo, apologies in advance if I missed a convention.