### PR TITLE
fix can't get a dict when Containers is None

### DIFF
--- a/docker/models/networks.py
+++ b/docker/models/networks.py
@@ -22,7 +22,7 @@ class Network(Model):
         """
         return [
             self.client.containers.get(cid) for cid in
-            self.attrs.get('Containers', {}).keys()
+            (self.attrs.get('Containers') or {}).keys()
         ]
 
     def connect(self, container):


### PR DESCRIPTION
Hi, guys

I use Docker version 17.04.0-ce, build 4845c56

When I use swarm mode and create a test network, I try to get containers info by `network.containers` ,but something wrong like this:

```
[2017-04-26 01:35:30,625] ERROR in app: Exception on /networks/tm0g5b5bjv7qfqmx027x22s08 [DELETE]
Traceback (most recent call last):
  File "/Users/hypo/.virtualenvs/agent/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/hypo/.virtualenvs/agent/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/hypo/.virtualenvs/agent/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/hypo/.virtualenvs/agent/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/hypo/.virtualenvs/agent/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/hypo/Project/agent/api/network.py", line 92, in delete_network_by_id
    containers = len(n.containers)
  File "/Users/hypo/.virtualenvs/agent/lib/python2.7/site-packages/docker/models/networks.py", line 25, in containers
    self.attrs.get('Containers', {}).keys()
AttributeError: 'NoneType' object has no attribute 'keys'
```

then I find the payload from docker like this:

```
{
  "Attachable": false,
  "Containers": null,
  "Created": "0001-01-01T00:00:00Z",
  "Driver": "overlay",
  "EnableIPv6": false,
  "IPAM": {
    "Config": [],
    "Driver": "",
    "Options": null
  },
  "Id": "g2momey03awcu1ib36blowpt8",
  "Internal": false,
  "Labels": null,
  "Name": "test",
  "Options": {
    "com.docker.network.driver.overlay.vxlanid_list": "4097"
  },
  "Scope": "swarm"
}
```

I think it is necessary to make sure the Containers is not None. _(:з」∠)_
Signed-off-by: Hypo Chen <i@ihypo.net>