### PR TITLE
returning the docker image details after docker load

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -273,6 +273,7 @@ class ImageApiMixin(object):
         """
         res = self._post(self._url("/images/load"), data=data)
         self._raise_for_status(res)
+        return res.text
 
     @utils.minimum_version('1.25')
     def prune_images(self, filters=None):


### PR DESCRIPTION
Currently, load_image does not return any information about the image being currently loaded, even though the docker daemon returns this information. This would be a critical information, otherwise this detail needs to be sent along with the docker image archive separately in a manifest file.

The "docker load" CLI displays this detail