### PR TITLE
Raising error in case of invalid value of since kwarg on Container.logs

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -825,6 +825,11 @@ class ContainerApiMixin(object):
                         params['since'] = utils.datetime_to_timestamp(since)
                     elif (isinstance(since, int) and since > 0):
                         params['since'] = since
+                    else:
+                        raise errors.InvalidArgument(
+                            'since value should be datetime or int, not {}'.
+                            format(type(since))
+                        )
             url = self._url("/containers/{0}/logs", container)
             res = self._get(url, params=params, stream=stream)
             return self._get_result(container, stream, res)

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1421,6 +1421,13 @@ class ContainerTest(BaseAPIClientTest):
             stream=False
         )
 
+    def test_log_since_with_invalid_value_raises_error(self):
+        with mock.patch('docker.api.client.APIClient.inspect_container',
+                        fake_inspect_container):
+            with self.assertRaises(docker.errors.InvalidArgument):
+                self.client.logs(fake_api.FAKE_CONTAINER_ID, stream=False,
+                                 follow=False, since=42.42)
+
     def test_log_tty(self):
         m = mock.Mock()
         with mock.patch('docker.api.client.APIClient.inspect_container',


### PR DESCRIPTION
Resolving https://github.com/docker/docker-py/issues/1515