### PR TITLE
Fix simple documentation copy/paste error.

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -245,10 +245,10 @@ class ImageApiMixin(object):
     def inspect_image(self, image):
         """
         Get detailed information about an image. Similar to the ``docker
-        inspect`` command, but only for containers.
+        inspect`` command, but only for images.
 
         Args:
-            container (str): The container to inspect
+            image (str): The image to inspect
 
         Returns:
             (dict): Similar to the output of ``docker inspect``, but as a


### PR DESCRIPTION
It seems that the documentation of inspect_image was copy/pasted from some place where containers where expected.