### PR TITLE
Win32 test fixes

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -209,8 +209,8 @@ def match_path(path, pattern):
     if pattern:
         pattern = os.path.relpath(pattern)
 
-    pattern_components = pattern.split('/')
-    path_components = path.split('/')[:len(pattern_components)]
+    pattern_components = pattern.split(os.path.sep)
+    path_components = path.split(os.path.sep)[:len(pattern_components)]
     return fnmatch('/'.join(path_components), pattern)
 
 

--- a/tests/integration/build_test.py
+++ b/tests/integration/build_test.py
@@ -1,5 +1,4 @@
 import io
-import json
 import os
 import shutil
 import tempfile
@@ -22,14 +21,11 @@ class BuildTest(BaseIntegrationTest):
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
             ' /tmp/silence.tar.gz'
         ]).encode('ascii'))
-        stream = self.client.build(fileobj=script, stream=True)
-        logs = ''
+        stream = self.client.build(fileobj=script, stream=True, decode=True)
+        logs = []
         for chunk in stream:
-            if six.PY3:
-                chunk = chunk.decode('utf-8')
-            json.loads(chunk)  # ensure chunk is a single, valid JSON blob
-            logs += chunk
-        self.assertNotEqual(logs, '')
+            logs.append(chunk)
+        assert len(logs) > 0
 
     def test_build_from_stringio(self):
         if six.PY3:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import json
 import sys
 import warnings
 
@@ -18,8 +17,7 @@ def setup_test_session():
         c.inspect_image(BUSYBOX)
     except docker.errors.NotFound:
         print("\npulling {0}".format(BUSYBOX), file=sys.stderr)
-        for data in c.pull(BUSYBOX, stream=True):
-            data = json.loads(data.decode('utf-8'))
+        for data in c.pull(BUSYBOX, stream=True, decode=True):
             status = data.get("status")
             progress = data.get("progress")
             detail = "{0} - {1}".format(status, progress)

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -3,6 +3,7 @@ import signal
 import tempfile
 
 import docker
+from docker.constants import IS_WINDOWS_PLATFORM
 from docker.utils.socket import next_frame_size
 from docker.utils.socket import read_exactly
 import pytest
@@ -523,13 +524,13 @@ class ArchiveTest(BaseIntegrationTest):
 
     def test_copy_file_to_container(self):
         data = b'Deaf To All But The Song'
-        with tempfile.NamedTemporaryFile() as test_file:
+        with tempfile.NamedTemporaryFile(delete=False) as test_file:
             test_file.write(data)
             test_file.seek(0)
             ctnr = self.client.create_container(
                 BUSYBOX,
                 'cat {0}'.format(
-                    os.path.join('/vol1', os.path.basename(test_file.name))
+                    os.path.join('/vol1/', os.path.basename(test_file.name))
                 ),
                 volumes=['/vol1']
             )
@@ -821,11 +822,12 @@ class KillTest(BaseIntegrationTest):
         self.assertEqual(state['Running'], False)
 
     def test_kill_with_signal(self):
-        container = self.client.create_container(BUSYBOX, ['sleep', '60'])
-        id = container['Id']
-        self.client.start(id)
+        id = self.client.create_container(BUSYBOX, ['sleep', '60'])
         self.tmp_containers.append(id)
-        self.client.kill(id, signal=signal.SIGKILL)
+        self.client.start(id)
+        self.client.kill(
+            id, signal=signal.SIGKILL if not IS_WINDOWS_PLATFORM else 9
+        )
         exitcode = self.client.wait(id)
         self.assertNotEqual(exitcode, 0)
         container_info = self.client.inspect_container(id)
@@ -901,28 +903,34 @@ class PortTest(BaseIntegrationTest):
 class ContainerTopTest(BaseIntegrationTest):
     def test_top(self):
         container = self.client.create_container(
-            BUSYBOX, ['sleep', '60'])
+            BUSYBOX, ['sleep', '60']
+        )
 
-        id = container['Id']
+        self.tmp_containers.append(container)
 
         self.client.start(container)
-        res = self.client.top(container['Id'])
-        self.assertEqual(
-            res['Titles'],
-            ['UID', 'PID', 'PPID', 'C', 'STIME', 'TTY', 'TIME', 'CMD']
-        )
-        self.assertEqual(len(res['Processes']), 1)
-        self.assertEqual(res['Processes'][0][7], 'sleep 60')
-        self.client.kill(id)
+        res = self.client.top(container)
+        if IS_WINDOWS_PLATFORM:
+            assert res['Titles'] == ['PID', 'USER', 'TIME', 'COMMAND']
+        else:
+            assert res['Titles'] == [
+                'UID', 'PID', 'PPID', 'C', 'STIME', 'TTY', 'TIME', 'CMD'
+            ]
+        assert len(res['Processes']) == 1
+        assert res['Processes'][0][-1] == 'sleep 60'
+        self.client.kill(container)
 
+    @pytest.mark.skipif(
+        IS_WINDOWS_PLATFORM, reason='No psargs support on windows'
+    )
     def test_top_with_psargs(self):
         container = self.client.create_container(
             BUSYBOX, ['sleep', '60'])
 
-        id = container['Id']
+        self.tmp_containers.append(container)
 
         self.client.start(container)
