### PR TITLE
Add join_swarm default listen address

### DIFF
--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -137,7 +137,7 @@ class SwarmApiMixin(object):
         return self._result(self._get(url), True)
 
     @utils.minimum_version('1.24')
-    def join_swarm(self, remote_addrs, join_token, listen_addr=None,
+    def join_swarm(self, remote_addrs, join_token, listen_addr='0.0.0.0:2377',
                    advertise_addr=None):
         """
         Make this Engine join a swarm that has already been created.

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -435,6 +435,10 @@ def post_fake_update_node():
     return 200, None
 
 
+def post_fake_join_swarm():
+    return 200, None
+
+
 def get_fake_network_list():
     return 200, [{
         "Name": "bridge",
@@ -599,6 +603,8 @@ fake_responses = {
         CURRENT_VERSION, prefix, FAKE_NODE_ID
     ), 'POST'):
     post_fake_update_node,
+    ('{1}/{0}/swarm/join'.format(CURRENT_VERSION, prefix), 'POST'):
+    post_fake_join_swarm,
     ('{1}/{0}/networks'.format(CURRENT_VERSION, prefix), 'GET'):
     get_fake_network_list,
     ('{1}/{0}/networks/create'.format(CURRENT_VERSION, prefix), 'POST'):

--- a/tests/unit/swarm_test.py
+++ b/tests/unit/swarm_test.py
@@ -30,3 +30,46 @@ class SwarmTest(BaseAPIClientTest):
         self.assertEqual(
             args[1]['headers']['Content-Type'], 'application/json'
         )
+
+    @requires_api_version('1.24')
+    def test_join_swarm(self):
+        remote_addr = ['1.2.3.4:2377']
+        listen_addr = '2.3.4.5:2377'
+        join_token = 'A_BEAUTIFUL_JOIN_TOKEN'
+
+        data = {
+            'RemoteAddrs': remote_addr,
+            'ListenAddr': listen_addr,
+            'JoinToken': join_token
+        }
+
+        self.client.join_swarm(
+            remote_addrs=remote_addr,
+            listen_addr=listen_addr,
+            join_token=join_token
+        )
+
+        args = fake_request.call_args
+
+        assert (args[0][1] == url_prefix + 'swarm/join')
+        assert (json.loads(args[1]['data']) == data)
+        assert (args[1]['headers']['Content-Type'] == 'application/json')
+
+    @requires_api_version('1.24')
+    def test_join_swarm_no_listen_address_takes_default(self):
+        remote_addr = ['1.2.3.4:2377']
+        join_token = 'A_BEAUTIFUL_JOIN_TOKEN'
+
+        data = {
+            'RemoteAddrs': remote_addr,
+            'ListenAddr': '0.0.0.0:2377',
+            'JoinToken': join_token
+        }
+
+        self.client.join_swarm(remote_addrs=remote_addr, join_token=join_token)
+
+        args = fake_request.call_args
+
+        assert (args[0][1] == url_prefix + 'swarm/join')
+        assert (json.loads(args[1]['data']) == data)
+        assert (args[1]['headers']['Content-Type'] == 'application/json')


### PR DESCRIPTION
Since the docker CLI adds a default listen address (0.0.0.0:2377)
when joining a node to the swarm, the docker-py api will support
the same behavior.