### PR TITLE
Allow port range like 8000-8010:80

### DIFF
--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -24,7 +24,7 @@ def build_port_bindings(ports):
     return port_bindings
 
 
-def to_port_range(port):
+def to_port_range(port, randomly_available_port = False):
     if not port:
         return None
 
@@ -36,6 +36,9 @@ def to_port_range(port):
 
         port, protocol = parts
         protocol = "/" + protocol
+
+    if randomly_available_port:
+        return ["%s%s" % (port, protocol)]
 
     parts = str(port).split('-')
 
@@ -69,7 +72,7 @@ def split_port(port):
         external_port, internal_port = parts
 
         internal_range = to_port_range(internal_port)
-        external_range = to_port_range(external_port)
+        external_range = to_port_range(external_port, len(internal_range) == 1)
 
         if internal_range is None or external_range is None:
             _raise_invalid_port(port)
@@ -81,7 +84,7 @@ def split_port(port):
 
     external_ip, external_port, internal_port = parts
     internal_range = to_port_range(internal_port)
-    external_range = to_port_range(external_port)
+    external_range = to_port_range(external_port, len(internal_range) == 1)
     if not external_range:
         external_range = [None] * len(internal_range)
 

--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -24,7 +24,7 @@ def build_port_bindings(ports):
     return port_bindings
 
 
-def to_port_range(port, randomly_available_port = False):
+def to_port_range(port, randomly_available_port=False):
     if not port:
         return None
 

--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -72,9 +72,11 @@ def split_port(port):
         external_port, internal_port = parts
 
         internal_range = to_port_range(internal_port)
-        external_range = to_port_range(external_port, len(internal_range) == 1)
+        if internal_range is None:
+            _raise_invalid_port(port)
 
-        if internal_range is None or external_range is None:
+        external_range = to_port_range(external_port, len(internal_range) == 1)
+        if external_range is None:
             _raise_invalid_port(port)
 
         if len(internal_range) != len(external_range):

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -530,6 +530,11 @@ class PortsTest(unittest.TestCase):
         self.assertEqual(internal_port, ["2000", "2001"])
         self.assertEqual(external_port, ["1000", "1001"])
 
+    def test_split_port_random_port_range_with_host_port(self):
+        internal_port, external_port = split_port("1000-1001:2000")
+        self.assertEqual(internal_port, ["2000"])
+        self.assertEqual(external_port, ["1000-1001"])
+
     def test_split_port_no_host_port(self):
         internal_port, external_port = split_port("2000")
         self.assertEqual(internal_port, ["2000"])


### PR DESCRIPTION
Docker recognizes (host port range):(container port) syntax and determines available port in range randomly.
docker-py raised the error 'Port ranges don't match in length'.
It would be very useful to allow it, especially for using docker-compose.
