### PR TITLE
Consistency fix: removes duplicate calls to _raise_for_status()

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -323,6 +323,7 @@ class APIClient(
     def _multiplexed_response_stream_helper(self, response):
         """A generator of multiplexed data blocks coming from a response
         stream."""
+        self._raise_for_status(response)
 
         # Disable timeout on the underlying socket to prevent
         # Read timed out(s) for long running processes
@@ -408,7 +409,6 @@ class APIClient(
             return self._stream_raw_result(res) if stream else \
                 self._result(res, binary=True)
 
-        self._raise_for_status(res)
         sep = six.binary_type()
         if stream:
             return self._multiplexed_response_stream_helper(res)


### PR DESCRIPTION
Hello,

This PR does not resolve any bug so I would totally understand that you just throw it but I believe it could avoid some future debugging.

In the APIClient's method `_get_result_tty`, the method `_raise_for_status` is called twice if the parameter `stream == False`. First by `_get_result_tty` itself, second by the method `_result` in `_multiplexed_buffer_helper`.

This change is safe because the methods `_multiplexed_buffer_helper` and `_multiplexed_response_stream_helper` are called only by `_get_result_tty` in the whole application.

Best