### PR TITLE
add auto_remove to RUN_HOST_CONFIG_KWARGS

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -798,6 +798,7 @@ RUN_CREATE_KWARGS = [
 
 # kwargs to copy straight from run to host_config
 RUN_HOST_CONFIG_KWARGS = [
+    'auto_remove',
     'blkio_weight_device',
     'blkio_weight',
     'cap_add',


### PR DESCRIPTION
Add auto_remove to `RUN_HOST_CONFIG_KWARGS`, to fix unexpected keyword error and make `auto_remove` argument can be passed to HostConfig correctly. 