### PR TITLE
Fix auth config path on Windows

### DIFF
--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -9,6 +9,9 @@ import shutil
 import tempfile
 import unittest
 
+from py.test import ensuretemp
+from pytest import mark
+
 from docker import auth, errors
 
 try:
@@ -267,6 +270,56 @@ class ResolveAuthTest(unittest.TestCase):
             ),
             None,
         )
+
+
+class FindConfigFileTest(unittest.TestCase):
+    def tmpdir(self, name):
+        tmpdir = ensuretemp(name)
+        self.addCleanup(tmpdir.remove)
+        return tmpdir
+
+    def test_find_config_fallback(self):
+        tmpdir = self.tmpdir('test_find_config_fallback')
+
+        with mock.patch.dict(os.environ, {'HOME': str(tmpdir)}):
+            assert auth.find_config_file() is None
+
+    def test_find_config_from_explicit_path(self):
+        tmpdir = self.tmpdir('test_find_config_from_explicit_path')
+        config_path = tmpdir.ensure('my-config-file.json')
+
+        assert auth.find_config_file(str(config_path)) == str(config_path)
+
+    def test_find_config_from_environment(self):
+        tmpdir = self.tmpdir('test_find_config_from_environment')
+        config_path = tmpdir.ensure('config.json')
+
+        with mock.patch.dict(os.environ, {'DOCKER_CONFIG': str(tmpdir)}):
+            assert auth.find_config_file() == str(config_path)
+
+    @mark.skipif("sys.platform == 'win32'")
+    def test_find_config_from_home_posix(self):
+        tmpdir = self.tmpdir('test_find_config_from_home_posix')
+        config_path = tmpdir.ensure('.docker', 'config.json')
+
+        with mock.patch.dict(os.environ, {'HOME': str(tmpdir)}):
+            assert auth.find_config_file() == str(config_path)
+
+    @mark.skipif("sys.platform == 'win32'")
+    def test_find_config_from_home_legacy_name(self):
+        tmpdir = self.tmpdir('test_find_config_from_home_legacy_name')
+        config_path = tmpdir.ensure('.dockercfg')
+
+        with mock.patch.dict(os.environ, {'HOME': str(tmpdir)}):
+            assert auth.find_config_file() == str(config_path)
+
+    @mark.skipif("sys.platform != 'win32'")
+    def test_find_config_from_home_windows(self):
+        tmpdir = self.tmpdir('test_find_config_from_home_windows')
+        config_path = tmpdir.ensure('.docker', 'config.json')
+
+        with mock.patch.dict(os.environ, {'USERPROFILE': str(tmpdir)}):
+            assert auth.find_config_file() == str(config_path)
 
 
 class LoadConfigTest(unittest.TestCase):


### PR DESCRIPTION
The Engine client looks *only* at the USERPROFILE environment variable
on Windows, so we should do that too.

Signed-off-by: Aanand Prasad <aanand.prasad@gmail.com>