### PR TITLE
Allow auto_remove in the host config kwargs list

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -814,6 +814,7 @@ RUN_CREATE_KWARGS = [
 
 # kwargs to copy straight from run to host_config
 RUN_HOST_CONFIG_KWARGS = [
+    'auto_remove',
     'blkio_weight_device',
     'blkio_weight',
     'cap_add',

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -33,6 +33,7 @@ class ContainerCollectionTest(unittest.TestCase):
         create_kwargs = _create_container_args(dict(
             image='alpine',
             command='echo hello world',
+            auto_remove=True,
             blkio_weight_device=[{'Path': 'foo', 'Weight': 3}],
             blkio_weight=2,
             cap_add=['foo'],
@@ -95,7 +96,7 @@ class ContainerCollectionTest(unittest.TestCase):
             ulimits=[{"Name": "nofile", "Soft": 1024, "Hard": 2048}],
             user='bob',
             userns_mode='host',
-            version='1.23',
+            version='1.25',
             volume_driver='some_driver',
             volumes=[
                 '/home/user1/:/mnt/vol2',
@@ -116,6 +117,7 @@ class ContainerCollectionTest(unittest.TestCase):
             entrypoint='/bin/sh',
             environment={'FOO': 'BAR'},
             host_config={
+                'AutoRemove': True,
                 'Binds': [
                     '/home/user1/:/mnt/vol2',
                     '/var/www:/mnt/vol1:ro',


### PR DESCRIPTION
The feature is supported, clearly stated in the containers.run() pydoc,
but the kwargs list spot check prevent the parameters from going through.

Fixes #1579

Signed-off-by: Martin Roy <lindycoder@gmail.com>