### PR TITLE
Added wait to the Container class documentation.

### DIFF
--- a/docs/containers.rst
+++ b/docs/containers.rst
@@ -53,3 +53,4 @@ Container objects
   .. automethod:: top
   .. automethod:: unpause
   .. automethod:: update
+  .. automethod:: wait


### PR DESCRIPTION
The container class documentation did not automatically document the `Container.wait` method.

Signed-off-by: Andreas Backx <andreas@backx.org>