### PR TITLE
Fix #1673 check resource error in container network API

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -200,7 +200,7 @@ class NetworkApiMixin(object):
         res = self._get(url, params=params)
         return self._result(res, json=True)
 
-    @check_resource('image')
+    @check_resource('container')
     @minimum_version('1.21')
     def connect_container_to_network(self, container, net_id,
                                      ipv4_address=None, ipv6_address=None,
@@ -237,7 +237,7 @@ class NetworkApiMixin(object):
         res = self._post_json(url, data=data)
         self._raise_for_status(res)
 
-    @check_resource('image')
+    @check_resource('container')
     @minimum_version('1.21')
     def disconnect_container_from_network(self, container, net_id,
                                           force=False):

--- a/tests/unit/api_network_test.py
+++ b/tests/unit/api_network_test.py
@@ -147,8 +147,8 @@ class NetworkTest(BaseAPIClientTest):
 
         with mock.patch('docker.api.client.APIClient.post', post):
             self.client.connect_container_to_network(
-                {'Id': container_id},
-                network_id,
+                container={'Id': container_id},
+                net_id=network_id,
                 aliases=['foo', 'bar'],
                 links=[('baz', 'quux')]
             )
@@ -176,7 +176,7 @@ class NetworkTest(BaseAPIClientTest):
 
         with mock.patch('docker.api.client.APIClient.post', post):
             self.client.disconnect_container_from_network(
-                {'Id': container_id}, network_id)
+                container={'Id': container_id}, net_id=network_id)
 
         self.assertEqual(
             post.call_args[0][0],


### PR DESCRIPTION
Fixes #1673 

Container network functions `connect_container_to_network()` and `disconnect_container_from_network()` checked 'image' as resource ID and not 'container'.  This caused a traceback when using container as named argument.