### PR TITLE
join_swarm should never send empty ListenAddr

### DIFF
--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -171,6 +171,12 @@ class SwarmApiMixin(object):
             "JoinToken": join_token,
             "AdvertiseAddr": advertise_addr,
         }
+        # We should never send empty value for ListenAddr.
+        # Docker Engine could decide by self about handling default case (use '0.0.0.0:2377')
+        # (accept if applicable or otherwise raise error).
+        if listen_addr is None:
+            del data["ListenAddr"]
+
         url = self._url('/swarm/join')
         response = self._post_json(url, data=data)
         self._raise_for_status(response)


### PR DESCRIPTION
We should never send empty values for `ListenAddr` in `/swarm/join` api call.
 
Docker Engine could decide by self about handling default case. Otherwise:
- if we send empty `ListenAddr` - always fail with `400 Client Error: Bad Request ("invalid ListenAddr "": invalid empty address")`. Just block using default `0.0.0.0:2377` by Docker Engine.

And we not should provide default `0.0.0.0:2377`, because it's internal Docker Engine default not related to client api call specs. 