### PR TITLE
Add network hostname aliases for services.

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -65,8 +65,10 @@ class ServiceApiMixin(object):
                 or global). Defaults to replicated.
             update_config (UpdateConfig): Specification for the update strategy
                 of the service. Default: ``None``
-            networks (:py:class:`list`): List of network names or IDs to attach
-                the service to. Default: ``None``.
+            networks (:py:class:`list` NetworkAttachment): List of
+                NetworkAttachments specifying the network names or IDs to
+                attach the service to and the aliases on the respective
+                networks. Default: ``None``.
             endpoint_spec (EndpointSpec): Properties that can be configured to
                 access and load balance a service. Default: ``None``.
 
@@ -106,7 +108,7 @@ class ServiceApiMixin(object):
             'Labels': labels,
             'TaskTemplate': task_template,
             'Mode': mode,
-            'Networks': utils.convert_service_networks(networks),
+            'Networks': networks,
             'EndpointSpec': endpoint_spec
         }
 

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -3,7 +3,8 @@ from .containers import ContainerConfig, HostConfig, LogConfig, Ulimit
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig
 from .services import (
-    ContainerSpec, DriverConfig, EndpointSpec, Mount, Placement, Resources,
-    RestartPolicy, SecretReference, ServiceMode, TaskTemplate, UpdateConfig
+    ContainerSpec, DriverConfig, EndpointSpec, Mount, NetworkAttachment, Placement,
+    Resources, RestartPolicy, SecretReference, ServiceMode, TaskTemplate,
+    UpdateConfig
 )
 from .swarm import SwarmSpec, SwarmExternalCA

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -483,3 +483,19 @@ class Placement(dict):
                 self['Platforms'].append({
                     'Architecture': plat[0], 'OS': plat[1]
                 })
+
+
+class NetworkAttachment(dict):
+    """
+        Placement constraints to be used as part of a :py:class:`TaskTemplate`
+
+        Args:
+            network (string): Network to attach to
+            aliases (list): List of aliases under which the service should be
+                reachable on the network
+    """
+    def __init__(self, network=None, aliases=None):
+        if network is not None:
+            self['Target'] = network
+        if aliases is not None:
+            self['Aliases'] = aliases


### PR DESCRIPTION
During a recent project that I worked on I used docker-py to create services in a docker swarm.
I stumbled across issue #1571 because my service was not available under the expected hostname.
The patch below resolved this for us by allowing to specify aliases.

The patch below obviously would change the API (and probably fail tests).
If you're interested in this patch, I'd be happy to rework it appropriately if you could give me some input on how you want handle such an API change.

Signed-off-by: Patrick Bänziger <patrick.baenziger@bsi-software.com>