### PR TITLE
Add labels and shmsize arguments to the image build

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -17,7 +17,8 @@ class BuildApiMixin(object):
               nocache=False, rm=False, stream=False, timeout=None,
               custom_context=False, encoding=None, pull=False,
               forcerm=False, dockerfile=None, container_limits=None,
-              decode=False, buildargs=None, gzip=False):
+              decode=False, buildargs=None, gzip=False, shmsize=None,
+              labels=None):
         remote = context = None
         headers = {}
         container_limits = container_limits or {}
@@ -86,6 +87,22 @@ class BuildApiMixin(object):
             else:
                 raise errors.InvalidVersion(
                     'buildargs was only introduced in API version 1.21'
+                )
+
+        if shmsize:
+            if utils.version_gte(self._version, '1.22'):
+                params.update({'shmsize': shmsize})
+            else:
+                raise errors.InvalidVersion(
+                    'shmsize was only introduced in API version 1.22'
+                )
+
+        if labels:
+            if utils.version_gte(self._version, '1.23'):
+                params.update({'labels': json.dumps(labels)})
+            else:
+                raise errors.InvalidVersion(
+                    'labels was only introduced in API version 1.23'
                 )
 
         if context is not None:

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,9 @@ correct value (e.g `gzip`).
     - cpusetcpus (str): CPUs in which to allow execution, e.g., `"0-3"`, `"0,1"`
 * decode (bool): If set to `True`, the returned stream will be decoded into
   dicts on the fly. Default `False`.
+* shmsize (int): Size of /dev/shm in bytes. The size must be greater 
+  than 0. If omitted the system uses 64MB.
+* labels (dict): A dictionary of labels to set on the image
 
 **Returns** (generator): A generator for the build output
 

--- a/tests/integration/build_test.py
+++ b/tests/integration/build_test.py
@@ -118,6 +118,44 @@ class BuildTest(BaseIntegrationTest):
         info = self.client.inspect_image('buildargs')
         self.assertEqual(info['Config']['User'], 'OK')
 
+    @requires_api_version('1.22')
+    def test_build_shmsize(self):
+        script = io.BytesIO('\n'.join([
+            'FROM scratch',
+            'CMD sh -c "echo \'Hello, World!\'"',
+        ]).encode('ascii'))
+
+        tag = 'shmsize'
+        shmsize = 134217728
+
+        stream = self.client.build(
+            fileobj=script, tag=tag, shmsize=shmsize
+        )
+        self.tmp_imgs.append(tag)
+        for chunk in stream:
+            pass
+
+        # There is currently no way to get the shmsize
+        # that was used to build the image
+
+    @requires_api_version('1.23')
+    def test_build_labels(self):
+        script = io.BytesIO('\n'.join([
+            'FROM scratch',
+        ]).encode('ascii'))
+
+        labels = {'test': 'OK'}
+
+        stream = self.client.build(
+            fileobj=script, tag='labels', labels=labels
+        )
+        self.tmp_imgs.append('labels')
+        for chunk in stream:
+            pass
+
+        info = self.client.inspect_image('labels')
+        self.assertEqual(info['Config']['Labels'], labels)
+
     def test_build_stderr_data(self):
         control_chars = ['\x1b[91m', '\x1b[0m']
         snippet = 'Ancient Temple (Mystic Oriental Dream ~ Ancient Temple)'


### PR DESCRIPTION
Closes #1262 

Allows labeling and setting the shmsize of built images.
