### PR TITLE
Fix linting error

### DIFF
--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -86,6 +86,7 @@ def fake_delete(self, url, *args, **kwargs):
 def fake_read_from_socket(self, response, stream):
     return six.binary_type()
 
+
 url_base = '{0}/'.format(fake_api.prefix)
 url_prefix = '{0}v{1}/'.format(
     url_base,


### PR DESCRIPTION
This seems to have been ignored by older versions of flake8, and fixed in version 3.1.0 or 3.1.1.