### PR TITLE
Use `requires[security]` in the requirements instead of just `requires`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The latest stable version [is available on PyPI](https://pypi.python.org/pypi/do
 
     pip install docker
 
+If you are intending to connect to a docker host via TLS, add `docker[tls]` to your requirements instead, or install with pip:
+
+    pip install docker[tls]
+
 ## Usage
 
 Connect to Docker using the default socket or the configuration in your environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: '{branch}-{build}'
 install:
   - "SET PATH=C:\\Python27-x64;C:\\Python27-x64\\Scripts;%PATH%"
   - "python --version"
-  - "pip install tox==2.1.1 virtualenv==13.1.2"
+  - "pip install tox==2.7.0 virtualenv==15.1.0"
 
 # Build the binary after tests
 build: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,16 @@
-requests[security]==2.11.1
-six>=1.4.0
-websocket-client==0.32.0
-backports.ssl_match_hostname>=3.5 ; python_version < '3.5'
-ipaddress==1.0.16 ; python_version < '3.3'
+appdirs==1.4.3
+asn1crypto==0.22.0
+backports.ssl-match-hostname==3.5.0.1
+cffi==1.10.0
+cryptography==1.9
 docker-pycreds==0.2.1
+enum34==1.1.6
+idna==2.5
+ipaddress==1.0.18
+packaging==16.8
+pycparser==2.17
+pyOpenSSL==17.0.0
+pyparsing==2.2.0
+requests==2.14.2
+six==1.10.0
+websocket-client==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.11.1
+requests[security]==2.11.1
 six>=1.4.0
 websocket-client==0.32.0
 backports.ssl_match_hostname>=3.5 ; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,10 @@ extras_require = {
     # ServerAltname: https://pypi.python.org/pypi/backports.ssl_match_hostname
     ':python_version < "3.3"': 'ipaddress >= 1.0.16',
 
-    # If using docker-py over TLS, highly recommend this option is pip-installed
-    # or pinned.
+    # If using docker-py over TLS, highly recommend this option is
+    # pip-installed or pinned.
 
-    # TODO: if pip installign both "requests" and "requests[security]", the
+    # TODO: if pip installing both "requests" and "requests[security]", the
     # extra package from the "security" option are not installed (see
     # https://github.com/pypa/pip/issues/4391).  Once that's fixed, instead of
     # installing the extra dependencies, install the following instead:

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,16 @@ extras_require = {
     # ssl_match_hostname to verify hosts match with certificates via
     # ServerAltname: https://pypi.python.org/pypi/backports.ssl_match_hostname
     ':python_version < "3.3"': 'ipaddress >= 1.0.16',
+
+    # If using docker-py over TLS, highly recommend this option is pip-installed
+    # or pinned.
+
+    # TODO: if pip installign both "requests" and "requests[security]", the
+    # extra package from the "security" option are not installed (see
+    # https://github.com/pypa/pip/issues/4391).  Once that's fixed, instead of
+    # installing the extra dependencies, install the following instead:
+    # 'requests[security] >= 2.5.2, != 2.11.0, != 2.12.2'
+    'tls': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
 }
 
 version = None


### PR DESCRIPTION
This installs a few more packages, but guarantees that at least on Mac OS a newer version of openssl is used instead of the default, which doesn't support TLS 1.2.  I think the openssl is provided for Windows wheels too.

See https://stackoverflow.com/questions/31811949/pip-install-requestssecurity-vs-pip-install-requests-difference.

An alternative is to specify a "security" option similar to requests:  see https://github.com/kennethreitz/requests/blob/master/setup.py#L98.

Also since the `requirements.txt` is pinning specific versions, I just pinned everything (including deps of deps) for a consistent build.