### PR TITLE
Requirements are aligned with compose repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.11.1
+requests==2.7.0
 six>=1.4.0
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'


### PR DESCRIPTION
This was made to avoid requests versions conflict during installation docker-compose and docker-py into the same venv
