### PR TITLE
init_path removed in Engine 17.05

### DIFF
--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -438,6 +438,10 @@ class HostConfig(dict):
         if init_path is not None:
             if version_lt(version, '1.25'):
                 raise host_config_version_error('init_path', '1.25')
+
+            if version_gte(version, '1.29'):
+                # https://github.com/moby/moby/pull/32470
+                raise host_config_version_error('init_path', '1.29', False)
             self['InitPath'] = init_path
 
         if volume_driver is not None:

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -451,6 +451,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         config = self.client.inspect_container(ctnr)
         assert config['HostConfig']['Init'] is True
 
+    @pytest.mark.xfail(True, reason='init-path removed in 17.05.0')
     @requires_api_version('1.25')
     def test_create_with_init_path(self):
         ctnr = self.client.create_container(


### PR DESCRIPTION
https://github.com/moby/moby/pull/32470