### PR TITLE
Clear uname/gname when creating tar archive

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -103,6 +103,10 @@ def create_archive(root, files=None, fileobj=None, gzip=False):
             # ignore it and proceed.
             continue
 
+        # Clear uname/gname as the docker client does.
+        i.uname = ''
+        i.gname = ''
+
         if constants.IS_WINDOWS_PLATFORM:
             # Windows doesn't keep track of the execute bit, so we make files
             # and directories executable by default.


### PR DESCRIPTION
To ensure that the cache from docker command client
can be reused, we must clear group/user name as the docker
client does.

Together with golang/go#20150 this fixes #998

Signed-off-by: Lars Jeppesen <lj@linel.dk>