### PR TITLE
Add default EndpointSpec

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -1,4 +1,6 @@
 import warnings
+
+from docker.types.services import EndpointSpec
 from .. import auth, errors, utils
 from ..types import ServiceMode
 
@@ -42,7 +44,8 @@ class ServiceApiMixin(object):
                 DeprecationWarning
             )
             endpoint_spec = endpoint_config
-
+        if not endpoint_spec:
+            endpoint_spec = EndpointSpec(mode='vip')
         url = self._url('/services/create')
         headers = {}
         image = task_template.get('ContainerSpec', {}).get('Image', None)


### PR DESCRIPTION
When using docker commandline command services will get endpointspec vip by default.

With Docker-py and docker API does not add the endpointspec by default which will in some cases produce services with out a virtual IP.

This commit fixes this by adding endpointspec vip if no endpointspec is provided.


Commandline:
` 

    {
        "ID": "v3vlafenufjwhd6wh5y10rsk7",
        "Version": {
            "Index": 952316
        },
        "CreatedAt": "2017-02-18T14:06:08.706610266Z",
        "UpdatedAt": "2017-02-18T14:06:08.712362806Z",
        "Spec": {
        ...
           "EndpointSpec": {
                "Mode": "vip"
            }
        },
        "Endpoint": {
            "Spec": {
                "Mode": "vip"
            },
            "VirtualIPs": [
                {
                    "NetworkID": "s59zg9b0tzydjj5q4e1fphu5l",
                    "Addr": "10.0.0.2/24"
                }
            ]
        }
    }

`

docker-py:
`  
  
    {
        "ID": "982p20ke2ryycixo8hotzq8u0",
        "Version": {
            "Index": 952326
        },
        "CreatedAt": "2017-02-18T14:10:05.782637481Z",
        "UpdatedAt": "2017-02-18T14:10:05.786939683Z",
        "Spec": {
       ...
        },
        "Endpoint": {
            "Spec": {},
            "VirtualIPs": [
                {
                    "NetworkID": "s59zg9b0tzydjj5q4e1fphu5l",
                    "Addr": "10.0.0.2/24"
                }
            ]
        }
    }

`

docker-py with fix:

`

     {
        "ID": "wtskxvfylcfte0c35wbzp15wu",
        "Version": {
            "Index": 952336
        },
        "CreatedAt": "2017-02-18T14:11:38.668470065Z",
        "UpdatedAt": "2017-02-18T14:11:38.672749174Z",
        "Spec": {
        ....
           "EndpointSpec": {
                "Mode": "vip"
            }
        },
        "Endpoint": {
            "Spec": {
                "Mode": "vip"
            },
            "VirtualIPs": [
                {
                    "NetworkID": "s59zg9b0tzydjj5q4e1fphu5l",
                    "Addr": "10.0.0.2/24"
                }
            ]
        }
`