### PR TITLE
Keep README in ASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Warning:** This readme is for the development version of docker-py, which is significantly different to the stable version. [Documentation for the stable version is here.](https://docker-py.readthedocs.io/)
 
-A Python library for the Docker API. It lets you do anything the `docker` command does, but from within Python apps – run containers, manage containers, manage Swarms, etc.
+A Python library for the Docker API. It lets you do anything the `docker` command does, but from within Python apps - run containers, manage containers, manage Swarms, etc.
 
 ## Installation
 


### PR DESCRIPTION
This avoids Python3 build errors when ran as non-UTF8 locale (C locale):

```
+ python3 setup.py build '--build-base=build-3'
Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    long_description = readme_rst.read()
  File "/usr/lib64/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 152: ordinal not in range(128)
```