### PR TITLE
Only pull the 'latest' tag when testing images

### DIFF
--- a/tests/integration/api_image_test.py
+++ b/tests/integration/api_image_test.py
@@ -42,7 +42,7 @@ class PullImageTest(BaseAPIIntegrationTest):
             self.client.remove_image('hello-world')
         except docker.errors.APIError:
             pass
-        res = self.client.pull('hello-world')
+        res = self.client.pull('hello-world', tag='latest')
         self.tmp_imgs.append('hello-world')
         self.assertEqual(type(res), six.text_type)
         self.assertGreaterEqual(
@@ -56,7 +56,8 @@ class PullImageTest(BaseAPIIntegrationTest):
             self.client.remove_image('hello-world')
         except docker.errors.APIError:
             pass
-        stream = self.client.pull('hello-world', stream=True, decode=True)
+        stream = self.client.pull(
+            'hello-world', tag='latest', stream=True, decode=True)
         self.tmp_imgs.append('hello-world')
         for chunk in stream:
             assert isinstance(chunk, dict)
@@ -300,7 +301,7 @@ class PruneImagesTest(BaseAPIIntegrationTest):
         ctnr = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         self.tmp_containers.append(ctnr)
 
-        self.client.pull('hello-world')
+        self.client.pull('hello-world', tag='latest')
         self.tmp_imgs.append('hello-world')
         img_id = self.client.inspect_image('hello-world')['Id']
         result = self.client.prune_images()


### PR DESCRIPTION
Fixes #1643

I can see a couple more `pull` calls in other tests without a tag, but I don't have enough context to know if they should be similarly changed.
