### PR TITLE
do not assume that read will consume the number of bytes requested

### DIFF
--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -69,7 +69,11 @@ def frames_iter(socket):
     """
     Returns a generator of frames read from socket
     """
-    n = next_frame_size(socket)
-    while n > 0:
-        yield read(socket, n)
+    while True:
         n = next_frame_size(socket)
+        if n == 0:
+            break
+        while n > 0:
+            result = read(socket, n)
+            n -= len(result)
+            yield result


### PR DESCRIPTION
The issue is that `os.read` does not always read the expected number of
bytes, and thus we are moving to the next frame too early causing drift
in the byte stream. When the reading drifts, it starts reading garbage
as the next frame size. Some examples of frame sizes were
4032897957 bytes, etc. Values this large were causing the exceptions
from `os.read`.

fixes #1211

Signed-off-by: Michael Merickel michael@merickel.org
