### PR TITLE
Remove MAINTAINER from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:2.7
-MAINTAINER Joffrey F <joffrey@docker.com>
 
 RUN mkdir /home/docker-py
 WORKDIR /home/docker-py

--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,5 +1,4 @@
 FROM python:3.5
-MAINTAINER Joffrey F <joffrey@docker.com>
 
 RUN mkdir /home/docker-py
 WORKDIR /home/docker-py

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -15,7 +15,6 @@ class BuildTest(BaseAPIIntegrationTest):
     def test_build_streaming(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
@@ -32,7 +31,6 @@ class BuildTest(BaseAPIIntegrationTest):
             return
         script = io.StringIO(six.text_type('\n').join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
@@ -54,7 +52,6 @@ class BuildTest(BaseAPIIntegrationTest):
         with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
             f.write("\n".join([
                 'FROM busybox',
-                'MAINTAINER docker-py',
                 'ADD . /test',
             ]))
 
@@ -182,7 +179,6 @@ class BuildTest(BaseAPIIntegrationTest):
         with open(os.path.join(base_dir, 'Dockerfile'), 'w') as f:
             f.write("\n".join([
                 'FROM busybox',
-                'MAINTAINER docker-py',
                 'ADD . /test',
             ]))
 

--- a/tests/unit/api_build_test.py
+++ b/tests/unit/api_build_test.py
@@ -11,7 +11,6 @@ class BuildTest(BaseAPIClientTest):
     def test_build_container(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
@@ -23,7 +22,6 @@ class BuildTest(BaseAPIClientTest):
     def test_build_container_pull(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
@@ -35,7 +33,6 @@ class BuildTest(BaseAPIClientTest):
     def test_build_container_stream(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
@@ -47,7 +44,6 @@ class BuildTest(BaseAPIClientTest):
     def test_build_container_custom_context(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'
@@ -60,7 +56,6 @@ class BuildTest(BaseAPIClientTest):
     def test_build_container_custom_context_gzip(self):
         script = io.BytesIO('\n'.join([
             'FROM busybox',
-            'MAINTAINER docker-py',
             'RUN mkdir -p /tmp/test',
             'EXPOSE 8080',
             'ADD https://dl.dropboxusercontent.com/u/20637798/silence.tar.gz'


### PR DESCRIPTION
It was deprecated in https://github.com/docker/docker/pull/25466

(Sorry @shin- ;)

Signed-off-by: Ben Firshman <ben@firshman.co.uk>