### PR TITLE
Add docker.models to setup packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     long_description=long_description,
     url='https://github.com/docker/docker-py/',
     packages=[
-        'docker', 'docker.api', 'docker.models', 'docker.transport', 
+        'docker', 'docker.api', 'docker.models', 'docker.transport',
         'docker.types', 'docker.utils',
     ],
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setup(
     long_description=long_description,
     url='https://github.com/docker/docker-py/',
     packages=[
-        'docker', 'docker.api', 'docker.transport', 'docker.utils',
-        'docker.types',
+        'docker', 'docker.api', 'docker.models', 'docker.transport', 
+        'docker.types', 'docker.utils',
     ],
     install_requires=requirements,
     tests_require=test_requirements,


### PR DESCRIPTION
Add the docker.models module to the list of packages in setup.py. The
.models module was merged into docker-py in #1186 (1984f68).

Resolves #1311.