### PR TITLE
Start to rename docker-py to docker-sdk-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM python:2.7
 MAINTAINER Joffrey F <joffrey@docker.com>
 
-RUN mkdir /home/docker-py
-WORKDIR /home/docker-py
+RUN mkdir /src
+WORKDIR /src
 
-COPY requirements.txt /home/docker-py/requirements.txt
+COPY requirements.txt /src/requirements.txt
 RUN pip install -r requirements.txt
 
-COPY test-requirements.txt /home/docker-py/test-requirements.txt
+COPY test-requirements.txt /src/test-requirements.txt
 RUN pip install -r test-requirements.txt
 
-COPY . /home/docker-py
+COPY . /src
 RUN pip install .

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -1,12 +1,12 @@
 FROM python:3.5
 
-RUN mkdir /home/docker-py
-WORKDIR /home/docker-py
+RUN mkdir /src
+WORKDIR /src
 
-COPY requirements.txt /home/docker-py/requirements.txt
+COPY requirements.txt /src/requirements.txt
 RUN pip install -r requirements.txt
 
-COPY docs-requirements.txt /home/docker-py/docs-requirements.txt
+COPY docs-requirements.txt /src/docs-requirements.txt
 RUN pip install -r docs-requirements.txt
 
-COPY . /home/docker-py
+COPY . /src

--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,14 +1,14 @@
 FROM python:3.5
 MAINTAINER Joffrey F <joffrey@docker.com>
 
-RUN mkdir /home/docker-py
-WORKDIR /home/docker-py
+RUN mkdir /src
+WORKDIR /src
 
-COPY requirements.txt /home/docker-py/requirements.txt
+COPY requirements.txt /src/requirements.txt
 RUN pip install -r requirements.txt
 
-COPY test-requirements.txt /home/docker-py/test-requirements.txt
+COPY test-requirements.txt /src/test-requirements.txt
 RUN pip install -r test-requirements.txt
 
-COPY . /home/docker-py
+COPY . /src
 RUN pip install .

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,15 @@ clean:
 
 .PHONY: build
 build:
-	docker build -t docker-py .
+	docker build -t docker-sdk-python .
 
 .PHONY: build-py3
 build-py3:
-	docker build -t docker-py3 -f Dockerfile-py3 .
+	docker build -t docker-sdk-python3 -f Dockerfile-py3 .
 
 .PHONY: build-docs
 build-docs:
-	docker build -t docker-py-docs -f Dockerfile-docs .
+	docker build -t docker-sdk-python-docs -f Dockerfile-docs .
 
 .PHONY: build-dind-certs
 build-dind-certs:
@@ -27,28 +27,28 @@ test: flake8 unit-test unit-test-py3 integration-dind integration-dind-ssl
 
 .PHONY: unit-test
 unit-test: build
-	docker run --rm docker-py py.test tests/unit
+	docker run --rm docker-sdk-python py.test tests/unit
 
 .PHONY: unit-test-py3
 unit-test-py3: build-py3
-	docker run --rm docker-py3 py.test tests/unit
+	docker run --rm docker-sdk-python3 py.test tests/unit
 
 .PHONY: integration-test
 integration-test: build
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker-py py.test tests/integration/${file}
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python py.test tests/integration/${file}
 
 .PHONY: integration-test-py3
 integration-test-py3: build-py3
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker-py3 py.test tests/integration/${file}
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python3 py.test tests/integration/${file}
 
 .PHONY: integration-dind
 integration-dind: build build-py3
 	docker rm -vf dpy-dind || :
 	docker run -d --name dpy-dind --privileged dockerswarm/dind:1.12.0 docker daemon\
 		-H tcp://0.0.0.0:2375
-	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-py\
+	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-sdk-python\
 		py.test tests/integration
-	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-py3\
+	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-sdk-python3\
 		py.test tests/integration
 	docker rm -vf dpy-dind
 
@@ -62,20 +62,20 @@ integration-dind-ssl: build-dind-certs build build-py3
 		--tlskey=/certs/server-key.pem -H tcp://0.0.0.0:2375
 	docker run --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\
 		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs"\
-		--link=dpy-dind-ssl:docker docker-py py.test tests/integration
+		--link=dpy-dind-ssl:docker docker-sdk-python py.test tests/integration
 	docker run --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\
 		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs"\
-		--link=dpy-dind-ssl:docker docker-py3 py.test tests/integration
+		--link=dpy-dind-ssl:docker docker-sdk-python3 py.test tests/integration
 	docker rm -vf dpy-dind-ssl dpy-dind-certs
 
 .PHONY: flake8
 flake8: build
-	docker run --rm docker-py flake8 docker tests
+	docker run --rm docker-sdk-python flake8 docker tests
 
 .PHONY: docs
 docs: build-docs
-	docker run --rm -it -v `pwd`:/home/docker-py docker-py-docs sphinx-build docs ./_build
+	docker run --rm -it -v `pwd`:/code docker-sdk-python-docs sphinx-build docs ./_build
 
 .PHONY: shell
 shell: build
-	docker run -it -v /var/run/docker.sock:/var/run/docker.sock docker-py python
+	docker run -it -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python python

--- a/docker/__init__.py
+++ b/docker/__init__.py
@@ -4,4 +4,4 @@ from .client import Client, from_env
 from .version import version, version_info
 
 __version__ = version
-__title__ = 'docker-py'
+__title__ = 'docker'

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -145,8 +145,8 @@ class APIClient(
             warnings.warn(
                 'The minimum API version supported is {}, but you are using '
                 'version {}. It is recommended you either upgrade Docker '
-                'Engine or use an older version of docker-py.'.format(
-                    MINIMUM_DOCKER_API_VERSION, self._version)
+                'Engine or use an older version of Docker SDK for '
+                'Python.'.format(MINIMUM_DOCKER_API_VERSION, self._version)
             )
 
     def _retrieve_server_version(self):

--- a/docker/client.py
+++ b/docker/client.py
@@ -158,9 +158,9 @@ class Client(object):
         s = ["'Client' object has no attribute '{}'".format(name)]
         # If a user calls a method on APIClient, they
         if hasattr(APIClient, name):
-            s.append("In docker-py 2.0, this method is now on the object "
-                     "APIClient. See the low-level API section of the "
-                     "documentation for more details.".format(name))
+            s.append("In Docker SDK for Python 2.0, this method is now on the "
+                     "object APIClient. See the low-level API section of the "
+                     "documentation for more details.")
         raise AttributeError(' '.join(s))
 
 

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -15,5 +15,5 @@ INSECURE_REGISTRY_DEPRECATION_WARNING = \
 
 IS_WINDOWS_PLATFORM = (sys.platform == 'win32')
 
-DEFAULT_USER_AGENT = "docker-py/{0}".format(version)
+DEFAULT_USER_AGENT = "docker-sdk-python/{0}".format(version)
 DEFAULT_NUM_POOLS = 25

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -474,7 +474,7 @@ class UserAgentTest(unittest.TestCase):
 
         self.assertEqual(self.mock_send.call_count, 1)
         headers = self.mock_send.call_args[0][0].headers
-        expected = 'docker-py/%s' % docker.__version__
+        expected = 'docker-sdk-python/%s' % docker.__version__
         self.assertEqual(headers['User-Agent'], expected)
 
     def test_custom_user_agent(self):


### PR DESCRIPTION
Pretty much everything except renaming the GitHub repo and
documentation, which is not actually done yet. Nearer the release
we can do a search/replace for all that stuff.

Ref #1310

Signed-off-by: Ben Firshman <ben@firshman.co.uk>