### PR TITLE
Do not try to get logs for not readable logging drivers

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -127,8 +127,14 @@ class ContainerError(DockerException):
         self.command = command
         self.image = image
         self.stderr = stderr
-        msg = ("Command '{}' in image '{}' returned non-zero exit status {}: "
-               "{}").format(command, image, exit_status, stderr)
+
+        if stderr is None:
+            msg = ("Command '{}' in image '{}' returned non-zero exit "
+                   "status {}").format(command, image, exit_status, stderr)
+        else:
+            msg = ("Command '{}' in image '{}' returned non-zero exit "
+                   "status {}: {}").format(command, image, exit_status, stderr)
+
         super(ContainerError, self).__init__(msg)
 
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -667,6 +667,13 @@ class ContainerCollection(Collection):
             The container logs, either ``STDOUT``, ``STDERR``, or both,
             depending on the value of the ``stdout`` and ``stderr`` arguments.
 
+            ``STDOUT`` and ``STDERR`` may be read only if either ``json-file``
+            or ``journald`` logging driver used. Thus, if you are using none of
+            these drivers, a ``None`` object is returned instead. See the
+            `Engine API documentation
+            <https://docs.docker.com/engine/api/v1.30/#operation/ContainerLogs/>`_
+            for full details.
+
             If ``detach`` is ``True``, a :py:class:`Container` object is
             returned instead.
 
@@ -709,7 +716,14 @@ class ContainerCollection(Collection):
         if exit_status != 0:
             stdout = False
             stderr = True
-        out = container.logs(stdout=stdout, stderr=stderr)
+
+        logging_driver = container.attrs['HostConfig']['LogConfig']['Type']
+
+        if logging_driver == 'json-file' or logging_driver == 'journald':
+            out = container.logs(stdout=stdout, stderr=stderr)
+        else:
+            out = None
+
         if remove:
             container.remove()
         if exit_status != 0:

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -88,6 +88,24 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert 'Networks' in attrs['NetworkSettings']
         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
 
+    def test_run_with_none_driver(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+
+        out = client.containers.run(
+            "alpine", "echo hello",
+            log_config=dict(type='none')
+        )
+        self.assertEqual(out, None)
+
+    def test_run_with_json_file_driver(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+
+        out = client.containers.run(
+            "alpine", "echo hello",
+            log_config=dict(type='json-file')
+        )
+        self.assertEqual(out, b'hello\n')
+
     def test_get(self):
         client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -146,6 +146,12 @@ def get_fake_inspect_container(tty=False):
             "StartedAt": "2013-09-25T14:01:18.869545111+02:00",
             "Ghost": False
         },
+        "HostConfig": {
+            "LogConfig": {
+                "Type": "json-file",
+                "Config": {}
+            },
+        },
         "MacAddress": "02:42:ac:11:00:0a"
     }
     return status_code, response


### PR DESCRIPTION
Fixes #1688

According to the [documentation](https://docs.docker.com/engine/api/v1.30/#operation/ContainerLogs), logs may be read only if either `json-file` or `journald` logging driver used. However, `client.containers.run` does not respect this rule and tries to read logs after running container.

```python
✗ python -i 
>>> import docker
>>> client = docker.from_env()
>>> client.containers.run("busybox:latest", "echo hello world", log_config=dict(type='syslog'))
Traceback (most recent call last):
.....
docker.errors.APIError: 500 Server Error: Internal Server Error ("configured logging driver does not support reading")
```

To overcome this issue, I added logging driver check to `client.containers.run`.

See for details https://github.com/docker/docker-py/issues/1688

After my fix it works as follows:

```python
```python
✗ python -i 
>>> import docker
>>> client = docker.from_env()
>>> client.containers.run("busybox:latest", "echo hello world", log_config=dict(type='syslog'))
"Result logged using `syslog` driver"
```

I understand this is not the best solution, but it is definitely better than exception. Any ideas?