### PR TITLE
Add docker-pycreds to test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest==2.9.1
 coverage==3.7.1
 pytest-cov==2.1.0
 flake8==2.4.1
+docker-pycreds==0.2.1


### PR DESCRIPTION
To run integration tests docker-pycreds is required.
Before running the integration tests conftest.py is
loaded which results in loads auth.py that
imports the docker-pycreds module.