### PR TITLE
Scope is added in volume after docker 1.12

### DIFF
--- a/docker/api/volume.py
+++ b/docker/api/volume.py
@@ -64,7 +64,8 @@ class VolumeApiMixin(object):
             {u'Driver': u'local',
              u'Labels': {u'key': u'value'},
              u'Mountpoint': u'/var/lib/docker/volumes/foobar/_data',
-             u'Name': u'foobar'}
+             u'Name': u'foobar',
+             u'Scope': u'local'}
 
         """
         url = self._url('/volumes/create')

--- a/tests/unit/api_volume_test.py
+++ b/tests/unit/api_volume_test.py
@@ -89,6 +89,16 @@ class VolumeTest(BaseAPIClientTest):
                 'perfectcherryblossom', driver_opts=''
             )
 
+    @requires_api_version('1.24')
+    def test_create_volume_with_no_specified_name(self):
+        result = self.client.create_volume(name=None)
+        self.assertIn('Name', result)
+        self.assertNotEqual(result['Name'], None)
+        self.assertIn('Driver', result)
+        self.assertEqual(result['Driver'], 'local')
+        self.assertIn('Scope', result)
+        self.assertEqual(result['Scope'], 'local')
+
     @requires_api_version('1.21')
     def test_inspect_volume(self):
         name = 'perfectcherryblossom'

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -389,11 +389,13 @@ def get_fake_volume_list():
             {
                 'Name': 'perfectcherryblossom',
                 'Driver': 'local',
-                'Mountpoint': '/var/lib/docker/volumes/perfectcherryblossom'
+                'Mountpoint': '/var/lib/docker/volumes/perfectcherryblossom',
+                'Scope': 'local'
             }, {
                 'Name': 'subterraneananimism',
                 'Driver': 'local',
-                'Mountpoint': '/var/lib/docker/volumes/subterraneananimism'
+                'Mountpoint': '/var/lib/docker/volumes/subterraneananimism',
+                'Scope': 'local'
             }
         ]
     }
@@ -408,7 +410,8 @@ def get_fake_volume():
         'Mountpoint': '/var/lib/docker/volumes/perfectcherryblossom',
         'Labels': {
             'com.example.some-label': 'some-value'
-        }
+        },
+        'Scope': 'local'
     }
     return status_code, response
 


### PR DESCRIPTION
volume scope is included after docker 1.12.

According to remote API 1.24, the return of creating volume is like below:

> HTTP/1.1 201 Created
Content-Type: application/json
{
  "Name": "tardis",
  "Driver": "custom",
  "Mountpoint": "/var/lib/docker/volumes/tardis",
  "Status": {
    "hello": "world"
  },
  "Labels": {
    "com.example.some-label": "some-value",
    "com.example.some-other-label": "some-other-value"
  },
  "Scope": "local"
}

