### PR TITLE
Set infinite timeout for the `events` method

### DIFF
--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -68,9 +68,10 @@ class DaemonApiMixin(object):
             'until': until,
             'filters': filters
         }
+        url = self._url('/events')
 
         return self._stream_helper(
-            self._get(self._url('/events'), params=params, stream=True),
+            self._get(url, params=params, stream=True, timeout=None),
             decode=decode
         )
 

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -363,7 +363,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         self.tmp_secrets.append(secret_id)
         secret_ref = docker.types.SecretReference(secret_id, secret_name)
         container_spec = docker.types.ContainerSpec(
-            'busybox', ['top'], secrets=[secret_ref]
+            'busybox', ['sleep', '999'], secrets=[secret_ref]
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()
@@ -388,7 +388,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         self.tmp_secrets.append(secret_id)
         secret_ref = docker.types.SecretReference(secret_id, secret_name)
         container_spec = docker.types.ContainerSpec(
-            'busybox', ['top'], secrets=[secret_ref]
+            'busybox', ['sleep', '999'], secrets=[secret_ref]
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -229,7 +229,7 @@ class DockerApiTest(BaseAPIClientTest):
             url_prefix + 'events',
             params={'since': None, 'until': None, 'filters': None},
             stream=True,
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=None
         )
 
     def test_events_with_since_until(self):
@@ -249,7 +249,7 @@ class DockerApiTest(BaseAPIClientTest):
                 'filters': None
             },
             stream=True,
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=None
         )
 
     def test_events_with_filters(self):
@@ -268,7 +268,7 @@ class DockerApiTest(BaseAPIClientTest):
                 'filters': expected_filters
             },
             stream=True,
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=None
         )
 
     def _socket_path_for_client_session(self, client):


### PR DESCRIPTION
Fixes #1523 