### PR TITLE
fix #1625 where ImageCollection.build() could return with incorrect image id

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -169,19 +169,20 @@ class ImageCollection(Collection):
         if isinstance(resp, six.string_types):
             return self.get(resp)
         last_event = None
+        image_id = None
         for chunk in json_stream(resp):
             if 'error' in chunk:
                 raise BuildError(chunk['error'])
             if 'stream' in chunk:
                 match = re.search(
-                    r'(Successfully built |sha256:)([0-9a-f]+)',
+                    r'(^Successfully built |sha256:)([0-9a-f]+)$',
                     chunk['stream']
                 )
                 if match:
                     image_id = match.group(2)
-                    return self.get(image_id)
             last_event = chunk
-
+        if image_id:
+            return self.get(image_id)
         raise BuildError(last_event or 'Unknown')
 
     def get(self, name):

--- a/tests/integration/models_images_test.py
+++ b/tests/integration/models_images_test.py
@@ -39,6 +39,17 @@ class ImageCollectionTest(BaseIntegrationTest):
         self.tmp_imgs.append(image.id)
         assert client.containers.run(image) == b"hello world\n"
 
+    def test_build_with_success_build_output(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        image = client.images.build(
+            tag='dup-txt-tag', fileobj=io.BytesIO(
+                "FROM alpine\n"
+                "CMD echo Successfully built 33c838732b70".encode('ascii')
+            )
+        )
+        self.tmp_imgs.append(image.id)
+        assert client.containers.run(image) == b"Successfully built 33c838732b70\n"
+
     def test_list(self):
         client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.pull('alpine:latest')

--- a/tests/integration/models_images_test.py
+++ b/tests/integration/models_images_test.py
@@ -44,11 +44,11 @@ class ImageCollectionTest(BaseIntegrationTest):
         image = client.images.build(
             tag='dup-txt-tag', fileobj=io.BytesIO(
                 "FROM alpine\n"
-                "CMD echo Successfully built 33c838732b70".encode('ascii')
+                "CMD echo Successfully built abcd1234".encode('ascii')
             )
         )
         self.tmp_imgs.append(image.id)
-        assert client.containers.run(image) == b"Successfully built 33c838732b70\n"
+        assert client.containers.run(image) == b"Successfully built abcd1234\n"
 
     def test_list(self):
         client = docker.from_env(version=TEST_API_VERSION)


### PR DESCRIPTION
modified ImageCollection.build() method to return the image id parsed from the last "Successful..." build log message.
Signed-off-by: Chris Ottinger <chris.ottinger@team.telstra.com> prematurely 