### PR TITLE
Show a helpful warning when people try to call `client.containers()`

### DIFF
--- a/docker/models/resource.py
+++ b/docker/models/resource.py
@@ -60,6 +60,12 @@ class Collection(object):
         #: is on.
         self.client = client
 
+    def __call__(self, *args, **kwargs):
+        raise TypeError(
+            "'{}' object is not callable. You might be trying to use the old "
+            "(pre-2.0) API - use docker.APIClient if so."
+            .format(self.__class__.__name__))
+
     def list(self):
         raise NotImplementedError
 

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1,5 +1,6 @@
 import datetime
 import docker
+from docker.utils import kwargs_from_env
 import os
 import unittest
 
@@ -58,6 +59,16 @@ class ClientTest(unittest.TestCase):
         s = str(cm.exception)
         assert "'Client' object has no attribute 'abcdef'" in s
         assert "this method is now on the object APIClient" not in s
+
+    def test_call_containers(self):
+        client = docker.Client(**kwargs_from_env())
+
+        with self.assertRaises(TypeError) as cm:
+            client.containers()
+
+        s = str(cm.exception)
+        assert "'ContainerCollection' object is not callable" in s
+        assert "docker.APIClient" in s
 
 
 class FromEnvTest(unittest.TestCase):


### PR DESCRIPTION
People upgrading to docker-py 2.0 without being aware of the new client API will likely try to call the old `containers()` method. This adds a helpful warning telling them to use APIClient to get the old API.