### PR TITLE
Use collection's get method inside ImageCollection's list method

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -221,7 +221,7 @@ class ImageCollection(Collection):
                 If the server returns an error.
         """
         resp = self.client.api.images(name=name, all=all, filters=filters)
-        return [self.prepare_model(r) for r in resp]
+        return [self.get(r["Id"]) for r in resp]
 
     def load(self, data):
         """


### PR DESCRIPTION
- Replicate the same thing as in `ContainerCollection`
- Without doing this, `Image.attrs` will not be the result of `docker inspect`, unless you run `Image.reload` method once
- Originally, getting `Image.labels` property raises an error because there's no `Labels` field in `Configs`