### PR TITLE
Fix APIError status_code property for client/server errors

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -59,7 +59,7 @@ class APIError(requests.exceptions.HTTPError, DockerException):
 
     @property
     def status_code(self):
-        if self.response:
+        if self.response is not None:
             return self.response.status_code
 
     def is_client_error(self):

--- a/tests/unit/errors_test.py
+++ b/tests/unit/errors_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+import requests
+
 from docker.errors import (APIError, DockerException,
                            create_unexpected_kwargs_error)
 
@@ -10,6 +12,69 @@ class APIErrorTest(unittest.TestCase):
             raise APIError("this should be caught by DockerException")
         except DockerException:
             pass
+
+    def test_status_code_200(self):
+        """The status_code property is present with 200 response."""
+        resp = requests.Response()
+        resp.status_code = 200
+        err = APIError('', response=resp)
+        assert err.status_code == 200
+
+    def test_status_code_400(self):
+        """The status_code property is present with 400 response."""
+        resp = requests.Response()
+        resp.status_code = 400
+        err = APIError('', response=resp)
+        assert err.status_code == 400
+
+    def test_status_code_500(self):
+        """The status_code property is present with 500 response."""
+        resp = requests.Response()
+        resp.status_code = 500
+        err = APIError('', response=resp)
+        assert err.status_code == 500
+
+    def test_is_server_error_200(self):
+        """Report not server error on 200 response."""
+        resp = requests.Response()
+        resp.status_code = 200
+        err = APIError('', response=resp)
+        assert err.is_server_error() is False
+
+    def test_is_server_error_300(self):
+        """Report not server error on 300 response."""
+        resp = requests.Response()
+        resp.status_code = 300
+        err = APIError('', response=resp)
+        assert err.is_server_error() is False
+
+    def test_is_server_error_400(self):
+        """Report not server error on 400 response."""
+        resp = requests.Response()
+        resp.status_code = 400
+        err = APIError('', response=resp)
+        assert err.is_server_error() is False
+
+    def test_is_server_error_500(self):
+        """Report server error on 500 response."""
+        resp = requests.Response()
+        resp.status_code = 500
+        err = APIError('', response=resp)
+        assert err.is_server_error() is True
+
+    def test_is_client_error_500(self):
+        """Report not client error on 500 response."""
+        resp = requests.Response()
+        resp.status_code = 500
+        err = APIError('', response=resp)
+        assert err.is_client_error() is False
+
+    def test_is_client_error_400(self):
+        """Report client error on 400 response."""
+        resp = requests.Response()
+        resp.status_code = 400
+        err = APIError('', response=resp)
+        assert err.is_client_error() is True
 
 
 class CreateUnexpectedKwargsErrorTest(unittest.TestCase):


### PR DESCRIPTION
requests.Response objects evaluate as falsy when the status_code
attribute is in the 400-500 range. Therefore we are assured that
prior to this change, APIError would show `is_server_error() == False`
when generated with a 500-level response and `is_client_error() == False`
when generated with a 400-level response. This is not desirable.

Added some seemingly dry (not DRY) unit tests to ensure nothing silly
slips back in here, and of course to verify the problem/fix