### PR TITLE
Allow configuring API version for integration test with env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ integration-dind: build build-py3
 	docker rm -vf dpy-dind || :
 	docker run -d --name dpy-dind --privileged dockerswarm/dind:1.13.0 docker daemon\
 		-H tcp://0.0.0.0:2375
-	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-sdk-python\
-		py.test tests/integration
-	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --link=dpy-dind:docker docker-sdk-python3\
-		py.test tests/integration
+	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TEST_API_VERSION=1.25"\
+		--link=dpy-dind:docker docker-sdk-python py.test tests/integration
+	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TEST_API_VERSION=1.25"\
+		--link=dpy-dind:docker docker-sdk-python3 py.test tests/integration
 	docker rm -vf dpy-dind
 
 .PHONY: integration-dind-ssl
@@ -61,10 +61,10 @@ integration-dind-ssl: build-dind-certs build build-py3
 		--tlscacert=/certs/ca.pem --tlscert=/certs/server-cert.pem\
 		--tlskey=/certs/server-key.pem -H tcp://0.0.0.0:2375
 	docker run --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\
-		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs"\
+		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --env="DOCKER_TEST_API_VERSION=1.25"\
 		--link=dpy-dind-ssl:docker docker-sdk-python py.test tests/integration
 	docker run --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\
-		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs"\
+		--env="DOCKER_TLS_VERIFY=1" --env="DOCKER_CERT_PATH=/certs" --env="DOCKER_TEST_API_VERSION=1.25"\
 		--link=dpy-dind-ssl:docker docker-sdk-python3 py.test tests/integration
 	docker rm -vf dpy-dind-ssl dpy-dind-certs
 

--- a/tests/integration/api_client_test.py
+++ b/tests/integration/api_client_test.py
@@ -25,8 +25,7 @@ class InformationTest(BaseAPIIntegrationTest):
         self.assertIn('Debug', res)
 
     def test_search(self):
-        client = docker.APIClient(timeout=10, **kwargs_from_env())
-        res = client.search('busybox')
+        res = self.client.search('busybox')
         self.assertTrue(len(res) >= 1)
         base_img = [x for x in res if x['name'] == 'busybox']
         self.assertEqual(len(base_img), 1)
@@ -126,8 +125,11 @@ class AutoDetectVersionTest(unittest.TestCase):
 class ConnectionTimeoutTest(unittest.TestCase):
     def setUp(self):
         self.timeout = 0.5
-        self.client = docker.api.APIClient(base_url='http://192.168.10.2:4243',
-                                           timeout=self.timeout)
+        self.client = docker.api.APIClient(
+            version=docker.constants.MINIMUM_DOCKER_API_VERSION,
+            base_url='http://192.168.10.2:4243',
+            timeout=self.timeout
+        )
 
     def test_timeout(self):
         start = time.time()

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import unittest
 
@@ -8,6 +9,7 @@ import six
 from .. import helpers
 
 BUSYBOX = 'busybox:buildroot-2014.02'
+TEST_API_VERSION = os.environ.get('DOCKER_TEST_API_VERSION')
 
 
 class BaseIntegrationTest(unittest.TestCase):
