### PR TITLE
provide best practice for Image.save

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -62,10 +62,11 @@ class Image(Model):
 
         Example:
 
-            >>> image = cli.get("fedora:latest")
+            >>> image = cli.images.get("fedora:latest")
             >>> resp = image.save()
             >>> f = open('/tmp/fedora-latest.tar', 'w')
-            >>> f.write(resp.data)
+            >>> for chunk in resp.stream():
+            >>>     f.write(chunk)
             >>> f.close()
         """
         return self.client.api.get_image(self.id)


### PR DESCRIPTION
For issue https://github.com/docker/docker-py/issues/1352, actually docker-py already provide the streaming way to save an image, but maybe the docstring will misdirecting users.

Just provide the  best practice for `Image.save` in docstring.

Signed-off-by: realityone <realityone@me.com>