### PR TITLE
Parameter typo in services.py fixed

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -302,7 +302,7 @@ class RestartPolicy(dict):
         condition (string): Condition for restart (``none``, ``on-failure``,
           or ``any``). Default: `none`.
         delay (int): Delay between restart attempts. Default: 0
-        attempts (int): Maximum attempts to restart a given container before
+        max_attempts (int): Maximum attempts to restart a given container before
           giving up. Default value is 0, which is ignored.
         window (int): Time window used to evaluate the restart policy. Default
           value is 0, which is unbounded.


### PR DESCRIPTION
Fixes #1489 
Typo fixed changed `attempts` to `max_attempts`