### PR TITLE
Ensure default timeout is used by API Client

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -83,8 +83,7 @@ class APIClient(
             configuration.
         user_agent (str): Set a custom user agent for requests to the server.
     """
-    def __init__(self, base_url=None, version=None,
-                 timeout=DEFAULT_TIMEOUT_SECONDS, tls=False,
+    def __init__(self, base_url=None, version=None, timeout=None, tls=False,
                  user_agent=DEFAULT_USER_AGENT, num_pools=DEFAULT_NUM_POOLS):
         super(APIClient, self).__init__()
 
@@ -94,7 +93,11 @@ class APIClient(
             )
 
         self.base_url = base_url
-        self.timeout = timeout
+        if timeout is not None:
+            self.timeout = timeout
+        else:
+            self.timeout = DEFAULT_TIMEOUT_SECONDS
+
         self.headers['User-Agent'] = user_agent
 
         self._auth_configs = auth.load_config()

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -83,7 +83,8 @@ class APIClient(
             configuration.
         user_agent (str): Set a custom user agent for requests to the server.
     """
-    def __init__(self, base_url=None, version=None, timeout=None, tls=False,
+    def __init__(self, base_url=None, version=None,
+                 timeout=DEFAULT_TIMEOUT_SECONDS, tls=False,
                  user_agent=DEFAULT_USER_AGENT, num_pools=DEFAULT_NUM_POOLS):
         super(APIClient, self).__init__()
 
@@ -93,11 +94,7 @@ class APIClient(
             )
 
         self.base_url = base_url
-        if timeout is not None:
-            self.timeout = timeout
-        else:
-            self.timeout = DEFAULT_TIMEOUT_SECONDS
-
+        self.timeout = timeout
         self.headers['User-Agent'] = user_agent
 
         self._auth_configs = auth.load_config()

--- a/docker/client.py
+++ b/docker/client.py
@@ -1,4 +1,5 @@
 from .api.client import APIClient
+from .constants import DEFAULT_TIMEOUT_SECONDS
 from .models.containers import ContainerCollection
 from .models.images import ImageCollection
 from .models.networks import NetworkCollection
@@ -73,7 +74,7 @@ class DockerClient(object):
         .. _`SSL version`:
             https://docs.python.org/3.5/library/ssl.html#ssl.PROTOCOL_TLSv1
         """
-        timeout = kwargs.pop('timeout', None)
+        timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT_SECONDS)
         version = kwargs.pop('version', None)
         return cls(timeout=timeout, version=version,
                    **kwargs_from_env(**kwargs))

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1,6 +1,9 @@
 import datetime
 import docker
 from docker.utils import kwargs_from_env
+from docker.constants import (
+    DEFAULT_DOCKER_API_VERSION, DEFAULT_TIMEOUT_SECONDS
+)
 import os
 import unittest
 
@@ -96,3 +99,13 @@ class FromEnvTest(unittest.TestCase):
         client = docker.from_env(version='2.32')
         self.assertEqual(client.api.base_url, "https://192.168.59.103:2376")
         self.assertEqual(client.api._version, '2.32')
+
+    def test_from_env_without_version_uses_default(self):
+        client = docker.from_env()
+
+        self.assertEqual(client.api._version, DEFAULT_DOCKER_API_VERSION)
+
+    def test_from_env_without_timeout_uses_default(self):
+        client = docker.from_env()
+
+        self.assertEqual(client.api.timeout, DEFAULT_TIMEOUT_SECONDS)


### PR DESCRIPTION
The `from_env` method on the `docker` module passed `None` as the value for the `timeout` keyword argument which overrode the default value in the initialiser, taken from `constants` module.

~This sets the default in the initialiser to `None` and adds logic to set that, in the same way that `version` is handled.~

This sets the default in `from_env` to the default defined in the `constants` module.

Addresses #1374 