### PR TITLE
Add attributes for pickling

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -83,6 +83,12 @@ class APIClient(
             configuration.
         user_agent (str): Set a custom user agent for requests to the server.
     """
+
+    __attrs__ = requests.Session.__attrs__ + ['_auth_configs',
+                                              '_version',
+                                              'base_url',
+                                              'timeout']
+
     def __init__(self, base_url=None, version=None,
                  timeout=DEFAULT_TIMEOUT_SECONDS, tls=False,
                  user_agent=DEFAULT_USER_AGENT, num_pools=DEFAULT_NUM_POOLS):

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -69,6 +69,11 @@ class NpipeHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
 
 class NpipeAdapter(requests.adapters.HTTPAdapter):
+
+    __attrs__ = requests.adapters.HTTPAdapter.__attrs__ + ['npipe_path',
+                                                           'pools',
+                                                           'timeout']
+
     def __init__(self, base_url, timeout=60,
                  pool_connections=constants.DEFAULT_NUM_POOLS):
         self.npipe_path = base_url.replace('npipe://', '')

--- a/docker/transport/ssladapter.py
+++ b/docker/transport/ssladapter.py
@@ -25,6 +25,10 @@ if sys.version_info[0] < 3 or sys.version_info[1] < 5:
 class SSLAdapter(HTTPAdapter):
     '''An HTTPS Transport Adapter that uses an arbitrary SSL version.'''
 
+    __attrs__ = HTTPAdapter.__attrs__ + ['assert_fingerprint',
+                                         'assert_hostname',
+                                         'ssl_version']
+
     def __init__(self, ssl_version=None, assert_hostname=None,
                  assert_fingerprint=None, **kwargs):
         self.ssl_version = ssl_version

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -50,6 +50,11 @@ class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 
 
 class UnixAdapter(requests.adapters.HTTPAdapter):
+
+    __attrs__ = requests.adapters.HTTPAdapter.__attrs__ + ['pools',
+                                                           'socket_path',
+                                                           'timeout']
+
     def __init__(self, socket_url, timeout=60,
                  pool_connections=constants.DEFAULT_NUM_POOLS):
         socket_path = socket_url.replace('http+unix://', '')


### PR DESCRIPTION
When using Python's multiprocessing module, it throws an AttributeError, complaining that the object does not have the attribute used. This adds the missing attributes and allows them to be pickled.