### PR TITLE
Several fixes to npipe support

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -220,7 +220,9 @@ class Client(
 
     def _get_raw_response_socket(self, response):
         self._raise_for_status(response)
-        if six.PY3:
+        if self.base_url == "http+docker://localnpipe":
+            sock = response.raw._fp.fp.raw.sock
+        elif six.PY3:
             sock = response.raw._fp.fp.raw
             if self.base_url.startswith("https://"):
                 sock = sock._sock

--- a/docker/transport/__init__.py
+++ b/docker/transport/__init__.py
@@ -2,5 +2,6 @@
 from .unixconn import UnixAdapter
 try:
     from .npipeconn import NpipeAdapter
+    from .npipesocket import NpipeSocket
 except ImportError:
     pass

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -95,7 +95,7 @@ class NpipeSocket(object):
         if mode.strip('b') != 'r':
             raise NotImplementedError()
         rawio = NpipeFileIOBase(self)
-        if bufsize is None or bufsize < 0:
+        if bufsize is None or bufsize <= 0:
             bufsize = io.DEFAULT_BUFFER_SIZE
         return io.BufferedReader(rawio, buffer_size=bufsize)
 

--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -5,6 +5,11 @@ import struct
 
 import six
 
+try:
+    from ..transport import NpipeSocket
+except ImportError:
+    NpipeSocket = type(None)
+
 
 class SocketError(Exception):
     pass
@@ -14,10 +19,12 @@ def read(socket, n=4096):
     """
     Reads at most n bytes from socket
     """
+
     recoverable_errors = (errno.EINTR, errno.EDEADLK, errno.EWOULDBLOCK)
 
     # wait for data to become available
-    select.select([socket], [], [])
+    if not isinstance(socket, NpipeSocket):
+        select.select([socket], [], [])
 
     try:
         if hasattr(socket, 'recv'):


### PR DESCRIPTION
- Do not allow bufsize to be 0 in `NpipeSocket.makefile()`
- Fix `_get_raw_response_socket` to always return the `NpipeSocket` object
- Override `NpipeHTTPConnectionPool._get_conn` to avoid crash in urllib3
- Fix `NpipeSocket.recv_into` for Python 2
- Do not call `select()` on `NpipeSocket` objects