### PR TITLE
Fix docstring of ImageCollection.get

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -193,8 +193,8 @@ class ImageCollection(Collection):
             (:py:class:`Image`): The image.
 
         Raises:
-            :py:class:`docker.errors.ImageNotFound` If the image does not
-            exist.
+            :py:class:`docker.errors.ImageNotFound`
+                If the image does not exist.
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
         """


### PR DESCRIPTION
Docstring is not rendered correctly. This PR fixes it.
[![https://gyazo.com/7e5eeb963d09fdeac2c1da4b93a21197](https://i.gyazo.com/7e5eeb963d09fdeac2c1da4b93a21197.png)](https://gyazo.com/7e5eeb963d09fdeac2c1da4b93a21197)
https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.get

Signed-off-by: Yusuke Miyazaki <miyazaki.dev@gmail.com>