### PR TITLE
excludes requests 2.18.0 from compatible versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'requests >= 2.5.2, != 2.11.0, != 2.12.2',
+    'requests >= 2.5.2, != 2.11.0, != 2.12.2, != 2.18.0',
     'six >= 1.4.0',
     'websocket-client >= 0.32.0',
     'docker-pycreds >= 0.2.1'


### PR DESCRIPTION
The 2.18.0 version of requests breaks compatibility with docker-py:
https://github.com/requests/requests/issues/4160

[This block](https://github.com/shazow/urllib3/blob/master/urllib3/connectionpool.py#L292) of code from urllib3 fails:
```python
    def _get_timeout(self, timeout):
        """ Helper that always returns a :class:`urllib3.util.Timeout` """
        if timeout is _Default:
            return self.timeout.clone()

        if isinstance(timeout, Timeout):
            return timeout.clone()
        else:
            # User passed us an int/float. This is for backwards compatibility,
            # can be removed later
            return Timeout.from_float(timeout)
```

In the case of requests version 2.18.0:
`timeout` was an instance of `urllib3.util.timeout.Timeout`
`Timeout` was an instance of `requests.packages.urllib3.util.timeout.Timeout`

When the `isinstance(timeout, Timeout)` check fails the `urllib3.util.timeout.Timeout` object is passed as the `connection` argument to `requests.packages.urllib3.util.timeout.Timeout.from_float`.