### PR TITLE
Closes #1588, image.tag does not return anything

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -96,7 +96,7 @@ class Image(Model):
         Returns:
             (bool): ``True`` if successful
         """
-        self.client.api.tag(self.id, repository, tag=tag, **kwargs)
+        return self.client.api.tag(self.id, repository, tag=tag, **kwargs)
 
 
 class ImageCollection(Collection):

--- a/tests/integration/models_images_test.py
+++ b/tests/integration/models_images_test.py
@@ -71,7 +71,8 @@ class ImageTest(BaseIntegrationTest):
         client = docker.from_env(version=TEST_API_VERSION)
         image = client.images.pull('alpine:latest')
 
-        image.tag(repo, tag)
+        result = image.tag(repo, tag)
+        assert result is True
         self.tmp_imgs.append(identifier)
         assert image.id in get_ids(client.images.list(repo))
         assert image.id in get_ids(client.images.list(identifier))


### PR DESCRIPTION
This patch returns the check made against api when tagging an image as stated in documentation

Signed-off-by: Olivier Sallou <olivier.sallou@irisa.fr>