### PR TITLE
Add cpuset_mems to HostConfig

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -472,6 +472,8 @@ class ContainerApiMixin(object):
             cpu_shares (int): CPU shares (relative weight).
             cpuset_cpus (str): CPUs in which to allow execution (``0-3``,
                 ``0,1``).
+            cpuset_mems (str): MEMs in which to allow execution (``0-3``,
+                ``0,1``).
             device_read_bps: Limit read rate (bytes per second) from a device
                 in the form of: `[{"Path": "device_path", "Rate": rate}]`
             device_read_iops: Limit read rate (IO per second) from a device.

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -116,8 +116,8 @@ class HostConfig(dict):
                  device_read_iops=None, device_write_iops=None,
                  oom_kill_disable=False, shm_size=None, sysctls=None,
                  tmpfs=None, oom_score_adj=None, dns_opt=None, cpu_shares=None,
-                 cpuset_cpus=None, userns_mode=None, pids_limit=None,
-                 isolation=None):
+                 cpuset_cpus=None, cpuset_mems=None, userns_mode=None,
+                 pids_limit=None, isolation=None):
 
         if mem_limit is not None:
             self['Memory'] = parse_bytes(mem_limit)
@@ -325,6 +325,12 @@ class HostConfig(dict):
                 raise host_config_version_error('cpuset_cpus', '1.18')
 
             self['CpuSetCpus'] = cpuset_cpus
+
+        if cpuset_mems:
+            if version_lt(version, '1.19'):
+                raise host_config_version_error('cpuset_mems', '1.19')
+
+            self['CpuSetMems'] = cpuset_mems
 
         if blkio_weight:
             if not isinstance(blkio_weight, int):

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1166,7 +1166,7 @@ class ContainerCPUTest(BaseAPIIntegrationTest):
         self.assertEqual(inspect_data['HostConfig']['CpuShares'], 512)
 
     @requires_api_version('1.18')
-    def test_container_cpuset(self):
+    def test_container_cpuset_cpus(self):
         cpuset_cpus = "0,1"
         container = self.client.create_container(
             BUSYBOX, 'ls', host_config=self.client.create_host_config(
@@ -1177,3 +1177,16 @@ class ContainerCPUTest(BaseAPIIntegrationTest):
         self.client.start(container)
         inspect_data = self.client.inspect_container(container)
         self.assertEqual(inspect_data['HostConfig']['CpusetCpus'], cpuset_cpus)
+
+    @requires_api_version('1.19')
+    def test_container_cpuset_mems(self):
+        cpuset_mems = "0"
+        container = self.client.create_container(
+            BUSYBOX, 'ls', host_config=self.client.create_host_config(
+                cpuset_mems=cpuset_mems
+            )
+        )
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        inspect_data = self.client.inspect_container(container)
+        self.assertEqual(inspect_data['HostConfig']['CpuSetMems'], cpuset_mems)


### PR DESCRIPTION
I've noticed that Docker Remote API has CpusetMems option to /containers/create [here](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/create-a-container) since API version 1.19, but docker-py doesn't support it [here](https://github.com/docker/docker-py/blob/master/docker/types/containers.py#L103), however. Therefore, I add such an option in this PR.

Would be great if we can have this. 😄 