### PR TITLE
Add support for `squash` building flag

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -18,7 +18,7 @@ class BuildApiMixin(object):
               custom_context=False, encoding=None, pull=False,
               forcerm=False, dockerfile=None, container_limits=None,
               decode=False, buildargs=None, gzip=False, shmsize=None,
-              labels=None, cache_from=None):
+              labels=None, cache_from=None, squash=None):
         """
         Similar to the ``docker build`` command. Either ``path`` or ``fileobj``
         needs to be set. ``path`` can be a local path (to a directory
@@ -94,6 +94,8 @@ class BuildApiMixin(object):
             labels (dict): A dictionary of labels to set on the image.
             cache_from (list): A list of images used for build cache
                 resolution.
+            squash (bool): Squash the resulting images layers into a
+                single layer.
 
         Returns:
             A generator for the build output.
@@ -196,6 +198,14 @@ class BuildApiMixin(object):
             else:
                 raise errors.InvalidVersion(
                     'cache_from was only introduced in API version 1.25'
+                )
+
+        if squash:
+            if utils.version_gte(self._version, '1.25'):
+                params.update({'squash': squash})
+            else:
+                raise errors.InvalidVersion(
+                    'squash was only introduced in API version 1.25'
                 )
 
         if context is not None:

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -8,7 +8,7 @@ from docker import errors
 import six
 
 from .base import BaseAPIIntegrationTest
-from ..helpers import requires_api_version
+from ..helpers import requires_api_version, requires_experimental
 
 
 class BuildTest(BaseAPIIntegrationTest):
@@ -188,6 +188,32 @@ class BuildTest(BaseAPIIntegrationTest):
             if 'Using cache' in chunk.get('stream', ''):
                 counter += 1
         assert counter == 0
+
+    @requires_api_version('1.25')
+    @requires_experimental
+    def test_build_squash(self):
+        script = io.BytesIO('\n'.join([
+            'FROM busybox',
+            'RUN echo blah > /file_1',
+            'RUN echo blahblah > /file_2',
+            'RUN echo blahblahblah > /file_3'
+        ]).encode('ascii'))
+
+        def build_squashed(squash):
+            tag = 'squash' if squash else 'nosquash'
+            stream = self.client.build(
+                fileobj=script, tag=tag, squash=squash
+            )
+            self.tmp_imgs.append(tag)
+            for chunk in stream:
+                pass
+
+            return self.client.inspect_image(tag)
+
+        non_squashed = build_squashed(False)
+        squashed = build_squashed(True)
+        self.assertEqual(len(non_squashed['RootFS']['Layers']), 4)
+        self.assertEqual(len(squashed['RootFS']['Layers']), 2)
 
     def test_build_stderr_data(self):
         control_chars = ['\x1b[91m', '\x1b[0m']


### PR DESCRIPTION
the ```@experimental-flags``` decorator was added upstream, this PR is now simpler.