### PR TITLE
Add `target` argument to image building

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -18,7 +18,7 @@ class BuildApiMixin(object):
               custom_context=False, encoding=None, pull=False,
               forcerm=False, dockerfile=None, container_limits=None,
               decode=False, buildargs=None, gzip=False, shmsize=None,
-              labels=None, cache_from=None):
+              labels=None, cache_from=None, target=None):
         """
         Similar to the ``docker build`` command. Either ``path`` or ``fileobj``
         needs to be set. ``path`` can be a local path (to a directory
@@ -94,6 +94,8 @@ class BuildApiMixin(object):
             labels (dict): A dictionary of labels to set on the image.
             cache_from (list): A list of images used for build cache
                 resolution.
+            target (str): Name of the build-stage to build in a multi-stage
+                Dockerfile.
 
         Returns:
             A generator for the build output.
@@ -196,6 +198,14 @@ class BuildApiMixin(object):
             else:
                 raise errors.InvalidVersion(
                     'cache_from was only introduced in API version 1.25'
+                )
+
+        if target:
+            if utils.version_gte(self._version, '1.29'):
+                params.update({'target': target})
+            else:
+                raise errors.InvalidVersion(
+                    'target was only introduced in API version 1.29'
                 )
 
         if context is not None:

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -151,6 +151,8 @@ class ImageCollection(Collection):
                 decoded into dicts on the fly. Default ``False``.
             cache_from (list): A list of images used for build cache
                 resolution.
+            target (str): Name of the build-stage to build in a multi-stage
+                Dockerfile.
 
         Returns:
             (:py:class:`Image`): The built image.


### PR DESCRIPTION
This is related to the multi-stage image building that was introduced in 17.05 (API 1.29).

This allows a user to specify the stage of a multi-stage Dockerfile to build for, rather than the final stage.

Please let me know if I should also add unit tests. I did not add them because the unit tests seem to be run with Docker API 1.26, and the 1.29 test will never be run anyway.
