### PR TITLE
Add support for service mount syntax.

### DIFF
--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -101,9 +101,11 @@ class ServiceCollection(Collection):
             log_driver_options (dict): Log driver options.
             mode (string): Scheduling mode for the service (``replicated`` or
                 ``global``). Defaults to ``replicated``.
-            mounts (list of str): Mounts for the containers, in the form
-                ``source:target:options``, where options is either
-                ``ro`` or ``rw``.
+            mounts (list of str): Mounts for the containers. Use either
+                ``docker service create --mount`` form
+                ``type=type,source=source,target=target,option=value,...``,
+                or `docker run --volume` form ``source:target:options``,
+                where options are either ``ro`` or ``rw``.
             name (str): Name to give to the service.
             networks (list): List of network names or IDs to attach the
                 service to. Default: ``None``.

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -226,10 +226,11 @@ class Mount(dict):
                     mount_kwargs.setdefault('labels', {}).update({k: v})
 
             if not (target and source):
-                raise SyntaxError("`target` and `source` are required fields.")
+                raise errors.InvalidArgument(
+                    "`target` and `source` are required fields.")
 
         except Exception as e:
-            raise SyntaxError(
+            raise errors.InvalidArgument(
                 "Invalid mount format {0}\n{1}".format(string, e))
 
         return cls(target, source, **mount_kwargs)

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -266,11 +266,13 @@ class TestMounts(unittest.TestCase):
         assert mount['Source'] == "/foo/bar"
         assert mount['Target'] == "/baz"
         assert mount['ReadOnly'] is True
+        assert mount['Type'] == 'bind'
 
     def test_parse_mount_string_rw(self):
         mount = Mount.parse_mount_string("/foo/bar:/baz:rw")
         assert mount['Source'] == "/foo/bar"
         assert mount['Target'] == "/baz"
+        assert mount['Type'] == 'bind'
         assert not mount['ReadOnly']
 
     def test_parse_mount_string_short_form(self):
@@ -339,6 +341,14 @@ class TestServiceMounts(unittest.TestCase):
         self.assertDictEqual(
             mount['VolumeOptions']['Labels'],
             {'color1': 'red', 'color2': 'blue'})
+
+    def test_parse_mount_string_invalid_format(self):
+        with pytest.raises(InvalidArgument):
+            Mount.parse_mount_string("type=bind,foo=bar=buz")
+
+    def test_parse_mount_string_missing_mandatory_params(self):
+        with pytest.raises(InvalidArgument):
+            Mount.parse_mount_string("type=bind,src=/foo/bar")
 
     @pytest.mark.xfail
     def test_parse_mount_bind_windows(self):

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -333,7 +333,6 @@ class TestServiceMounts(unittest.TestCase):
         mount = Mount.parse_mount_string(
             "src=/foo/bar,dst=/abc/xyz,ro,volume-label=color1=red,"
             "volume-label='color2=blue'")
-        print mount
         self.assertEqual(mount['Source'], '/foo/bar')
         self.assertEqual(mount['Target'], '/abc/xyz')
         self.assertEqual(mount['ReadOnly'], True)


### PR DESCRIPTION
Docker `service create` offers [new, reacher syntax](https://docs.docker.com/engine/reference/commandline/service_create/#/add-bind-mounts-or-volumes) for defining mounts and volumes. But `client.services.create` only takes [the "old" `docker run` syntax for volumes](https://docs.docker.com/engine/tutorials/dockervolumes), which, btw, is not supported by `service create` command. Let's fix the confusion and offer the new syntax alongside with the old one.

TODO: 
- [x] Implementation and base unit tests
- [x] Add negative unit tests
- [x] Update docs

If you're OK with the idea, say so; I'll complete PR + address any comments.

Signed-off-by: Dmitri Zimine <dz@stackstorm.com>