### PR TITLE
update docker-py test status code from 500 to 400

### DIFF
--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -168,7 +168,7 @@ class SwarmTest(BaseAPIIntegrationTest):
         with pytest.raises(docker.errors.APIError) as e:
             self.client.remove_node(node_id)
 
-        assert e.value.response.status_code == 500
+        assert e.value.response.status_code >= 400
 
         with pytest.raises(docker.errors.APIError) as e:
             self.client.remove_node(node_id, True)


### PR DESCRIPTION
Since PR in moby/moby https://github.com/moby/moby/pull/32122 hopes to get status code from rpc code which is determined in swarmkit.

So, when we made this rule, we found that  some status code from moby/moby needs changed.

While in integration test of moby/moby, we will use docker-py to test daemon's API. It always fails in this status code. So I try to make this change.

ping @shin- @thaJeztah @stevvooe

Signed-off-by: allencloud <allen.sun@daocloud.io>