### PR TITLE
split_port should not break when passed a non-string argument

### DIFF
--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -54,6 +54,7 @@ def port_range(start, end, proto, randomly_available_port=False):
 
 
 def split_port(port):
+    port = str(port)
     match = PORT_SPEC.match(port)
     if match is None:
         _raise_invalid_port(port)

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -587,6 +587,9 @@ class PortsTest(unittest.TestCase):
     def test_split_port_empty_string(self):
         self.assertRaises(ValueError, lambda: split_port(""))
 
+    def test_split_port_non_string(self):
+        assert split_port(1243) == (['1243'], None)
+
     def test_build_port_bindings_with_one_port(self):
         port_bindings = build_port_bindings(["127.0.0.1:1000:1000"])
         self.assertEqual(port_bindings["1000"], [("127.0.0.1", "1000")])


### PR DESCRIPTION
Fixes #1668 