### PR TITLE
Fix #1575 - Add cpu_rt_period and cpu_rt_runtime args

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -861,6 +861,8 @@ RUN_HOST_CONFIG_KWARGS = [
     'cpu_shares',
     'cpuset_cpus',
     'cpuset_mems',
+    'cpu_rt_period',
+    'cpu_rt_runtime',
     'device_read_bps',
     'device_read_iops',
     'device_write_bps',

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -120,7 +120,8 @@ class HostConfig(dict):
                  isolation=None, auto_remove=False, storage_opt=None,
                  init=None, init_path=None, volume_driver=None,
                  cpu_count=None, cpu_percent=None, nano_cpus=None,
-                 cpuset_mems=None, runtime=None):
+                 cpuset_mems=None, runtime=None, cpu_rt_period=None,
+                 cpu_rt_runtime=None):
 
         if mem_limit is not None:
             self['Memory'] = parse_bytes(mem_limit)
@@ -338,6 +339,26 @@ class HostConfig(dict):
                     'cpuset_mems', cpuset_mems, 'str'
                 )
             self['CpusetMems'] = cpuset_mems
+
+        if cpu_rt_period:
+            if version_lt(version, '1.25'):
+                raise host_config_version_error('cpu_rt_period', '1.25')
+
+            if not isinstance(cpu_rt_period, int):
+                raise host_config_type_error(
+                    'cpu_rt_period', cpu_rt_period, 'int'
+                )
+            self['CPURealtimePeriod'] = cpu_rt_period
+
+        if cpu_rt_runtime:
+            if version_lt(version, '1.25'):
+                raise host_config_version_error('cpu_rt_runtime', '1.25')
+
+            if not isinstance(cpu_rt_runtime, int):
+                raise host_config_type_error(
+                    'cpu_rt_runtime', cpu_rt_runtime, 'int'
+                )
+            self['CPURealtimeRuntime'] = cpu_rt_runtime
 
         if blkio_weight:
             if not isinstance(blkio_weight, int):

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -206,6 +206,28 @@ class HostConfigTest(unittest.TestCase):
             InvalidVersion, lambda: create_host_config(
                 version='1.24', nano_cpus=1))
 
+    def test_create_host_config_with_cpu_rt_period_types(self):
+        with pytest.raises(TypeError):
+            create_host_config(version='1.25', cpu_rt_period='1000')
+
+    def test_create_host_config_with_cpu_rt_period(self):
+        config = create_host_config(version='1.25', cpu_rt_period=1000)
+        self.assertEqual(config.get('CPURealtimePeriod'), 1000)
+        self.assertRaises(
+            InvalidVersion, lambda: create_host_config(
+                version='1.24', cpu_rt_period=1000))
+
+    def test_ctrate_host_config_with_cpu_rt_runtime_types(self):
+        with pytest.raises(TypeError):
+            create_host_config(version='1.25', cpu_rt_runtime='1000')
+
+    def test_create_host_config_with_cpu_rt_runtime(self):
+        config = create_host_config(version='1.25', cpu_rt_runtime=1000)
+        self.assertEqual(config.get('CPURealtimeRuntime'), 1000)
+        self.assertRaises(
+            InvalidVersion, lambda: create_host_config(
+                version='1.24', cpu_rt_runtime=1000))
+
 
 class ContainerConfigTest(unittest.TestCase):
     def test_create_container_config_volume_driver_warning(self):


### PR DESCRIPTION
Hi, due to the need of real-time `run`. I add `cpu_rt_period` and `cpu_rt_runtime` in hostconfig with version(1.25), types(int) checks. Also add version and type checks in dockertype unit test.

But have couples questions for writing tests.
1. In the `models_containers_test` => The `test_create_container_args` sits on version 1.23, which `rt` is not supported yet. Do I need an additional test for this?
2. More important, the most relevant of testing for `cpu_rt_period`, `cpu_rt_runtime`, the real-time scheduler need to be enabled in the kernel (`CONFIG_RT_GROUP_SCHED` flag). Do we have any appropriate way to test this? 

Thanks!
Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>