### PR TITLE
Fix Swarm model init to correctly pass arguments through to init_swarm

### DIFF
--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -29,7 +29,7 @@ class Swarm(Model):
         return self.attrs.get('Version').get('Index')
 
     def init(self, advertise_addr=None, listen_addr='0.0.0.0:2377',
-             force_new_cluster=False, swarm_spec=None, **kwargs):
+             force_new_cluster=False, **kwargs):
         """
         Initialize a new swarm on this Engine.
 
@@ -87,11 +87,11 @@ class Swarm(Model):
             )
 
         """
-        init_kwargs = {}
-        for arg in ['advertise_addr', 'listen_addr', 'force_new_cluster']:
-            if arg in kwargs:
-                init_kwargs[arg] = kwargs[arg]
-                del kwargs[arg]
+        init_kwargs = {
+            'advertise_addr': advertise_addr,
+            'listen_addr': listen_addr,
+            'force_new_cluster': force_new_cluster
+        }
         init_kwargs['swarm_spec'] = SwarmSpec(**kwargs)
         self.client.api.init_swarm(**init_kwargs)
         self.reload()

--- a/tests/integration/models_nodes_test.py
+++ b/tests/integration/models_nodes_test.py
@@ -14,7 +14,7 @@ class NodesTest(unittest.TestCase):
 
     def test_list_get_update(self):
         client = docker.from_env()
-        client.swarm.init(listen_addr=helpers.swarm_listen_addr())
+        client.swarm.init('eth0', listen_addr=helpers.swarm_listen_addr())
         nodes = client.nodes.list()
         assert len(nodes) == 1
         assert nodes[0].attrs['Spec']['Role'] == 'manager'

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -11,7 +11,7 @@ class ServiceTest(unittest.TestCase):
     def setUpClass(cls):
         client = docker.from_env()
         helpers.force_leave_swarm(client)
-        client.swarm.init(listen_addr=helpers.swarm_listen_addr())
+        client.swarm.init('eth0', listen_addr=helpers.swarm_listen_addr())
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/integration/models_swarm_test.py
+++ b/tests/integration/models_swarm_test.py
@@ -15,7 +15,8 @@ class SwarmTest(unittest.TestCase):
     def test_init_update_leave(self):
         client = docker.from_env()
         client.swarm.init(
-            snapshot_interval=5000, listen_addr=helpers.swarm_listen_addr()
+            advertise_addr='eth0', snapshot_interval=5000,
+            listen_addr=helpers.swarm_listen_addr()
         )
         assert client.swarm.attrs['Spec']['Raft']['SnapshotInterval'] == 5000
         client.swarm.update(snapshot_interval=10000)


### PR DESCRIPTION
Fixes #1359 