### PR TITLE
Add cacheFrom to build options

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -18,7 +18,7 @@ class BuildApiMixin(object):
               custom_context=False, encoding=None, pull=False,
               forcerm=False, dockerfile=None, container_limits=None,
               decode=False, buildargs=None, gzip=False, shmsize=None,
-              labels=None):
+              labels=None, cachefrom=None):
         """
         Similar to the ``docker build`` command. Either ``path`` or ``fileobj``
         needs to be set. ``path`` can be a local path (to a directory
@@ -92,6 +92,7 @@ class BuildApiMixin(object):
             shmsize (int): Size of `/dev/shm` in bytes. The size must be
                 greater than 0. If omitted the system uses 64MB.
             labels (dict): A dictionary of labels to set on the image.
+            cachefrom (list): A list of images used for build cache resolution.
 
         Returns:
             A generator for the build output.
@@ -186,6 +187,14 @@ class BuildApiMixin(object):
             else:
                 raise errors.InvalidVersion(
                     'labels was only introduced in API version 1.23'
+                )
+
+        if cachefrom:
+            if utils.version_gte(self._version, '1.25'):
+                params.update({'cachefrom': json.dumps(cachefrom)})
+            else:
+                raise errors.InvalidVersion(
+                    'cachefrom was only introduced in API version 1.25'
                 )
 
         if context is not None:

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -153,6 +153,24 @@ class BuildTest(BaseAPIIntegrationTest):
         info = self.client.inspect_image('labels')
         self.assertEqual(info['Config']['Labels'], labels)
 
+    @requires_api_version('1.25')
+    def test_build_cachefrom(self):
+        script = io.BytesIO('\n'.join([
+            'FROM scratch',
+        ]).encode('ascii'))
+
+        cachefrom = ['build1']
+
+        stream = self.client.build(
+            fileobj=script, tag='cachefrom', cachefrom=cachefrom
+        )
+        self.tmp_imgs.append('cachefrom')
+        for chunk in stream:
+            pass
+
+        info = self.client.inspect_image('cachefrom')
+        self.assertEqual(info['Config']['CacheFrom'], cachefrom)
+
     def test_build_stderr_data(self):
         control_chars = ['\x1b[91m', '\x1b[0m']
         snippet = 'Ancient Temple (Mystic Oriental Dream ~ Ancient Temple)'


### PR DESCRIPTION
This adds the cache-from build option (https://github.com/docker/docker/pull/26839) and fixes #1382.