### PR TITLE
Fix if replicas is set to 0, Fixes #1572

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -407,7 +407,7 @@ class ServiceMode(dict):
                 'replicas can only be used for replicated mode'
             )
         self[mode] = {}
-        if replicas:
+        if replicas is not None:
             self[mode]['Replicas'] = replicas
 
     @property

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -305,6 +305,12 @@ class ServiceModeTest(unittest.TestCase):
         assert mode.mode == 'replicated'
         assert mode.replicas == 21
 
+    def test_replicated_replicas_0(self):
+        mode = ServiceMode('replicated', 0)
+        assert mode == {'replicated': {'Replicas': 0}}
+        assert mode.mode == 'replicated'
+        assert mode.replicas == 0
+
     def test_invalid_mode(self):
         with pytest.raises(InvalidArgument):
             ServiceMode('foobar')


### PR DESCRIPTION
This will fix the issue in #1572.

Added a test to make sure that if replicas is set to 0 it will really be 0.

Following code would return false in case of replicas is 0, this would prevent from updating a service to have 0 replicas.

```
if replicas:
  do something
```
