### PR TITLE
fix parsing environment files with newlines

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -1052,7 +1052,11 @@ def parse_env_file(env_file):
             if line[0] == '#':
                 continue
 
-            parse_line = line.strip().split('=', 1)
+            line = line.strip()
+            if not line:
+                continue
+
+            parse_line = line.split('=', 1)
             if len(parse_line) == 2:
                 k, v = parse_line
                 environment[k] = v

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -465,8 +465,16 @@ class ParseEnvFileTest(unittest.TestCase):
     def test_parse_env_file_commented_line(self):
         env_file = self.generate_tempfile(
             file_content='USER=jdoe\n#PASS=secret')
-        get_parse_env_file = parse_env_file((env_file))
+        get_parse_env_file = parse_env_file(env_file)
         self.assertEqual(get_parse_env_file, {'USER': 'jdoe'})
+        os.unlink(env_file)
+
+    def test_parse_env_file_newline(self):
+        env_file = self.generate_tempfile(
+            file_content='\nUSER=jdoe\n\n\nPASS=secret')
+        get_parse_env_file = parse_env_file(env_file)
+        self.assertEqual(get_parse_env_file,
+                         {'USER': 'jdoe', 'PASS': 'secret'})
         os.unlink(env_file)
 
     def test_parse_env_file_invalid_line(self):


### PR DESCRIPTION
This fixes an environment file that's only newlines and also a file with extra newlines. Complete with a test. I also tested that such a case would work natively with `docker run` and it does. Here's a complete re-creation:

```
# echo $'\n' > test.txt

# docker run --rm --env-file=test.txt alpine sh
[root@app-docker1 jcotton]# echo $?

# python
Python 2.6.6 (r266:84292, Nov 21 2013, 10:50:32)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import docker
>>> docker.__version__
'1.10.6'
>>> docker.utils.parse_env_file('/dev/null')
{}
>>> docker.utils.parse_env_file('test.txt')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.6/site-packages/docker/utils/utils.py", line 974, in parse_env_file
    env_file, line))
docker.errors.DockerException: Invalid line in environment file test.txt:


>>>
```