### PR TITLE
Allow events daemon command to read config.json

### DIFF
--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -54,7 +54,7 @@ class DaemonApiMixin(object):
         }
 
         return self._stream_helper(
-            self.get(self._url('/events'), params=params, stream=True),
+            self._get(self._url('/events'), params=params, stream=True),
             decode=decode
         )
 

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -228,7 +228,8 @@ class DockerApiTest(BaseAPIClientTest):
             'GET',
             url_prefix + 'events',
             params={'since': None, 'until': None, 'filters': None},
-            stream=True
+            stream=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
     def test_events_with_since_until(self):
@@ -247,7 +248,8 @@ class DockerApiTest(BaseAPIClientTest):
                 'until': ts + 10,
                 'filters': None
             },
-            stream=True
+            stream=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
     def test_events_with_filters(self):
@@ -265,7 +267,8 @@ class DockerApiTest(BaseAPIClientTest):
                 'until': None,
                 'filters': expected_filters
             },
-            stream=True
+            stream=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
     def _socket_path_for_client_session(self, client):


### PR DESCRIPTION
Events units test have also been updated/fixed.
This should fix #1472 