### PR TITLE
Without a specific tag, all ubuntu tags would be pulled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ client = docker.from_env()
 You can run containers:
 
 ```python
->>> client.containers.run("ubuntu", "echo hello world")
+>>> client.containers.run("ubuntu:latest", "echo hello world")
 'hello world\n'
 ```
 


### PR DESCRIPTION
The example on the main page suggests to new users that they could run
client.containers.run("ubuntu", "echo hello world") and see some output.

I also went under the assumption that when you do not specify a tag, that :latest would be pulled.
In reality, every tag that exists for ubuntu was pulled onto my host machine, which caused it to run out of disk space.

Either the API itself is making a mistake by deviating from the behavior of the real docker client, or we need to prevent Python API users from making this mistake by perhaps extra documentation.  I do not see any use case for pulling every tag in existence.