### PR TITLE
fix: Missing exception handling in split_port when no container port

### DIFF
--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -85,8 +85,13 @@ def split_port(port):
         return internal_range, external_range
 
     external_ip, external_port, internal_port = parts
+
+    if not internal_port:
+        _raise_invalid_port(port)
+
     internal_range = to_port_range(internal_port)
     external_range = to_port_range(external_port, len(internal_range) == 1)
+
     if not external_range:
         external_range = [None] * len(internal_range)
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -574,6 +574,10 @@ class PortsTest(unittest.TestCase):
         self.assertRaises(ValueError,
                           lambda: split_port("localhost:"))
 
+    def test_with_no_container_port(self):
+        self.assertRaises(ValueError,
+                          lambda: split_port("localhost:80:"))
+
     def test_build_port_bindings_with_one_port(self):
         port_bindings = build_port_bindings(["127.0.0.1:1000:1000"])
         self.assertEqual(port_bindings["1000"], [("127.0.0.1", "1000")])


### PR DESCRIPTION
"localhost:host_port:" case will raise TypeError exception directly

Catch the "TypeError" and give proper error message

* docker/utils/ports.py

Signed-off-by: Lei Gong <xue177125184@gmail.com>