### PR TITLE
Add system df to low-level API

### DIFF
--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -158,6 +158,7 @@ class DaemonApiMixin(object):
         url = self._url("/version", versioned_api=api_version)
         return self._result(self._get(url), json=True)
 
+    @utils.minimum_version('1.25')
     def df(self, api_version=True):
         """
         Returns disk information from the server. Similar to the ``docker

--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -157,3 +157,18 @@ class DaemonApiMixin(object):
         """
         url = self._url("/version", versioned_api=api_version)
         return self._result(self._get(url), json=True)
+
+    def df(self, api_version=True):
+        """
+        Returns disk information from the server. Similar to the ``docker
+        system df`` command.
+
+        Returns:
+            (dict): The server disk information
+
+        Raises:
+            :py:class:`docker.errors.APIError`
+                If the server returns an error.
+        """
+        url = self._url("/system/df", versioned_api=api_version)
+        return self._result(self._get(url), json=True)

--- a/tests/integration/api_client_test.py
+++ b/tests/integration/api_client_test.py
@@ -8,6 +8,7 @@ import warnings
 import docker
 from docker.utils import kwargs_from_env
 
+from ..helpers import requires_api_version
 from .base import BaseAPIIntegrationTest, BUSYBOX
 
 
@@ -18,6 +19,7 @@ class InformationTest(BaseAPIIntegrationTest):
         self.assertIn('Version', res)
         self.assertEqual(len(res['Version'].split('.')), 3)
 
+    @requires_api_version('1.25')
     def test_df(self):
         res = self.client.df()
         self.assertIn('LayersSize', res)

--- a/tests/integration/api_client_test.py
+++ b/tests/integration/api_client_test.py
@@ -18,6 +18,13 @@ class InformationTest(BaseAPIIntegrationTest):
         self.assertIn('Version', res)
         self.assertEqual(len(res['Version'].split('.')), 3)
 
+    def test_df(self):
+        res = self.client.df()
+        self.assertIn('LayersSize', res)
+        self.assertIn('Images', res)
+        self.assertIn('Containers', res)
+        self.assertIn('Volumes', res)
+
     def test_info(self):
         res = self.client.info()
         self.assertIn('Containers', res)

--- a/tests/integration/client_test.py
+++ b/tests/integration/client_test.py
@@ -20,3 +20,7 @@ class ClientTest(unittest.TestCase):
     def test_version(self):
         client = docker.from_env(version=TEST_API_VERSION)
         assert 'Version' in client.version()
+
+    def test_df(self):
+        client = docker.from_env()
+        assert 'LayersSize' in client.version()

--- a/tests/integration/client_test.py
+++ b/tests/integration/client_test.py
@@ -25,4 +25,4 @@ class ClientTest(unittest.TestCase):
     @requires_api_version('1.25')
     def test_df(self):
         client = docker.from_env()
-        assert 'LayersSize' in client.version()
+        assert 'LayersSize' in client.df()

--- a/tests/integration/client_test.py
+++ b/tests/integration/client_test.py
@@ -3,6 +3,7 @@ import unittest
 import docker
 
 from .base import TEST_API_VERSION
+from ..helpers import requires_api_version
 
 
 class ClientTest(unittest.TestCase):
@@ -21,6 +22,7 @@ class ClientTest(unittest.TestCase):
         client = docker.from_env(version=TEST_API_VERSION)
         assert 'Version' in client.version()
 
+    @requires_api_version('1.25')
     def test_df(self):
         client = docker.from_env()
         assert 'LayersSize' in client.version()

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -17,6 +17,7 @@ from requests.packages import urllib3
 import six
 
 from . import fake_api
+from ..helpers import requires_api_version
 
 import pytest
 
@@ -192,6 +193,7 @@ class DockerApiTest(BaseAPIClientTest):
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
+    @requires_api_version('1.25')
     def test_df(self):
         self.client.df()
 

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -192,6 +192,24 @@ class DockerApiTest(BaseAPIClientTest):
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
+    def test_df(self):
+        self.client.df()
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'system/df',
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_df_no_api_version(self):
+        self.client.df(False)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_base + 'system/df',
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
     def test_retrieve_server_version(self):
         client = APIClient(version="auto")
         self.assertTrue(isinstance(client._version, six.string_types))

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -46,6 +46,13 @@ class ClientTest(unittest.TestCase):
         assert client.version() == mock_func.return_value
         mock_func.assert_called_with()
 
+    @mock.patch('docker.api.APIClient.df')
+    def test_df(self, mock_func):
+        mock_func.return_value = fake_api.get_fake_version()[1]
+        client = docker.from_env()
+        assert client.df() == mock_func.return_value
+        mock_func.assert_called_with()
+
     def test_call_api_client_method(self):
         client = docker.from_env()
         with self.assertRaises(AttributeError) as cm:

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -5,6 +5,7 @@ import os
 import unittest
 
 from . import fake_api
+from ..helpers import requires_api_version
 
 try:
     from unittest import mock
@@ -47,6 +48,7 @@ class ClientTest(unittest.TestCase):
         mock_func.assert_called_with()
 
     @mock.patch('docker.api.APIClient.df')
+    @requires_api_version('1.25')
     def test_df(self, mock_func):
         mock_func.return_value = fake_api.get_fake_version()[1]
         client = docker.from_env()


### PR DESCRIPTION
Add `system df` to low-level API.

Ref: [system df](https://docs.docker.com/engine/api/v1.25/#operation/SystemDataUsage)