### PR TITLE
Adding swarm id_attribute to match docker output

### DIFF
--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -9,6 +9,8 @@ class Swarm(Model):
     The server's Swarm state. This a singleton that must be reloaded to get
     the current state of the Swarm.
     """
+    id_attribute = 'ID'
+
     def __init__(self, *args, **kwargs):
         super(Swarm, self).__init__(*args, **kwargs)
         if self.client:

--- a/tests/integration/models_swarm_test.py
+++ b/tests/integration/models_swarm_test.py
@@ -22,6 +22,7 @@ class SwarmTest(unittest.TestCase):
         assert client.swarm.attrs['Spec']['Raft']['SnapshotInterval'] == 5000
         client.swarm.update(snapshot_interval=10000)
         assert client.swarm.attrs['Spec']['Raft']['SnapshotInterval'] == 10000
+        assert client.swarm.id
         assert client.swarm.leave(force=True)
         with self.assertRaises(docker.errors.APIError) as cm:
             client.swarm.reload()


### PR DESCRIPTION
Swarm id is returned in a attribute with the key ID and the current swarm model was using the default behaviour and looking for Id. This was causing swarm.id to be None and swarm.short_id to error.
