### PR TITLE
update node remove test status code from 500 to >= 400

### DIFF
--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -173,4 +173,4 @@ class SwarmTest(BaseAPIIntegrationTest):
         with pytest.raises(docker.errors.APIError) as e:
             self.client.remove_node(node_id, True)
 
-        assert e.value.response.status_code == 500
+        assert e.value.response.status_code >= 400


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

This PR is related to PR https://github.com/docker/docker-py/pull/1605.

This is my fault to ignore test the following status code at the test case `test_remove_main_node `. The original thought of this PR is from https://github.com/moby/moby/pull/32122.

What I did:
1. update node remove test status code from 500 to >= 400

ping @shin- @stevvooe