### PR TITLE
Use unambiguous advertise-addr when initializing a swarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ TEST_ENGINE_VERSION ?= 17.06.0-ce
 .PHONY: integration-dind
 integration-dind: build build-py3
 	docker rm -vf dpy-dind || :
-	docker run -d --name dpy-dind --privileged dockerswarm/dind:${TEST_ENGINE_VERSION} docker daemon\
+	docker run -d --name dpy-dind --privileged dockerswarm/dind:${TEST_ENGINE_VERSION} dockerd\
 		-H tcp://0.0.0.0:2375 --experimental
 	docker run --rm --env="DOCKER_HOST=tcp://docker:2375" --env="DOCKER_TEST_API_VERSION=${TEST_API_VERSION}"\
 		--link=dpy-dind:docker docker-sdk-python py.test tests/integration
@@ -60,7 +60,7 @@ integration-dind-ssl: build-dind-certs build build-py3
 	docker run -d --name dpy-dind-certs dpy-dind-certs
 	docker run -d --env="DOCKER_HOST=tcp://localhost:2375" --env="DOCKER_TLS_VERIFY=1"\
 		--env="DOCKER_CERT_PATH=/certs" --volumes-from dpy-dind-certs --name dpy-dind-ssl\
-		-v /tmp --privileged dockerswarm/dind:${TEST_ENGINE_VERSION} docker daemon --tlsverify\
+		-v /tmp --privileged dockerswarm/dind:${TEST_ENGINE_VERSION} dockerd --tlsverify\
 		--tlscacert=/certs/ca.pem --tlscert=/certs/server-cert.pem\
 		--tlskey=/certs/server-key.pem -H tcp://0.0.0.0:2375 --experimental
 	docker run --rm --volumes-from dpy-dind-ssl --env="DOCKER_HOST=tcp://docker:2375"\

--- a/tests/integration/api_network_test.py
+++ b/tests/integration/api_network_test.py
@@ -447,14 +447,14 @@ class TestNetworks(BaseAPIIntegrationTest):
 
     @requires_api_version('1.25')
     def test_create_network_attachable(self):
-        assert self.client.init_swarm('eth0')
+        assert self.init_swarm()
         _, net_id = self.create_network(driver='overlay', attachable=True)
         net = self.client.inspect_network(net_id)
         assert net['Attachable'] is True
 
     @requires_api_version('1.29')
     def test_create_network_ingress(self):
-        assert self.client.init_swarm('eth0')
+        assert self.init_swarm()
         self.client.remove_network('ingress')
         _, net_id = self.create_network(driver='overlay', ingress=True)
         net = self.client.inspect_network(net_id)

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -110,5 +110,5 @@ class BaseAPIIntegrationTest(BaseIntegrationTest):
 
     def init_swarm(self, **kwargs):
         return self.client.init_swarm(
-            'eth0', listen_addr=helpers.swarm_listen_addr(), **kwargs
+            '127.0.0.1', listen_addr=helpers.swarm_listen_addr(), **kwargs
         )

--- a/tests/integration/models_nodes_test.py
+++ b/tests/integration/models_nodes_test.py
@@ -15,7 +15,7 @@ class NodesTest(unittest.TestCase):
 
     def test_list_get_update(self):
         client = docker.from_env(version=TEST_API_VERSION)
-        client.swarm.init('eth0', listen_addr=helpers.swarm_listen_addr())
+        client.swarm.init('127.0.0.1', listen_addr=helpers.swarm_listen_addr())
         nodes = client.nodes.list()
         assert len(nodes) == 1
         assert nodes[0].attrs['Spec']['Role'] == 'manager'

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -12,7 +12,7 @@ class ServiceTest(unittest.TestCase):
     def setUpClass(cls):
         client = docker.from_env(version=TEST_API_VERSION)
         helpers.force_leave_swarm(client)
-        client.swarm.init('eth0', listen_addr=helpers.swarm_listen_addr())
+        client.swarm.init('127.0.0.1', listen_addr=helpers.swarm_listen_addr())
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/integration/models_swarm_test.py
+++ b/tests/integration/models_swarm_test.py
@@ -16,7 +16,7 @@ class SwarmTest(unittest.TestCase):
     def test_init_update_leave(self):
         client = docker.from_env(version=TEST_API_VERSION)
         client.swarm.init(
-            advertise_addr='eth0', snapshot_interval=5000,
+            advertise_addr='127.0.0.1', snapshot_interval=5000,
             listen_addr=helpers.swarm_listen_addr()
         )
         assert client.swarm.attrs['Spec']['Raft']['SnapshotInterval'] == 5000


### PR DESCRIPTION
Test suite / Jenkins stuff.

https://github.com/docker/docker-py/pull/1733#issuecomment-326183021