### PR TITLE
Changes for current docker-py to pass in docker master

### DIFF
--- a/tests/integration/service_test.py
+++ b/tests/integration/service_test.py
@@ -150,7 +150,10 @@ class ServiceTest(BaseIntegrationTest):
         )
         svc_info = self.client.inspect_service(svc_id)
         assert 'UpdateConfig' in svc_info['Spec']
-        assert update_config == svc_info['Spec']['UpdateConfig']
+        uc = svc_info['Spec']['UpdateConfig']
+        assert update_config['Parallelism'] == uc['Parallelism']
+        assert update_config['Delay'] == uc['Delay']
+        assert update_config['FailureAction'] == uc['FailureAction']
 
     def test_create_service_with_restart_policy(self):
         container_spec = docker.types.ContainerSpec('busybox', ['true'])
@@ -166,15 +169,3 @@ class ServiceTest(BaseIntegrationTest):
         svc_info = self.client.inspect_service(svc_id)
         assert 'RestartPolicy' in svc_info['Spec']['TaskTemplate']
         assert policy == svc_info['Spec']['TaskTemplate']['RestartPolicy']
-
-    def test_update_service_name(self):
-        name, svc_id = self.create_simple_service()
-        svc_info = self.client.inspect_service(svc_id)
-        svc_version = svc_info['Version']['Index']
-        new_name = self.get_service_name()
-        assert self.client.update_service(
-            svc_id, svc_version, name=new_name,
-            task_template=svc_info['Spec']['TaskTemplate']
-        )
-        svc_info = self.client.inspect_service(svc_id)
-        assert svc_info['Spec']['Name'] == new_name


### PR DESCRIPTION
- update config structure has new members
- service name update is no longer supported

Signed-off-by: Alessandro Boch <aboch@docker.com>

It fixes the following failures when running `make test-docker-py` on docker master with recent docker-py (https://github.com/docker/libnetwork/pull/1533 is also needed):

```
=================================== FAILURES ===================================
______________ ServiceTest.test_create_service_with_update_config ______________
/docker-py/tests/integration/service_test.py:153: in test_create_service_with_update_config
    assert update_config == svc_info['Spec']['UpdateConfig']
E   AssertionError: assert {'Delay': 5, ...ion': 'pause'} == {'Delay': 5, '...allelism': 10}
E     Omitting 3 identical items, use -v to show
E     Right contains more items:
E     {u'MaxFailureRatio': 0}
E     Use -v to get the full diff
_____________________ ServiceTest.test_update_service_name _____________________
/docker-py/tests/integration/service_test.py:175: in test_update_service_name
    assert self.client.update_service(
/docker-py/docker/utils/decorators.py:35: in wrapper
    return f(self, *args, **kwargs)
/docker-py/docker/utils/decorators.py:21: in wrapped
    return f(self, resource_id, *args, **kwargs)
/docker-py/docker/api/service.py:104: in update_service
    self._raise_for_status(resp)
/docker-py/docker/client.py:176: in _raise_for_status
    raise errors.APIError(e, response, explanation=explanation)
E   APIError: 500 Server Error: Internal Server Error ("rpc error: code = 2 desc = renaming services is not supported")
============== 2 failed, 149 passed, 2 skipped in 154.24 seconds ===============
```