### PR TITLE
Change "Remote API" to "Engine API"

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -50,7 +50,7 @@ class APIClient(
         SwarmApiMixin,
         VolumeApiMixin):
     """
-    A low-level client for the Docker Remote API.
+    A low-level client for the Docker Engine API.
 
     Example:
 

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -108,7 +108,7 @@ class ContainerApiMixin(object):
             author (str): The name of the author
             changes (str): Dockerfile instructions to apply while committing
             conf (dict): The configuration for the container. See the
-                `Remote API documentation
+                `Engine API documentation
                 <https://docs.docker.com/reference/api/docker_remote_api/>`_
                 for full details.
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -78,7 +78,7 @@ class Container(Model):
             author (str): The name of the author
             changes (str): Dockerfile instructions to apply while committing
             conf (dict): The configuration for the container. See the
-                `Remote API documentation
+                `Engine API documentation
                 <https://docs.docker.com/reference/api/docker_remote_api/>`_
                 for full details.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ html_theme = 'alabaster'
 # documentation.
 #
 html_theme_options = {
-    'description': 'A Python library for the Docker Remote API',
+    'description': 'A Python library for the Docker Engine API',
     'fixed_sidebar': True,
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
 Docker SDK for Python
 =====================
 
-A Python library for the Docker Remote API. It lets you do anything the ``docker`` command does, but from within Python apps – run containers, manage containers, manage Swarms, etc.
+A Python library for the Docker Engine API. It lets you do anything the ``docker`` command does, but from within Python apps – run containers, manage containers, manage Swarms, etc.
 
-For more information about the Remote API, `see its documentation <https://docs.docker.com/engine/reference/api/docker_remote_api/>`_.
+For more information about the Engine API, `see its documentation <https://docs.docker.com/engine/reference/api/docker_remote_api/>`_.
 
 Installation
 ------------


### PR DESCRIPTION
This is currently inconsistent, but mostly called "Engine API".
For the release of Docker 1.13, this will be "Engine API" all
over the Engine documentation, too.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>