### PR TITLE
Fix #1477: Allow detach and remove for api versions >= 1.25

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -4,6 +4,7 @@ from ..api import APIClient
 from ..errors import (ContainerError, ImageNotFound,
                       create_unexpected_kwargs_error)
 from ..types import HostConfig
+from ..utils import compare_version
 from .images import Image
 from .resource import Collection, Model
 
@@ -652,8 +653,12 @@ class ContainerCollection(Collection):
             image = image.id
         detach = kwargs.pop("detach", False)
         if detach and remove:
-            raise RuntimeError("The options 'detach' and 'remove' cannot be "
-                               "used together.")
+            if compare_version("1.24",
+                               self.client.api._version) > 0:
+                kwargs["auto_remove"] = True
+            else:
+                raise RuntimeError("The options 'detach' and 'remove' cannot "
+                                   "be used together in api versions < 1.25.")
 
         try:
             container = self.create(image=image, command=command,
@@ -798,6 +803,7 @@ RUN_CREATE_KWARGS = [
 
 # kwargs to copy straight from run to host_config
 RUN_HOST_CONFIG_KWARGS = [
+    'auto_remove',
     'blkio_weight_device',
     'blkio_weight',
     'cap_add',

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -274,8 +274,38 @@ class ContainerCollectionTest(unittest.TestCase):
         client.api.remove_container.assert_called_with(FAKE_CONTAINER_ID)
 
         client = make_fake_client()
+        client.api._version = '1.24'
         with self.assertRaises(RuntimeError):
             client.containers.run("alpine", detach=True, remove=True)
+
+        client = make_fake_client()
+        client.api._version = '1.23'
+        with self.assertRaises(RuntimeError):
+            client.containers.run("alpine", detach=True, remove=True)
+
+        client = make_fake_client()
+        client.api._version = '1.25'
+        client.containers.run("alpine", detach=True, remove=True)
+        client.api.remove_container.assert_not_called()
+        client.api.create_container.assert_called_with(
+            command=None,
+            image='alpine',
+            detach=True,
+            host_config={'AutoRemove': True,
+                         'NetworkMode': 'default'}
+        )
+
+        client = make_fake_client()
+        client.api._version = '1.26'
+        client.containers.run("alpine", detach=True, remove=True)
+        client.api.remove_container.assert_not_called()
+        client.api.create_container.assert_called_with(
+            command=None,
+            image='alpine',
+            detach=True,
+            host_config={'AutoRemove': True,
+                         'NetworkMode': 'default'}
+        )
 
     def test_create(self):
         client = make_fake_client()


### PR DESCRIPTION
This pull request addresses the exception that is currently raised when a container attempts to start with "detach" and "remove" both set. The current behavior is to throw a RuntimeError without considering the version of the API.

This pull request implements the following behavior:

1) For API versions >= 1.25, when "detach" and "remove" are both set, do not throw the RuntimeError. Assume that the caller intends for the container to be automatically removed when the container's process exits and set the "auto_remove" flag to True.

2) For API versions < 1.25 continue to throw the RuntimeError.

Although suggested in the discussion thread for issue #1497, this pull request does not automatically convert remove=True to auto_remove=True when the api version is >= 1.25. The reason for this decision is that the remove flag in the run function is tied to logic that captures the logs of the container before removing it. If "remove" were automatically converted to "auto_remove," log capture cannot be guaranteed before the container is removed in cases where detach=False.

Signed-off-by: David Steines <d.steines@gmail.com>