### PR TITLE
Prevent data loss when attaching to container

### DIFF
--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -34,6 +34,25 @@ class UnixHTTPConnection(httplib.HTTPConnection, object):
         self.sock = sock
 
 
+class AttachHTTPResponse(httplib.HTTPResponse):
+    '''
+    A HTTPResponse object that doesn't use a buffered fileobject.
+    '''
+    def __init__(self, sock, *args, **kwargs):
+        # Delegate to super class
+        httplib.HTTPResponse.__init__(self, sock, *args, **kwargs)
+
+        # Override fp with a fileobject that doesn't buffer
+        self.fp = sock.makefile('rb', 0)
+
+
+class AttachUnixHTTPConnection(UnixHTTPConnection):
+    '''
+    A HTTPConnection that returns responses that don't used buffering.
+    '''
+    response_class = AttachHTTPResponse
+
+
 class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
     def __init__(self, base_url, socket_path, timeout=60, maxsize=10):
         super(UnixHTTPConnectionPool, self).__init__(
@@ -44,9 +63,17 @@ class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
         self.timeout = timeout
 
     def _new_conn(self):
-        return UnixHTTPConnection(
-            self.base_url, self.socket_path, self.timeout
-        )
+        # Special case for attach url, as we do a http upgrade to tcp and
+        # a buffered connection can cause data loss.
+        path = urllib3.util.parse_url(self.base_url).path
+        if path.endswith('attach'):
+            return AttachUnixHTTPConnection(
+                self.base_url, self.socket_path, self.timeout
+            )
+        else:
+            return UnixHTTPConnection(
+                self.base_url, self.socket_path, self.timeout
+            )
 
 
 class UnixAdapter(requests.adapters.HTTPAdapter):


### PR DESCRIPTION
This PR resolves an issue with the attach(...) and attach_socket(...) container methods. Intermittent truncation of stdout was being seem when attaching to a container. The problem occurred with particular frequency when running docker inside a virtual machine, this is a timing issue so something about that environment hits the window more regularly. 
After much digging I was able to determine the cause of the problem. It's the use of buffering when httplib/http.client calls [makefile(...) on the socket]( https://github.com/python/cpython/blob/3.6/Lib/http/client.py#L235). The attach methods do a HTTP upgrade to tcp before the raw socket can be using to stream data from the container. The problem is that if the container starts stream data while httplib/http.client is reading the response to the attach request part of the data ends up in the buffer of fileobject. This data is lost as after the attach request data is read directly from the raw socket.
This patch creates a custom HTTPReponse to be used with attach requests that override the fp attribute with a fileobject at doesn’t use buffering thus avoiding the issue.