@@ -27,7 +29,7 @@ class BaseIntegrationTest(unittest.TestCase):
         self.tmp_networks = []
 
     def tearDown(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         for img in self.tmp_imgs:
             try:
                 client.api.remove_image(img)
@@ -61,7 +63,9 @@ class BaseAPIIntegrationTest(BaseIntegrationTest):
 
     def setUp(self):
         super(BaseAPIIntegrationTest, self).setUp()
-        self.client = docker.APIClient(timeout=60, **kwargs_from_env())
+        self.client = docker.APIClient(
+            version=TEST_API_VERSION, timeout=60, **kwargs_from_env()
+        )
 
     def run_container(self, *args, **kwargs):
         container = self.client.create_container(*args, **kwargs)

--- a/tests/integration/client_test.py
+++ b/tests/integration/client_test.py
@@ -2,19 +2,21 @@ import unittest
 
 import docker
 
+from .base import TEST_API_VERSION
+
 
 class ClientTest(unittest.TestCase):
 
     def test_info(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         info = client.info()
         assert 'ID' in info
         assert 'Name' in info
 
     def test_ping(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         assert client.ping() is True
 
     def test_version(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         assert 'Version' in client.version()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,7 @@ from .base import BUSYBOX
 @pytest.fixture(autouse=True, scope='session')
 def setup_test_session():
     warnings.simplefilter('error')
-    c = docker.APIClient(**kwargs_from_env())
+    c = docker.APIClient(version='auto', **kwargs_from_env())
     try:
         c.inspect_image(BUSYBOX)
     except docker.errors.NotFound:

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -1,25 +1,25 @@
 import docker
-from .base import BaseIntegrationTest
+from .base import BaseIntegrationTest, TEST_API_VERSION
 
 
 class ContainerCollectionTest(BaseIntegrationTest):
 
     def test_run(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         self.assertEqual(
             client.containers.run("alpine", "echo hello world", remove=True),
             b'hello world\n'
         )
 
     def test_run_detach(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         assert container.attrs['Config']['Image'] == "alpine"
         assert container.attrs['Config']['Cmd'] == ['sleep', '300']
 
     def test_run_with_error(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         with self.assertRaises(docker.errors.ContainerError) as cm:
             client.containers.run("alpine", "cat /test", remove=True)
         assert cm.exception.exit_status == 1
@@ -28,19 +28,19 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert "No such file or directory" in str(cm.exception)
 
     def test_run_with_image_that_does_not_exist(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         with self.assertRaises(docker.errors.ImageNotFound):
             client.containers.run("dockerpytest_does_not_exist")
 
     def test_get(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         assert client.containers.get(container.id).attrs[
             'Config']['Image'] == "alpine"
 
     def test_list(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container_id = client.containers.run(
             "alpine", "sleep 300", detach=True).id
         self.tmp_containers.append(container_id)
@@ -59,7 +59,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
 class ContainerTest(BaseIntegrationTest):
 
     def test_commit(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run(
             "alpine", "sh -c 'echo \"hello\" > /test'",
             detach=True
@@ -73,14 +73,14 @@ class ContainerTest(BaseIntegrationTest):
         )
 
     def test_diff(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "touch /test", detach=True)
         self.tmp_containers.append(container.id)
         container.wait()
         assert container.diff() == [{'Path': '/test', 'Kind': 1}]
 
     def test_exec_run(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run(
             "alpine", "sh -c 'echo \"hello\" > /test; sleep 60'", detach=True
         )
@@ -88,7 +88,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.exec_run("cat /test") == b"hello\n"
 
     def test_kill(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         while container.status != 'running':
@@ -99,7 +99,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.status == 'exited'
 
     def test_logs(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "echo hello world",
                                           detach=True)
         self.tmp_containers.append(container.id)
@@ -107,7 +107,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.logs() == b"hello world\n"
 
     def test_pause(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         container.pause()
@@ -118,7 +118,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.status == "running"
 
     def test_remove(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "echo hello", detach=True)
         self.tmp_containers.append(container.id)
         assert container.id in [c.id for c in client.containers.list(all=True)]
@@ -128,7 +128,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.id not in [c.id for c in containers]
 
     def test_rename(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "echo hello", name="test1",
                                           detach=True)
         self.tmp_containers.append(container.id)
@@ -138,7 +138,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.name == "test2"
 
     def test_restart(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 100", detach=True)
         self.tmp_containers.append(container.id)
         first_started_at = container.attrs['State']['StartedAt']
@@ -148,7 +148,7 @@ class ContainerTest(BaseIntegrationTest):
         assert first_started_at != second_started_at
 
     def test_start(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.create("alpine", "sleep 50", detach=True)
         self.tmp_containers.append(container.id)
         assert container.status == "created"
@@ -157,7 +157,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.status == "running"
 
     def test_stats(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 100", detach=True)
         self.tmp_containers.append(container.id)
         stats = container.stats(stream=False)
@@ -166,7 +166,7 @@ class ContainerTest(BaseIntegrationTest):
             assert key in stats
 
     def test_stop(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "top", detach=True)
         self.tmp_containers.append(container.id)
         assert container.status in ("running", "created")
@@ -175,7 +175,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.status == "exited"
 
     def test_top(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 60", detach=True)
         self.tmp_containers.append(container.id)
         top = container.top()
@@ -183,7 +183,7 @@ class ContainerTest(BaseIntegrationTest):
         assert 'sleep 60' in top['Processes'][0]
 
     def test_update(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 60", detach=True,
                                           cpu_shares=2)
         self.tmp_containers.append(container.id)
@@ -193,7 +193,7 @@ class ContainerTest(BaseIntegrationTest):
         assert container.attrs['HostConfig']['CpuShares'] == 3
 
     def test_wait(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sh -c 'exit 0'",
                                           detach=True)
         self.tmp_containers.append(container.id)

--- a/tests/integration/models_images_test.py
+++ b/tests/integration/models_images_test.py
@@ -3,13 +3,13 @@ import io
 import docker
 import pytest
 
-from .base import BaseIntegrationTest
+from .base import BaseIntegrationTest, TEST_API_VERSION
 
 
 class ImageCollectionTest(BaseIntegrationTest):
 
     def test_build(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.build(fileobj=io.BytesIO(
             "FROM alpine\n"
             "CMD echo hello world".encode('ascii')
@@ -19,7 +19,7 @@ class ImageCollectionTest(BaseIntegrationTest):
 
     @pytest.mark.xfail(reason='Engine 1.13 responds with status 500')
     def test_build_with_error(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         with self.assertRaises(docker.errors.BuildError) as cm:
             client.images.build(fileobj=io.BytesIO(
                 "FROM alpine\n"
@@ -29,18 +29,18 @@ class ImageCollectionTest(BaseIntegrationTest):
                                      "NOTADOCKERFILECOMMAND")
 
     def test_list(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.pull('alpine:latest')
         assert image.id in get_ids(client.images.list())
 
     def test_list_with_repository(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.pull('alpine:latest')
         assert image.id in get_ids(client.images.list('alpine'))
         assert image.id in get_ids(client.images.list('alpine:latest'))
 
     def test_pull(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.pull('alpine:latest')
         assert 'alpine:latest' in image.attrs['RepoTags']
 
@@ -52,7 +52,7 @@ class ImageTest(BaseIntegrationTest):
         tag = 'some-tag'
         identifier = '{}:{}'.format(repo, tag)
 
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.pull('alpine:latest')
 
         image.tag(repo, tag)

--- a/tests/integration/models_networks_test.py
+++ b/tests/integration/models_networks_test.py
@@ -1,12 +1,12 @@
 import docker
 from .. import helpers
-from .base import BaseIntegrationTest
+from .base import BaseIntegrationTest, TEST_API_VERSION
 
 
 class ImageCollectionTest(BaseIntegrationTest):
 
     def test_create(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         name = helpers.random_name()
         network = client.networks.create(name, labels={'foo': 'bar'})
         self.tmp_networks.append(network.id)
@@ -14,7 +14,7 @@ class ImageCollectionTest(BaseIntegrationTest):
         assert network.attrs['Labels']['foo'] == "bar"
 
     def test_get(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         name = helpers.random_name()
         network_id = client.networks.create(name).id
         self.tmp_networks.append(network_id)
@@ -22,7 +22,7 @@ class ImageCollectionTest(BaseIntegrationTest):
         assert network.name == name
 
     def test_list_remove(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         name = helpers.random_name()
         network = client.networks.create(name)
         self.tmp_networks.append(network.id)
@@ -50,7 +50,7 @@ class ImageCollectionTest(BaseIntegrationTest):
 class ImageTest(BaseIntegrationTest):
 
     def test_connect_disconnect(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         network = client.networks.create(helpers.random_name())
         self.tmp_networks.append(network.id)
         container = client.containers.create("alpine", "sleep 300")

--- a/tests/integration/models_nodes_test.py
+++ b/tests/integration/models_nodes_test.py
@@ -3,17 +3,18 @@ import unittest
 import docker
 
 from .. import helpers
+from .base import TEST_API_VERSION
 
 
 class NodesTest(unittest.TestCase):
     def setUp(self):
-        helpers.force_leave_swarm(docker.from_env())
+        helpers.force_leave_swarm(docker.from_env(version=TEST_API_VERSION))
 
     def tearDown(self):
-        helpers.force_leave_swarm(docker.from_env())
+        helpers.force_leave_swarm(docker.from_env(version=TEST_API_VERSION))
 
     def test_list_get_update(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         client.swarm.init('eth0', listen_addr=helpers.swarm_listen_addr())
         nodes = client.nodes.list()
         assert len(nodes) == 1

--- a/tests/integration/models_resources_test.py
+++ b/tests/integration/models_resources_test.py
@@ -1,11 +1,11 @@
 import docker
-from .base import BaseIntegrationTest
+from .base import BaseIntegrationTest, TEST_API_VERSION
 
 
 class ModelTest(BaseIntegrationTest):
 
     def test_reload(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         first_started_at = container.attrs['State']['StartedAt']

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -4,21 +4,22 @@ import docker
 import pytest
 
 from .. import helpers
+from .base import TEST_API_VERSION
 
 
 class ServiceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         helpers.force_leave_swarm(client)
         client.swarm.init('eth0', listen_addr=helpers.swarm_listen_addr())
 
     @classmethod
     def tearDownClass(cls):
-        helpers.force_leave_swarm(docker.from_env())
+        helpers.force_leave_swarm(docker.from_env(version=TEST_API_VERSION))
 
     def test_create(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         name = helpers.random_name()
         service = client.services.create(
             # create arguments
@@ -36,7 +37,7 @@ class ServiceTest(unittest.TestCase):
         assert container_spec['Labels'] == {'container': 'label'}
 
     def test_get(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         name = helpers.random_name()
         service = client.services.create(
             name=name,
@@ -47,7 +48,7 @@ class ServiceTest(unittest.TestCase):
         assert service.name == name
 
     def test_list_remove(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         service = client.services.create(
             name=helpers.random_name(),
             image="alpine",
@@ -58,7 +59,7 @@ class ServiceTest(unittest.TestCase):
         assert service not in client.services.list()
 
     def test_tasks(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         service1 = client.services.create(
             name=helpers.random_name(),
             image="alpine",
@@ -83,7 +84,7 @@ class ServiceTest(unittest.TestCase):
 
     @pytest.mark.skip(reason="Makes Swarm unstable?")
     def test_update(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         service = client.services.create(
             # create arguments
             name=helpers.random_name(),

--- a/tests/integration/models_swarm_test.py
+++ b/tests/integration/models_swarm_test.py
@@ -3,17 +3,18 @@ import unittest
 import docker
 
 from .. import helpers
+from .base import TEST_API_VERSION
 
 
 class SwarmTest(unittest.TestCase):
     def setUp(self):
-        helpers.force_leave_swarm(docker.from_env())
+        helpers.force_leave_swarm(docker.from_env(version=TEST_API_VERSION))
 
     def tearDown(self):
-        helpers.force_leave_swarm(docker.from_env())
+        helpers.force_leave_swarm(docker.from_env(version=TEST_API_VERSION))
 
     def test_init_update_leave(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         client.swarm.init(
             advertise_addr='eth0', snapshot_interval=5000,
             listen_addr=helpers.swarm_listen_addr()

--- a/tests/integration/models_volumes_test.py
+++ b/tests/integration/models_volumes_test.py
@@ -1,10 +1,10 @@
 import docker
-from .base import BaseIntegrationTest
+from .base import BaseIntegrationTest, TEST_API_VERSION
 
 
 class VolumesTest(BaseIntegrationTest):
     def test_create_get(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         volume = client.volumes.create(
             'dockerpytest_1',
             driver='local',
@@ -19,7 +19,7 @@ class VolumesTest(BaseIntegrationTest):
         assert volume.name == 'dockerpytest_1'
 
     def test_list_remove(self):
-        client = docker.from_env()
+        client = docker.from_env(version=TEST_API_VERSION)
         volume = client.volumes.create('dockerpytest_1')
         self.tmp_volumes.append(volume.id)
         assert volume in client.volumes.list()


### PR DESCRIPTION
This allows testing multiple engine version in Jenkins with matching API version for each (1.24 for 1.12, 1.25 for 1.13 etc.)