### PR TITLE
Fix #1720 - Add index boundary check in fnmatch.py to fix regression in .dockerignore parsing

### DIFF
--- a/docker/utils/fnmatch.py
+++ b/docker/utils/fnmatch.py
@@ -75,7 +75,7 @@ def translate(pat):
                 # is some flavor of "**"
                 i = i + 1
                 # Treat **/ as ** so eat the "/"
-                if pat[i] == '/':
+                if i < n and pat[i] == '/':
                     i = i + 1
                 if i >= n:
                     # is "**EOF" - to align with .gitignore just accept all

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -874,6 +874,23 @@ class ExcludePathsTest(unittest.TestCase):
             )
         )
 
+    def test_trailing_double_wildcard(self):
+        assert self.exclude(['subdir/**']) == convert_paths(
+            self.all_paths - set(
+                ['subdir/file.txt',
+                 'subdir/target/file.txt',
+                 'subdir/target/subdir/file.txt',
+                 'subdir/subdir2/file.txt',
+                 'subdir/subdir2/target/file.txt',
+                 'subdir/subdir2/target/subdir/file.txt',
+                 'subdir/target',
+                 'subdir/target/subdir',
+                 'subdir/subdir2',
+                 'subdir/subdir2/target',
+                 'subdir/subdir2/target/subdir']
+            )
+        )
+
 
 class TarTest(unittest.TestCase):
     def test_tar_with_excludes(self):


### PR DESCRIPTION
Commit d798afca made changes for the handling of '**' patterns in .dockerignore. This causes an IndexError with patterns ending with '**', e.g. 'subdir/**'. This adds a missing boundary check
before checking for trailing '/'.