-        res = self.client.top(container['Id'], 'waux')
+        res = self.client.top(container, 'waux')
         self.assertEqual(
             res['Titles'],
             ['USER', 'PID', '%CPU', '%MEM', 'VSZ', 'RSS',
@@ -930,7 +938,6 @@ class ContainerTopTest(BaseIntegrationTest):
         )
         self.assertEqual(len(res['Processes']), 1)
         self.assertEqual(res['Processes'][0][10], 'sleep 60')
-        self.client.kill(id)
 
 
 class RestartContainerTest(BaseIntegrationTest):

--- a/tests/integration/container_test.py
+++ b/tests/integration/container_test.py
@@ -414,6 +414,9 @@ class VolumeBindTest(BaseIntegrationTest):
             ['touch', os.path.join(self.mount_dest, self.filename)],
         )
 
+    @pytest.mark.xfail(
+        IS_WINDOWS_PLATFORM, reason='Test not designed for Windows platform'
+    )
     def test_create_with_binds_rw(self):
 
         container = self.run_with_volume(
@@ -429,6 +432,9 @@ class VolumeBindTest(BaseIntegrationTest):
         inspect_data = self.client.inspect_container(container)
         self.check_container_data(inspect_data, True)
 
+    @pytest.mark.xfail(
+        IS_WINDOWS_PLATFORM, reason='Test not designed for Windows platform'
+    )
     def test_create_with_binds_ro(self):
         self.run_with_volume(
             False,

--- a/tests/integration/image_test.py
+++ b/tests/integration/image_test.py
@@ -55,12 +55,10 @@ class PullImageTest(BaseIntegrationTest):
             self.client.remove_image('hello-world')
         except docker.errors.APIError:
             pass
-        stream = self.client.pull('hello-world', stream=True)
+        stream = self.client.pull('hello-world', stream=True, decode=True)
         self.tmp_imgs.append('hello-world')
         for chunk in stream:
-            if six.PY3:
-                chunk = chunk.decode('utf-8')
-            json.loads(chunk)  # ensure chunk is a single, valid JSON blob
+            assert isinstance(chunk, dict)
         self.assertGreaterEqual(
             len(self.client.images('hello-world')), 1
         )
@@ -150,7 +148,7 @@ class ImportImageTest(BaseIntegrationTest):
     @contextlib.contextmanager
     def dummy_tar_file(self, n_bytes):
         '''Yields the name of a valid tar file of size n_bytes.'''
-        with tempfile.NamedTemporaryFile() as tar_file:
+        with tempfile.NamedTemporaryFile(delete=False) as tar_file:
             self.write_dummy_tar_content(n_bytes, tar_file)
             tar_file.seek(0)
             yield tar_file.name

--- a/tests/integration/network_test.py
+++ b/tests/integration/network_test.py
@@ -72,15 +72,15 @@ class TestNetworks(BaseIntegrationTest):
         assert ipam['Driver'] == 'default'
 
         assert ipam['Config'] == [{
-                'Subnet': "172.28.0.0/16",
-                'IPRange': "172.28.5.0/24",
-                'Gateway': "172.28.5.254",
-                'AuxiliaryAddresses': {
-                    "a": "172.28.1.5",
-                    "b": "172.28.1.6",
-                    "c": "172.28.1.7",
-                },
-            }]
+            'Subnet': "172.28.0.0/16",
+            'IPRange': "172.28.5.0/24",
+            'Gateway': "172.28.5.254",
+            'AuxiliaryAddresses': {
+                "a": "172.28.1.5",
+                "b": "172.28.1.6",
+                "c": "172.28.1.7",
+            },
+        }]
 
     @requires_api_version('1.21')
     def test_create_network_with_host_driver_fails(self):

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -86,7 +86,7 @@ def fake_delete(self, url, *args, **kwargs):
 def fake_read_from_socket(self, response, stream):
     return six.binary_type()
 
-url_base = 'http+docker://localunixsocket/'
+url_base = '{0}/'.format(fake_api.prefix)
 url_prefix = '{0}v{1}/'.format(
     url_base,
     docker.constants.DEFAULT_DOCKER_API_VERSION)
@@ -422,6 +422,9 @@ class StreamTest(base.Cleanup, base.BaseTestCase):
 
             data += connection.recv(2048)
 
+    @pytest.mark.skipif(
+        docker.constants.IS_WINDOWS_PLATFORM, reason='Unix only'
+    )
     def test_early_stream_response(self):
         self.request_handler = self.early_response_sending_handler
         lines = []

--- a/tests/unit/container_test.py
+++ b/tests/unit/container_test.py
@@ -270,8 +270,8 @@ class CreateContainerTest(DockerClientTest):
                          {'Content-Type': 'application/json'})
 
     def test_create_container_with_cpu_shares(self):
-        self.client.create_container('busybox', 'ls',
-                                     cpu_shares=5)
+        with pytest.deprecated_call():
+            self.client.create_container('busybox', 'ls', cpu_shares=5)
 
         args = fake_request.call_args
         self.assertEqual(args[0][1],
@@ -316,8 +316,8 @@ class CreateContainerTest(DockerClientTest):
                          {'Content-Type': 'application/json'})
 
     def test_create_container_with_cpuset(self):
-        self.client.create_container('busybox', 'ls',
-                                     cpuset='0,1')
+        with pytest.deprecated_call():
+            self.client.create_container('busybox', 'ls', cpuset='0,1')
 
         args = fake_request.call_args
         self.assertEqual(args[0][1],

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -408,6 +408,9 @@ def post_fake_update_container():
 
 # Maps real api url to fake response callback
 prefix = 'http+docker://localunixsocket'
+if constants.IS_WINDOWS_PLATFORM:
+    prefix = 'http+docker://localnpipe'
+
 fake_responses = {
     '{0}/version'.format(prefix):
     get_fake_raw_version,


### PR DESCRIPTION
This should let all but 2 tests (volume bindings integration tests) pass when running on WIndows 10 with Docker for Windows.