### PR TITLE
Remove wrong url in docker/transport/npipeconn.py

### DIFF
--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -96,7 +96,6 @@ class NpipeAdapter(requests.adapters.HTTPAdapter):
         # doesn't have a hostname, like is the case when using a UNIX socket.
         # Since proxies are an irrelevant notion in the case of UNIX sockets
         # anyway, we simply return the path URL directly.
-        # See also: https://github.com/docker/docker-sdk-python/issues/811
         return request.path_url
 
     def close(self):


### PR DESCRIPTION
well,no repo called docker-sdk-python existed
Signed-off-by: Aaron.L.Xu <likexu@harmonycloud.cn>