### PR TITLE
Add Python 3.6 to tox envs and setup.py

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{branch}-{build}'
 
 install:
-  - "SET PATH=C:\\Python27-x64;C:\\Python27-x64\\Scripts;%PATH%"
+  - "SET PATH=C:\\Python36-x64;C:\\Python36-x64\\Scripts;%PATH%"
   - "python --version"
   - "pip install -U pip"
   - "pip install tox==2.1.1 virtualenv==13.1.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: '{branch}-{build}'
 install:
   - "SET PATH=C:\\Python27-x64;C:\\Python27-x64\\Scripts;%PATH%"
   - "python --version"
+  - "pip install -U pip"
   - "pip install tox==2.1.1 virtualenv==13.1.2"
 
 # Build the binary after tests

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Utilities',
         'License :: OSI Approved :: Apache Software License',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, flake8
+envlist = py27, py33, py34, py35, py36, flake8
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
After running the tests in a Python 3.6 environment it looks like
there are no incompatibilities in the code.

This addresses #1676

Signed-off-by: grahamlyons <graham@grahamlyons.com>