### PR TITLE
Add function to refresh credentials from config.json

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -433,3 +433,17 @@ class APIClient(
     @property
     def api_version(self):
         return self._version
+
+    def reload_config(self, dockercfg_path=None):
+        """
+        Force a reload of the auth configuration
+
+        Args:
+            dockercfg_path (str): Use a custom path for the Docker config file
+                (default ``$HOME/.docker/config.json`` if present,
+                otherwise``$HOME/.dockercfg``)
+
+        Returns:
+            None
+        """
+        self._auth_configs = auth.load_config(dockercfg_path)

--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -123,9 +123,9 @@ class DaemonApiMixin(object):
         # If dockercfg_path is passed check to see if the config file exists,
         # if so load that config.
         if dockercfg_path and os.path.exists(dockercfg_path):
-            self._auth_configs = auth.load_config(dockercfg_path)
+            self._auth_configs = self.reload_config(dockercfg_path)
         elif not self._auth_configs:
-            self._auth_configs = auth.load_config()
+            self._auth_configs = self.reload_config()
 
         authcfg = auth.resolve_authconfig(self._auth_configs, registry)
         # If we found an existing auth config for this registry and username
@@ -174,3 +174,17 @@ class DaemonApiMixin(object):
         """
         url = self._url("/version", versioned_api=api_version)
         return self._result(self._get(url), json=True)
+
+    def reload_config(self, dockercfg_path=None):
+        """
+        Forces a reload of the auth configuration
+
+        Args:
+            dockercfg_path (str): Use a custom path for the Docker config file
+                (default ``$HOME/.docker/config.json`` if present,
+                otherwise``$HOME/.dockercfg``)
+
+        Returns:
+            None
+        """
+        self._auth_configs = auth.load_config(dockercfg_path)

--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -123,9 +123,9 @@ class DaemonApiMixin(object):
         # If dockercfg_path is passed check to see if the config file exists,
         # if so load that config.
         if dockercfg_path and os.path.exists(dockercfg_path):
-            self._auth_configs = self.reload_config(dockercfg_path)
+            self._auth_configs = auth.load_config(dockercfg_path)
         elif not self._auth_configs:
-            self._auth_configs = self.reload_config()
+            self._auth_configs = auth.load_config()
 
         authcfg = auth.resolve_authconfig(self._auth_configs, registry)
         # If we found an existing auth config for this registry and username
@@ -174,17 +174,3 @@ class DaemonApiMixin(object):
         """
         url = self._url("/version", versioned_api=api_version)
         return self._result(self._get(url), json=True)
-
-    def reload_config(self, dockercfg_path=None):
-        """
-        Forces a reload of the auth configuration
-
-        Args:
-            dockercfg_path (str): Use a custom path for the Docker config file
-                (default ``$HOME/.docker/config.json`` if present,
-                otherwise``$HOME/.dockercfg``)
-
-        Returns:
-            None
-        """
-        self._auth_configs = auth.load_config(dockercfg_path)


### PR DESCRIPTION
# SCENARIO

1. docker-py performs an action that sets the ``X-Registry-Auth`` header in the API request (push, pull, etc.)
2. Password is changed for a registry.
3. ``docker login`` is performed on the CLI to update the config.json.
4. Pushes for the client instance now fail, since it has cached the auth configuration.

# SOLUTION

- ~~Add a ``refresh`` param (default: ``False``) to ``docker.auth.get_config_header()`` which, when ``True``, forces a refresh of the config.json.~~
- ~~Update all functions which call ``docker.auth.get_config_header()`` to support a ``refresh_credentials`` argument (default: ``False``) which is passed through as ``refresh`` when ``get_config_header()`` is called.~~
- ~~Using ``client.push('myuser/myimage', tag='mytag', refresh_credentials=True)``, docker-py now has up-to-date auth configuration.~~

- A function has been added to the ``DaemonApiMixin`` which allows for the auth to be reloaded for an existing ``APIClient`` instance (e.g. ``client.reload_config()``)