### PR TITLE
Rename all meaningful occurrences of docker-py to docker-sdk-python

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing guidelines
 
 See the [Docker contributing guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md).
-The following is specific to docker-py.
+The following is specific to Docker SDK for Python.
 
 Thank you for your interest in the project. We look forward to your
 contribution. In order to make the process as fast and streamlined as possible,
@@ -10,13 +10,14 @@ here is a set of guidelines we recommend you follow.
 ## Reporting issues
 
 We do our best to ensure bugs don't creep up in our releases, but some may
-still slip through. If you encounter one while using docker-py, please create
-an issue [in the tracker](https://github.com/docker/docker-py/issues/new) with
+still slip through. If you encounter one while using the SDK, please
+create an issue
+[in the tracker](https://github.com/docker/docker-py/issues/new) with
 the following information:
 
-- docker-py version, docker version and python version
+- SDK version, Docker version and python version
 ```
-pip freeze | grep docker-py && python --version && docker version
+pip freeze | grep docker && python --version && docker version
 ```
 - OS, distribution and OS version
 - The issue you're encountering including a stacktrace if applicable
@@ -24,14 +25,14 @@ pip freeze | grep docker-py && python --version && docker version
 
 To save yourself time, please be sure to check our
 [documentation](https://docker-py.readthedocs.io/) and use the
-[search function](https://github.com/docker/docker-py/search) to find out if
-it has already been addressed, or is currently being looked at.
+[search function](https://github.com/docker/docker-py/search) to find
+out if it has already been addressed, or is currently being looked at.
 
 ## Submitting pull requests
 
 Do you have a fix for an existing issue, or want to add a new functionality
-to docker-py? We happily welcome pull requests. Here are a few tips to make
-the review process easier on both the maintainers and yourself.
+to the SDK? We happily welcome pull requests. Here are a few tips to
+make the review process easier on both the maintainers and yourself.
 
 ### 1. Sign your commits
 
@@ -87,11 +88,10 @@ to reach out and ask questions. We will do our best to answer and help out.
 
 ## Development environment
 
-If you're looking contribute to docker-py but are new to the project or Python,
-here are the steps to get you started.
+If you're looking contribute to Docker SDK for Python but are new to the
+project or Python, here are the steps to get you started.
 
-1. Fork [https://github.com/docker/docker-py](https://github.com/docker/docker-py)
-   to your username.
+1. Fork https://github.com/docker/docker-py to your username.
 2. Clone your forked repository locally with
   `git clone git@github.com:yourusername/docker-py.git`.
 3. Configure a
@@ -110,8 +110,7 @@ To get the source source code and run the unit tests, run:
 ```
 $ git clone git://github.com/docker/docker-py.git
 $ cd docker-py
-$ pip install tox
-$ tox
+$ make test
 ```
 
 ## Building the docs

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,4 @@
-# Docker-py maintainers file
+# Docker SDK for Python maintainers file
 #
 # This file describes who runs the docker/docker-py project and how.
 # This is a living document - if you see something out of date or missing, speak up!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Build Status](https://travis-ci.org/docker/docker-py.svg?branch=master)](https://travis-ci.org/docker/docker-py)
 
-**Warning:** This readme is for the development version of docker-py, which is significantly different to the stable version. [Documentation for the stable version is here.](https://docker-py.readthedocs.io/)
+**Warning:** This README is for the development version of the Docker SDK for
+Python, which is significantly different to the stable version.
+[Documentation for the stable version is here.](https://docker-py.readthedocs.io/)
 
 A Python library for the Docker Engine API. It lets you do anything the `docker` command does, but from within Python apps – run containers, manage containers, manage Swarms, etc.
 
@@ -10,7 +12,7 @@ A Python library for the Docker Engine API. It lets you do anything the `docker`
 
 The latest stable version [is available on PyPi](https://pypi.python.org/pypi/docker/). Either add `docker` to your `requirements.txt` file or install with pip:
 
-    pip install docker-py
+    pip install docker
 
 ## Usage
 

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -96,7 +96,7 @@ class NpipeAdapter(requests.adapters.HTTPAdapter):
         # doesn't have a hostname, like is the case when using a UNIX socket.
         # Since proxies are an irrelevant notion in the case of UNIX sockets
         # anyway, we simply return the path URL directly.
-        # See also: https://github.com/docker/docker-py/issues/811
+        # See also: https://github.com/docker/docker-sdk-python/issues/811
         return request.path_url
 
     def close(self):

--- a/docker/utils/json_stream.py
+++ b/docker/utils/json_stream.py
@@ -13,10 +13,11 @@ json_decoder = json.JSONDecoder()
 
 
 def stream_as_text(stream):
-    """Given a stream of bytes or text, if any of the items in the stream
+    """
+    Given a stream of bytes or text, if any of the items in the stream
     are bytes convert them to text.
-    This function can be removed once docker-py returns text streams instead
-    of byte streams.
+    This function can be removed once we return text streams
+    instead of byte streams.
     """
     for data in stream:
         if not isinstance(data, six.text_type):


### PR DESCRIPTION
## DO NOT MERGE

This should only be merged at release time, and once the GitHub repo has been renamed.
