### PR TITLE
Add init parameter to container HostConfig

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -493,6 +493,7 @@ class ContainerCollection(Collection):
             hostname (str): Optional hostname for the container.
             init (bool): Run an init inside the container that forwards
                 signals and reaps processes
+            init_path (bool): Path to the docker-init binary
             ipc_mode (str): Set the IPC mode for the container.
             isolation (str): Isolation technology to use. Default: `None`.
             labels (dict or list): A dictionary of name-value labels (e.g.
@@ -817,6 +818,7 @@ RUN_HOST_CONFIG_KWARGS = [
     'extra_hosts',
     'group_add',
     'init',
+    'init_path',
     'ipc_mode',
     'isolation',
     'kernel_memory',

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -491,6 +491,8 @@ class ContainerCollection(Collection):
             group_add (:py:class:`list`): List of additional group names and/or
                 IDs that the container process will run as.
             hostname (str): Optional hostname for the container.
+            init (bool): Run an init inside the container that forwards
+                signals and reaps processes
             ipc_mode (str): Set the IPC mode for the container.
             isolation (str): Isolation technology to use. Default: `None`.
             labels (dict or list): A dictionary of name-value labels (e.g.
@@ -814,6 +816,7 @@ RUN_HOST_CONFIG_KWARGS = [
     'dns',
     'extra_hosts',
     'group_add',
+    'init',
     'ipc_mode',
     'isolation',
     'kernel_memory',

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -118,7 +118,7 @@ class HostConfig(dict):
                  tmpfs=None, oom_score_adj=None, dns_opt=None, cpu_shares=None,
                  cpuset_cpus=None, userns_mode=None, pids_limit=None,
                  isolation=None, auto_remove=False, storage_opt=None,
-                 init=None):
+                 init=None, init_path=None):
 
         if mem_limit is not None:
             self['Memory'] = parse_bytes(mem_limit)
@@ -422,6 +422,11 @@ class HostConfig(dict):
             if version_lt(version, '1.25'):
                 raise host_config_version_error('init', '1.25')
             self['Init'] = init
+
+        if init_path:
+            if version_lt(version, '1.25'):
+                raise host_config_version_error('init', '1.25')
+            self['InitPath'] = init_path
 
 
 def host_config_type_error(param, param_value, expected):

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -117,7 +117,8 @@ class HostConfig(dict):
                  oom_kill_disable=False, shm_size=None, sysctls=None,
                  tmpfs=None, oom_score_adj=None, dns_opt=None, cpu_shares=None,
                  cpuset_cpus=None, userns_mode=None, pids_limit=None,
-                 isolation=None, auto_remove=False, storage_opt=None):
+                 isolation=None, auto_remove=False, storage_opt=None,
+                 init=None):
 
         if mem_limit is not None:
             self['Memory'] = parse_bytes(mem_limit)
@@ -416,6 +417,11 @@ class HostConfig(dict):
             if version_lt(version, '1.24'):
                 raise host_config_version_error('storage_opt', '1.24')
             self['StorageOpt'] = storage_opt
+
+        if init is not None:
+            if version_lt(version, '1.25'):
+                raise host_config_version_error('init', '1.25')
+            self['Init'] = init
 
 
 def host_config_type_error(param, param_value, expected):

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -450,6 +450,18 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         config = self.client.inspect_container(ctnr)
         assert config['HostConfig']['Init'] is True
 
+    @requires_api_version('1.25')
+    def test_create_with_init_path(self):
+        ctnr = self.client.create_container(
+            BUSYBOX, 'true',
+            host_config=self.client.create_host_config(
+                init_path="/usr/libexec/docker-init"
+            )
+        )
+        self.tmp_containers.append(ctnr['Id'])
+        config = self.client.inspect_container(ctnr)
+        assert config['HostConfig']['InitPath'] == "/usr/libexec/docker-init"
+
 
 class VolumeBindTest(BaseAPIIntegrationTest):
     def setUp(self):

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -438,6 +438,18 @@ class CreateContainerTest(BaseAPIIntegrationTest):
             'size': '120G'
         }
 
+    @requires_api_version('1.25')
+    def test_create_with_init(self):
+        ctnr = self.client.create_container(
+            BUSYBOX, 'true',
+            host_config=self.client.create_host_config(
+                init=True
+            )
+        )
+        self.tmp_containers.append(ctnr['Id'])
+        config = self.client.inspect_container(ctnr)
+        assert config['HostConfig']['Init'] is True
+
 
 class VolumeBindTest(BaseAPIIntegrationTest):
     def setUp(self):


### PR DESCRIPTION
Docker introduced "init". This allows to run an init inside the container that forwards signals and reaps processes.

It would be nice if docker-py supported this one.