### PR TITLE
1.10.6 release

### DIFF
--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -169,13 +169,16 @@ class NpipeSocket(object):
 
     def settimeout(self, value):
         if value is None:
-            self._timeout = win32pipe.NMPWAIT_NOWAIT
+            # Blocking mode
+            self._timeout = win32pipe.NMPWAIT_WAIT_FOREVER
         elif not isinstance(value, (float, int)) or value < 0:
             raise ValueError('Timeout value out of range')
         elif value == 0:
-            self._timeout = win32pipe.NMPWAIT_USE_DEFAULT_WAIT
+            # Non-blocking mode
+            self._timeout = win32pipe.NMPWAIT_NO_WAIT
         else:
-            self._timeout = value
+            # Timeout mode - Value converted to milliseconds
+            self._timeout = value * 1000
 
     def gettimeout(self):
         return self._timeout

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "1.10.5"
+version = "1.10.6"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -1,10 +1,21 @@
 Change Log
 ==========
 
+1.10.6
+------
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/26?closed=1)
+
+### Bugfixes
+
+* Fixed an issue where setting a `NpipeSocket` instance to blocking mode would
+  put it in non-blocking mode and vice-versa.
+
+
 1.10.5
 ------
 
-[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/24?closed=1)
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/25?closed=1)
 
 ### Bugfixes
 


### PR DESCRIPTION
1.10.6
------

[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/26?closed=1)

### Bugfixes

* Fixed an issue where setting a `NpipeSocket` instance to blocking mode would
  put it in non-blocking mode and vice-versa.