### PR TITLE
Update assert in test_create_with_restart_policy

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -122,7 +122,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
             self.client.remove_container(id)
         err = exc.exception.explanation
         self.assertIn(
-            'You cannot remove a running container', err
+            'You cannot remove ', err
         )
         self.client.remove_container(id, force=True)
 


### PR DESCRIPTION
In https://github.com/docker/docker/pull/30870 a new error message is displayed if the container is restarting.

To make `test_create_with_restart_policy` pass against the above change,
the test checks that the error message contains `You cannot remove ` instead of
`You cannot remove a running container`