### PR TITLE
Fix readonly in mounts.

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -135,6 +135,7 @@ class Mount(dict):
                 'Only acceptable mount types are `bind` and `volume`.'
             )
         self['Type'] = type
+        self['ReadOnly'] = read_only
 
         if type == 'bind':
             if propagation is not None:
@@ -174,7 +175,7 @@ class Mount(dict):
         else:
             target = parts[1]
             source = parts[0]
-            read_only = not (len(parts) == 3 or parts[2] == 'ro')
+            read_only = not (len(parts) == 2 or parts[2] == 'rw')
             return cls(target, source, read_only=read_only)
 
 

--- a/tests/unit/types.py
+++ b/tests/unit/types.py
@@ -1,0 +1,16 @@
+import unittest
+from docker.types.services import Mount
+
+
+class TestMounts(unittest.TestCase):
+    def test_parse_mount_string_docker(self):
+        mount = Mount.parse_mount_string("foo/bar:/buz:ro")
+        self.assertEqual(mount['Source'], "foo/bar")
+        self.assertEqual(mount['Target'], "/buz")
+        self.assertEqual(mount['ReadOnly'], True)
+
+        mount = Mount.parse_mount_string("foo/bar:/buz:rw")
+        self.assertEqual(mount['ReadOnly'], False)
+
+        mount = Mount.parse_mount_string("foo/bar:/buz")
+        self.assertEqual(mount['ReadOnly'], False)


### PR DESCRIPTION
Fixes: #1371 - properly pass `ro` and `rw` to mount parameters for swarm services.

Signed-off-by: Dmitri Zimine <dz@stackstorm.com>