### PR TITLE
Clarify network_mode can be custom network name

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -529,7 +529,7 @@ class ContainerApiMixin(object):
                 behavior. Accepts number between 0 and 100.
             memswap_limit (str or int): Maximum amount of memory + swap a
                 container is allowed to consume.
-            network_mode (str): One of:
+            network_mode (str): Supported standard value is one of:
 
                 - ``bridge`` Create a new network stack for the container on
                   on the bridge network.
@@ -537,6 +537,9 @@ class ContainerApiMixin(object):
                 - ``container:<name|id>`` Reuse another container's network
                   stack.
                 - ``host`` Use the host network stack.
+
+                Any other value is taken as a custom network's name to which
+                this container should connect to.
             oom_kill_disable (bool): Whether to disable OOM killer.
             oom_score_adj (int): An integer value containing the score given
                 to the container in order to tune OOM killer preferences.


### PR DESCRIPTION
The explaination of the network_mode is confusing. It stated this
parameter can only be one of 'bridge', 'none', 'container:<name|id>',
or 'host'. This statement is misleading. Network mode can be an
arbitrary network name as well.

Signed-off-by: Hongbin Lu <hongbin.lu@huawei.com>