### PR TITLE
Return back something useful during load_image.

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -271,8 +271,8 @@ class ImageApiMixin(object):
         Args:
             data (binary): Image data to be loaded.
         """
-        res = self._post(self._url("/images/load"), data=data)
-        self._raise_for_status(res)
+        return self._result(
+            self._post(self._url("/images/load"), data=data))
 
     def pull(self, repository, tag=None, stream=False,
              insecure_registry=False, auth_config=None, decode=False):


### PR DESCRIPTION
In docker 1.12.0, During a `docker load` there will say something
useful back(https://github.com/docker/docker/pull/23377/commits).
In docker-py, this is also needed because I have lots of images
and after a recent docker load I had no idea what image
I just imported.

Signed-off-by: Zhengchuan.hu &lt;zhengchuan.hu@easystack.cn>