### PR TITLE
Added util for creating build context from git repo

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -140,6 +140,10 @@ class BuildError(Exception):
     pass
 
 
+class GitError(BuildError):
+    pass
+
+
 def create_unexpected_kwargs_error(name, kwargs):
     quoted_kwargs = ["'{}'".format(k) for k in sorted(kwargs)]
     text = ["{}() ".format(name)]

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from .build import tar, exclude_paths
 from .decorators import check_resource, minimum_version, update_headers
+from .git import make_git_build_context, is_git_url
 from .utils import (
     compare_version, convert_port_bindings, convert_volume_binds,
     mkbuildcontext, parse_repository_tag, parse_host,

--- a/docker/utils/git.py
+++ b/docker/utils/git.py
@@ -1,0 +1,167 @@
+import tempfile
+import shutil
+import subprocess
+import requests
+import os
+import logging
+import re
+
+try:
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urlparse, urlunparse
+
+from . import tar
+from ..errors import GitError
+
+
+log = logging.getLogger(__name__)
+
+
+def is_git_url(path):
+    """Determines if the provided path is a git URL.
+
+    Args:
+        path (str): Path to evaluate
+
+    Returns:
+        bool: True, if the path is a valid Git URL
+    """
+    return path.startswith(("git://", "git@", "github.com/")) or (
+        path.startswith(("http://", "https://")) and
+        bool(re.search("\.git(?:#.+)?$", path))
+    )
+
+
+def make_git_build_context(git_url, **kwargs):
+    """Makes a build context out of a git URL
+
+    Args:
+        git_url: URL to the Git repository
+        **kwargs: Keyword args passed to `tar`
+
+    Returns:
+        A tar archive file object
+    """
+    root_dir = tempfile.mkdtemp(prefix='docker-build-git')
+    try:
+        context_dir = clone(git_url, root_dir)
+
+        dockerignore = os.path.join(context_dir, '.dockerignore')
+        exclude = None
+        if os.path.exists(dockerignore):
+            with open(dockerignore, 'r') as f:
+                exclude = list(filter(bool, f.read().splitlines()))
+
+        fileobj = tar(context_dir, exclude=exclude, **kwargs)
+    finally:
+        if os.path.exists(root_dir):
+            shutil.rmtree(root_dir)
+
+    return fileobj
+
+
+def clone(remote_url, dest_dir):
+    """Clones a repository into the destination directory
+
+    Returns:
+        str: A local path to the build context
+    """
+    if remote_url.startswith("github.com/"):
+        remote_url = 'https://' + remote_url
+
+    url = urlparse(remote_url)
+
+    clone_args = get_clone_args(url, dest_dir)
+    git(*clone_args)
+
+    return checkout(url.fragment, dest_dir)
+
+
+def get_clone_args(url, root_dir):
+    """Gets the git arguments to clone a repository into a new directory
+
+    Args:
+        url (urlparse.ParseResult): the repository url to clone
+        root_dir (str): the directory to clone into
+
+    Returns:
+        list: A list of git arguments to clone the repository
+    """
+    args = ["clone", "--recursive"]
+    shallow = len(url.fragment) == 0
+
+    if shallow and url.scheme.startswith("http"):
+        smart_http_url = "%s/info/refs?service=git-upload-pack" % \
+                         urlunparse(url)
+        resp = requests.get(smart_http_url, allow_redirects=True)
+        if resp.headers.get("Content-Type", "") != \
+                "application/x-git-upload-pack-advertisement":
+            shallow = False
+
+    if shallow:
+        args += ["--depth", "1"]
+
+    if url.fragment:
+        url = (url.scheme, url.netloc, url.path, url.params, url.query, "")
+
+    return args + [urlunparse(url), root_dir]
+
+
+def checkout(fragment, root_dir):
+    """Checks out a git reference into the root directory
+
+    Args:
+        fragment (str): the URL fragment specifying the directory to checkout
+        root_dir: the root directory of the cloned repository
+
+    Returns:
+        str: A local path to the build context
+
+    Raises:
+        :py:class:`docker.errors.GitError`
+            if checking out the git reference fails
+    """
+    try:
+        ref, context_dir = fragment.split(':', 1)
+    except ValueError:
+        ref, context_dir = fragment, ""
+
+    if ref:
+        git_within_dir(root_dir, "checkout", ref)
+
+    if context_dir:
+        full_context_dir = os.path.join(root_dir, context_dir)
+        if not os.path.isdir(full_context_dir):
+            raise GitError("Error setting git context, "
+                           "%s not a directory in git root" % context_dir)
+
+        root_dir = full_context_dir
+
+    return root_dir
+
+
+def git_within_dir(root_dir, *args):
+    return git("--work-tree", root_dir, "--git-dir",
+               os.path.join(root_dir, ".git"), *args)
+
+
+def git(*args):
+    """Executes the git command in a subprocess with the specified args
+
+    Args:
+        *args (tuple): Variable length string arguments passed to git command
+
+    Returns:
+        True if successful
+
+    Raises:
+        :py:class:`docker.errors.GitError`
+            if the git process returns with a non-zero exit code
+    """
+    log.debug("Executing: git %s", " ".join(args))
+    return_code = subprocess.call(("git",) + args)
+    if return_code != 0:
+        raise GitError("Error trying to use git: exit status %d" % return_code)
+
+    return True

--- a/tests/integration/git_repo_test.py
+++ b/tests/integration/git_repo_test.py
@@ -1,0 +1,41 @@
+from .base import BaseAPIIntegrationTest
+import os
+import tempfile
+import shutil
+
+from docker.utils import make_git_build_context
+from docker.utils import git
+
+
+class GitBuildTest(BaseAPIIntegrationTest):
+
+    def setUp(self):
+        super(GitBuildTest, self).setUp()
+
+        root_dir = tempfile.mkdtemp(prefix='docker-test-git-checkout')
+        self.addCleanup(shutil.rmtree, root_dir)
+
+        repo_dir = os.path.join(root_dir, 'repo')
+        git.git('init', repo_dir)
+        git.git_within_dir(repo_dir, 'config', 'user.email', 'test@docker.com')
+        git.git_within_dir(repo_dir, 'config', 'user.name', 'Test')
+
+        with open(os.path.join(repo_dir, 'Dockerfile'), 'w') as f:
+            f.write('FROM busybox')
+
+        git.git_within_dir(repo_dir, 'add', '-A')
+        git.git_within_dir(repo_dir, 'commit', '-am', 'initial commit')
+
+        self.repo_dir = repo_dir
+
+    def test_build_git_repo(self):
+        fileobj = make_git_build_context('file://' + self.repo_dir)
+
+        stream = self.client.build(fileobj=fileobj, custom_context=True,
+                                   decode=True)
+
+        lines = []
+        for chunk in stream:
+            lines.append(chunk)
+
+        assert 'Successfully built' in lines[-1]['stream']

--- a/tests/unit/utils_git_test.py
+++ b/tests/unit/utils_git_test.py
@@ -1,0 +1,211 @@
+import unittest
+import tempfile
+import shutil
+import os
+
+from docker.utils import git
+from docker.errors import GitError
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
+
+
+class GitTest(unittest.TestCase):
+
+    def test_is_git_url(self):
+        self.assertTrue(git.is_git_url("https://github.com/repo/root.git"))
+        self.assertTrue(git.is_git_url(
+            "https://github.com/repo/root.git#branch"
+        ))
+        self.assertTrue(git.is_git_url(
+            "https://github.com/repo/root.git#branch:folder"
+        ))
+
+        self.assertTrue(git.is_git_url("http://github.com/repo/root.git"))
+        self.assertTrue(git.is_git_url(
+            "http://github.com/repo/root.git#branch"
+        ))
+        self.assertTrue(git.is_git_url(
+            "http://github.com/repo/root.git#branch:folder"
+        ))
+
+        self.assertTrue(git.is_git_url("git://github.com/repo/root"))
+        self.assertTrue(git.is_git_url("git://github.com/repo/root.git"))
+        self.assertTrue(git.is_git_url(
+            "git://github.com/repo/root.git#branch"
+        ))
+        self.assertTrue(git.is_git_url(
+            "git://github.com/repo/root.git#branch:folder"
+        ))
+
+        self.assertTrue(git.is_git_url("github.com/repo/root"))
+        self.assertTrue(git.is_git_url("github.com/repo/root.git"))
+        self.assertTrue(git.is_git_url("github.com/repo/root.git#branch"))
+        self.assertTrue(git.is_git_url(
+            "github.com/repo/root.git#branch:folder"
+        ))
+
+        self.assertFalse(git.is_git_url("https://server/root"))
+        self.assertTrue(git.is_git_url("https://server/root.git"))
+        self.assertTrue(git.is_git_url("https://server/root.git#branch"))
+        self.assertTrue(git.is_git_url(
+            "https://server/root.git#branch:folder"
+        ))
+
+        self.assertFalse(git.is_git_url("http://server/context.tar.gz"))
+        self.assertFalse(git.is_git_url("https://server/context.tar.gz"))
+
+    @mock.patch('docker.utils.git.tar')
+    def test_make_git_context_with_dockerignore(self, mock_tar):
+        root_dir = tempfile.mkdtemp(prefix='docker-test-make-git-context')
+        self.addCleanup(shutil.rmtree, root_dir)
+
+        with open(os.path.join(root_dir, '.dockerignore'), 'w') as f:
+            f.write('\n'.join([
+                'ignored',
+                'Dockerfile',
+                '.dockerignore',
+                '!ignored/subdir/excepted-file',
+                '',  # empty line
+            ]))
+
+        mock_clone = mock.Mock(return_value=root_dir)
+        with mock.patch('docker.utils.git.clone', mock_clone):
+            git.make_git_build_context('https://github.com/user/repo.git')
+
+        mock_tar.assert_called_once_with(root_dir, exclude=[
+            'ignored',
+            'Dockerfile',
+            '.dockerignore',
+            '!ignored/subdir/excepted-file'
+        ])
+
+    @mock.patch('docker.utils.git.tar')
+    def test_make_git_context_with_kwargs(self, mock_tar):
+        mock_clone = mock.Mock(return_value='/tmp')
+        with mock.patch('docker.utils.git.clone', mock_clone):
+            git.make_git_build_context('https://github.com/user/repo.git',
+                                       dockerfile='Dockerfile-test')
+
+        mock_tar.assert_called_once_with('/tmp', exclude=None,
+                                         dockerfile='Dockerfile-test')
+
+    def test_clone_args_smart_http(self):
+        mock_requests = mock.Mock(
+            get=mock.Mock(return_value=mock.Mock(headers={
+                "Content-Type": "application/x-git-upload-pack-advertisement"
+            }))
+        )
+
+        repo_url = 'https://github.com/user/repo.git'
+        parsed_url = urlparse(repo_url)
+
+        with mock.patch('docker.utils.git.requests', mock_requests):
+            args = git.get_clone_args(parsed_url, '/tmp')
+            self.assertListEqual(args, ['clone', '--recursive', '--depth', '1',
+                                        repo_url, '/tmp'])
+
+    def test_clone_args_dumb_http(self):
+        mock_requests = mock.Mock(
+            get=mock.Mock(return_value=mock.Mock(headers={
+                "Content-Type": "text/plain"
+            }))
+        )
+
+        repo_url = 'https://github.com/user/repo.git'
+        parsed_url = urlparse(repo_url)
+
+        with mock.patch('docker.utils.git.requests', mock_requests):
+            args = git.get_clone_args(parsed_url, '/tmp')
+            self.assertListEqual(args,
+                                 ['clone', '--recursive', repo_url, '/tmp'])
+
+    def test_clone_args_git(self):
+        repo_url = 'git://github.com/user/repo'
+        parsed_url = urlparse(repo_url)
+
+        args = git.get_clone_args(parsed_url, '/tmp')
+        self.assertListEqual(args, ['clone', '--recursive', '--depth', '1',
+                                    repo_url, '/tmp'])
+
+    def test_clone_args_fragment_stripped(self):
+        repo_url = 'git://github.com/user/repo#fragment'
+        parsed_url = urlparse(repo_url)
+
+        args = git.get_clone_args(parsed_url, '/tmp')
+        self.assertListEqual(args, ['clone', '--recursive',
+                                    'git://github.com/user/repo', '/tmp'])
+
+    def test_clone_args_git_ssh(self):
+        repo_url = 'git@github.com:user/repo.git'
+        parsed_url = urlparse(repo_url)
+
+        args = git.get_clone_args(parsed_url, '/tmp')
+        self.assertListEqual(args, ['clone', '--recursive', '--depth', '1',
+                                    repo_url, '/tmp'])
+
+    def test_git_checkout(self):
+        root_dir = tempfile.mkdtemp(prefix='docker-test-git-checkout')
+        self.addCleanup(shutil.rmtree, root_dir)
+
+        repo_dir = os.path.join(root_dir, 'repo')
+        git.git('init', repo_dir)
+        git.git_within_dir(repo_dir, 'config', 'user.email', 'test@docker.com')
+        git.git_within_dir(repo_dir, 'config', 'user.name', 'Test')
+
+        with open(os.path.join(repo_dir, 'Dockerfile'), 'w') as f:
+            f.write('FROM scratch')
+
+        sub_dir = os.path.join(repo_dir, 'subdir')
+        os.mkdir(sub_dir)
+
+        with open(os.path.join(sub_dir, 'Dockerfile'), 'w') as f:
+            f.write('FROM scratch\nEXPOSE 5000')
+
+        git.git_within_dir(repo_dir, 'add', '-A')
+        git.git_within_dir(repo_dir, 'commit', '-am', 'initial commit')
+        git.git_within_dir(repo_dir, 'checkout', '-b', 'test-branch')
+
+        with open(os.path.join(repo_dir, 'Dockerfile'), 'w') as f:
+            f.write('FROM scratch\nEXPOSE 6000')
+
+        with open(os.path.join(sub_dir, 'Dockerfile'), 'w') as f:
+            f.write('FROM scratch\nEXPOSE 7000')
+
+        git.git_within_dir(repo_dir, 'add', '-A')
+        git.git_within_dir(repo_dir, 'commit', '-am', 'branch commit')
+        git.git_within_dir(repo_dir, 'checkout', 'master')
+
+        test_cases = (
+            ('', ['FROM scratch'], False),
+            ('master', ['FROM scratch'], False),
+            (':subdir', ['FROM scratch', 'EXPOSE 5000'], False),
+            (':nosubdir', '', True),
+            (':Dockerfile', '', True),
+            ('master:nosubdir', '', True),
+            ('master:subdir', ['FROM scratch', 'EXPOSE 5000'], False),
+            ('test-branch', ['FROM scratch', 'EXPOSE 6000'], False),
+            ('test-branch:', ['FROM scratch', 'EXPOSE 6000'], False),
+            ('test-branch:subdir', ['FROM scratch', 'EXPOSE 7000'], False),
+        )
+
+        for frag, expected, should_fail in test_cases:
+            print('Fragment Test: %s' % frag)
+            if should_fail:
+                with self.assertRaises(GitError):
+                    git.checkout(frag, repo_dir)
+                continue
+            else:
+                context_path = git.checkout(frag, repo_dir)
+
+            with open(os.path.join(context_path, 'Dockerfile'), 'r') as f:
+                dockerfile = f.read().splitlines()
+
+            self.assertListEqual(expected, dockerfile)


### PR DESCRIPTION
This adds a package to docker.utils for dealing with building directly from git repos.

This feature mostly mirrors how `docker` implements cloning in the client, so it supports the same git protocols, branch checkouts, and subfolders. One notable exception is that it does NOT automatically detect git URLs and clone the repo in the client by default like `docker` does.  As currently implemented, this would require the end user to pass the result as a custom_context to build(). Ref: #980 