### PR TITLE
allow ipv6 :: notation in split_port

### DIFF
--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -1,4 +1,7 @@
 
+import re
+
+
 def add_port_mapping(port_bindings, internal_port, external):
     if internal_port in port_bindings:
         port_bindings[internal_port].append(external)
@@ -57,7 +60,11 @@ def _raise_invalid_port(port):
 
 
 def split_port(port):
+    # mask : inside [] with ^ (ipv6 address)
+    port = re.sub(r'\[[^]]*\]', lambda x: x.group(0).replace(':', '^'), port)
     parts = str(port).split(':')
+    # unmask parts
+    parts = [part.replace('^', ':') for part in parts]
 
     if not 1 <= len(parts) <= 3:
         _raise_invalid_port(port)

--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -1,6 +1,4 @@
 
-import re
-
 
 def add_port_mapping(port_bindings, internal_port, external):
     if internal_port in port_bindings:
@@ -60,11 +58,7 @@ def _raise_invalid_port(port):
 
 
 def split_port(port):
-    # mask : inside [] with ^ (ipv6 address)
-    port = re.sub(r'\[[^]]*\]', lambda x: x.group(0).replace(':', '^'), port)
-    parts = str(port).split(':')
-    # unmask parts
-    parts = [part.replace('^', ':') for part in parts]
+    parts = str(port).rsplit(':',2)
 
     if not 1 <= len(parts) <= 3:
         _raise_invalid_port(port)

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -547,6 +547,12 @@ class PortsTest(unittest.TestCase):
         self.assertEqual(external_port,
                          [("127.0.0.1", "1000"), ("127.0.0.1", "1001")])
 
+    def test_split_port_with_ipv6_address(self):
+        internal_port, external_port = split_port(
+            "[2001:abcd:ef00::2]:1000:2000")
+        self.assertEqual(internal_port, ["2000"])
+        self.assertEqual(external_port, [("[2001:abcd:ef00::2]", "1000")])
+
     def test_split_port_invalid(self):
         self.assertRaises(ValueError,
                           lambda: split_port("0.0.0.0:1000:2000:tcp"))

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -549,9 +549,9 @@ class PortsTest(unittest.TestCase):
 
     def test_split_port_with_ipv6_address(self):
         internal_port, external_port = split_port(
-            "[2001:abcd:ef00::2]:1000:2000")
+            "2001:abcd:ef00::2:1000:2000")
         self.assertEqual(internal_port, ["2000"])
-        self.assertEqual(external_port, [("[2001:abcd:ef00::2]", "1000")])
+        self.assertEqual(external_port, [("2001:abcd:ef00::2", "1000")])
 
     def test_split_port_invalid(self):
         self.assertRaises(ValueError,


### PR DESCRIPTION
fixes #1361 and docker/compose#2663, and allows to use IPv6 in compose port mappings.