### PR TITLE
Make check_duplicate network flag true by default.

### DIFF
--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -17,7 +17,7 @@ class NetworkApiMixin(object):
                 Available filters:
                 - ``driver=[<driver-name>]`` Matches a network's driver.
                 - ``label=[<key>]`` or ``label=[<key>=<value>]``.
-                - ``type=["custom"|"builtin"]`` Filters networks by type.
+                - ``type=['custom'|'builtin']`` Filters networks by type.
 
         Returns:
             (dict): List of network objects.
@@ -34,13 +34,13 @@ class NetworkApiMixin(object):
         if ids:
             filters['id'] = ids
         params = {'filters': utils.convert_filters(filters)}
-        url = self._url("/networks")
+        url = self._url('/networks')
         res = self._get(url, params=params)
         return self._result(res, json=True)
 
     @minimum_version('1.21')
     def create_network(self, name, driver=None, options=None, ipam=None,
-                       check_duplicate=None, internal=False, labels=None,
+                       check_duplicate=True, internal=False, labels=None,
                        enable_ipv6=False, attachable=None, scope=None,
                        ingress=None):
         """
@@ -52,7 +52,7 @@ class NetworkApiMixin(object):
             options (dict): Driver options as a key-value dictionary
             ipam (IPAMConfig): Optional custom IP scheme for the network.
             check_duplicate (bool): Request daemon to check for networks with
-                same name. Default: ``None``.
+                same name. Default: ``True``.
             internal (bool): Restrict external access to the network. Default
                 ``False``.
             labels (dict): Map of labels to set on the network. Default
@@ -74,7 +74,7 @@ class NetworkApiMixin(object):
         Example:
             A network using the bridge driver:
 
-                >>> client.create_network("network1", driver="bridge")
+                >>> client.create_network('network1', driver='bridge')
 
             You can also create more advanced networks with custom IPAM
             configurations. For example, setting the subnet to
@@ -89,7 +89,7 @@ class NetworkApiMixin(object):
                 >>> ipam_config = docker.types.IPAMConfig(
                     pool_configs=[ipam_pool]
                 )
-                >>> docker_client.create_network("network1", driver="bridge",
+                >>> docker_client.create_network('network1', driver='bridge',
                                                  ipam=ipam_config)
         """
         if options is not None and not isinstance(options, dict):
@@ -110,7 +110,7 @@ class NetworkApiMixin(object):
                 )
             if not isinstance(labels, dict):
                 raise TypeError('labels must be a dictionary')
-            data["Labels"] = labels
+            data['Labels'] = labels
 
         if enable_ipv6:
             if version_lt(self._version, '1.23'):
@@ -140,7 +140,7 @@ class NetworkApiMixin(object):
 
             data['Ingress'] = ingress
 
-        url = self._url("/networks/create")
+        url = self._url('/networks/create')
         res = self._post_json(url, data=data)
         return self._result(res, json=True)
 
@@ -175,7 +175,7 @@ class NetworkApiMixin(object):
         Args:
             net_id (str): The network's id
         """
-        url = self._url("/networks/{0}", net_id)
+        url = self._url('/networks/{0}', net_id)
         res = self._delete(url)
         self._raise_for_status(res)
 
@@ -196,7 +196,7 @@ class NetworkApiMixin(object):
                 raise InvalidVersion('verbose was introduced in API 1.28')
             params['verbose'] = verbose
 
-        url = self._url("/networks/{0}", net_id)
+        url = self._url('/networks/{0}', net_id)
         res = self._get(url, params=params)
         return self._result(res, json=True)
 
@@ -226,14 +226,14 @@ class NetworkApiMixin(object):
             (IPv4/IPv6) addresses.
         """
         data = {
-            "Container": container,
-            "EndpointConfig": self.create_endpoint_config(
+            'Container': container,
+            'EndpointConfig': self.create_endpoint_config(
                 aliases=aliases, links=links, ipv4_address=ipv4_address,
                 ipv6_address=ipv6_address, link_local_ips=link_local_ips
             ),
         }
 
-        url = self._url("/networks/{0}/connect", net_id)
+        url = self._url('/networks/{0}/connect', net_id)
         res = self._post_json(url, data=data)
         self._raise_for_status(res)
 
@@ -251,13 +251,13 @@ class NetworkApiMixin(object):
             force (bool): Force the container to disconnect from a network.
                 Default: ``False``
         """
-        data = {"Container": container}
+        data = {'Container': container}
         if force:
             if version_lt(self._version, '1.22'):
                 raise InvalidVersion(
                     'Forced disconnect was introduced in API 1.22'
                 )
             data['Force'] = force
-        url = self._url("/networks/{0}/disconnect", net_id)
+        url = self._url('/networks/{0}/disconnect', net_id)
         res = self._post_json(url, data=data)
         self._raise_for_status(res)

--- a/tests/integration/api_network_test.py
+++ b/tests/integration/api_network_test.py
@@ -50,13 +50,13 @@ class TestNetworks(BaseAPIIntegrationTest):
                 driver='default',
                 pool_configs=[
                     IPAMPool(
-                        subnet="172.28.0.0/16",
-                        iprange="172.28.5.0/24",
-                        gateway="172.28.5.254",
+                        subnet='172.28.0.0/16',
+                        iprange='172.28.5.0/24',
+                        gateway='172.28.5.254',
                         aux_addresses={
-                            "a": "172.28.1.5",
-                            "b": "172.28.1.6",
-                            "c": "172.28.1.7",
+                            'a': '172.28.1.5',
+                            'b': '172.28.1.6',
+                            'c': '172.28.1.7',
                         },
                     ),
                 ],
@@ -71,13 +71,13 @@ class TestNetworks(BaseAPIIntegrationTest):
         assert ipam['Driver'] == 'default'
 
         assert ipam['Config'] == [{
-            'Subnet': "172.28.0.0/16",
-            'IPRange': "172.28.5.0/24",
-            'Gateway': "172.28.5.254",
+            'Subnet': '172.28.0.0/16',
+            'IPRange': '172.28.5.0/24',
+            'Gateway': '172.28.5.254',
             'AuxiliaryAddresses': {
-                "a": "172.28.1.5",
-                "b": "172.28.1.6",
-                "c": "172.28.1.7",
+                'a': '172.28.1.5',
+                'b': '172.28.1.6',
+                'c': '172.28.1.7',
             },
         }]
 
@@ -218,7 +218,7 @@ class TestNetworks(BaseAPIIntegrationTest):
         net_name, net_id = self.create_network(
             ipam=IPAMConfig(
                 driver='default',
-                pool_configs=[IPAMPool(subnet="132.124.0.0/16")],
+                pool_configs=[IPAMPool(subnet='132.124.0.0/16')],
             ),
         )
         container = self.client.create_container(
@@ -247,7 +247,7 @@ class TestNetworks(BaseAPIIntegrationTest):
         net_name, net_id = self.create_network(
             ipam=IPAMConfig(
                 driver='default',
-                pool_configs=[IPAMPool(subnet="2001:389::1/64")],
+                pool_configs=[IPAMPool(subnet='2001:389::1/64')],
             ),
         )
         container = self.client.create_container(
@@ -325,6 +325,12 @@ class TestNetworks(BaseAPIIntegrationTest):
         net_id = self.client.create_network(net_name, check_duplicate=False)
         self.tmp_networks.append(net_id['Id'])
 
+    @requires_api_version('1.21')
+    def test_create_check_duplicate_with_default_param(self):
+        net_name, net_od = self.create_network()
+        with self.assertRaises(docker.errors.APIError):
+            self.client.create_network(net_name)
+
     @requires_api_version('1.22')
     def test_connect_with_links(self):
         net_name, net_id = self.create_network()
@@ -356,8 +362,8 @@ class TestNetworks(BaseAPIIntegrationTest):
                 driver='default',
                 pool_configs=[
                     IPAMPool(
-                        subnet="172.28.0.0/16", iprange="172.28.5.0/24",
-                        gateway="172.28.5.254"
+                        subnet='172.28.0.0/16', iprange='172.28.5.0/24',
+                        gateway='172.28.5.254'
                     )
                 ]
             )
@@ -384,8 +390,8 @@ class TestNetworks(BaseAPIIntegrationTest):
                 driver='default',
                 pool_configs=[
                     IPAMPool(
-                        subnet="2001:389::1/64", iprange="2001:389::0/96",
-                        gateway="2001:389::ffff"
+                        subnet='2001:389::1/64', iprange='2001:389::0/96',
+                        gateway='2001:389::ffff'
                     )
                 ]
             )
@@ -436,8 +442,8 @@ class TestNetworks(BaseAPIIntegrationTest):
                 driver='default',
                 pool_configs=[
                     IPAMPool(
-                        subnet="2001:389::1/64", iprange="2001:389::0/96",
-                        gateway="2001:389::ffff"
+                        subnet='2001:389::1/64', iprange='2001:389::0/96',
+                        gateway='2001:389::ffff'
                     )
                 ]
             )

--- a/tests/integration/models_networks_test.py
+++ b/tests/integration/models_networks_test.py
@@ -11,7 +11,7 @@ class ImageCollectionTest(BaseIntegrationTest):
         network = client.networks.create(name, labels={'foo': 'bar'})
         self.tmp_networks.append(network.id)
         assert network.name == name
-        assert network.attrs['Labels']['foo'] == "bar"
+        assert network.attrs['Labels']['foo'] == 'bar'
 
     def test_get(self):
         client = docker.from_env(version=TEST_API_VERSION)
@@ -21,6 +21,13 @@ class ImageCollectionTest(BaseIntegrationTest):
         network = client.networks.get(network_id)
         assert network.name == name
 
+    def test_create_network_with_duplicate_name(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        name = helpers.random_name()
+        client.networks.create(name)
+        with self.assertRaises(docker.errors.APIError):
+            client.networks.create(name)
+
     def test_list_remove(self):
         client = docker.from_env(version=TEST_API_VERSION)
         name = helpers.random_name()
@@ -29,7 +36,7 @@ class ImageCollectionTest(BaseIntegrationTest):
         assert network.id in [n.id for n in client.networks.list()]
         assert network.id not in [
             n.id for n in
-            client.networks.list(ids=["fdhjklfdfdshjkfds"])
+            client.networks.list(ids=['fdhjklfdfdshjkfds'])
         ]
         assert network.id in [
             n.id for n in
@@ -37,7 +44,7 @@ class ImageCollectionTest(BaseIntegrationTest):
         ]
         assert network.id not in [
             n.id for n in
-            client.networks.list(names=["fdshjklfdsjhkl"])
+            client.networks.list(names=['fdshjklfdsjhkl'])
         ]
         assert network.id in [
             n.id for n in
@@ -53,7 +60,7 @@ class ImageTest(BaseIntegrationTest):
         client = docker.from_env(version=TEST_API_VERSION)
         network = client.networks.create(helpers.random_name())
         self.tmp_networks.append(network.id)
-        container = client.containers.create("alpine", "sleep 300")
+        container = client.containers.create('alpine', 'sleep 300')
         self.tmp_containers.append(container.id)
         assert network.containers == []
         network.connect(container)

--- a/tests/unit/api_network_test.py
+++ b/tests/unit/api_network_test.py
@@ -17,16 +17,16 @@ class NetworkTest(BaseAPIClientTest):
     def test_list_networks(self):
         networks = [
             {
-                "name": "none",
-                "id": "8e4e55c6863ef424",
-                "type": "null",
-                "endpoints": []
+                'name': 'none',
+                'id': '8e4e55c6863ef424',
+                'type': 'null',
+                'endpoints': []
             },
             {
-                "name": "host",
-                "id": "062b6d9ea7913fde",
-                "type": "host",
-                "endpoints": []
+                'name': 'host',
+                'id': '062b6d9ea7913fde',
+                'type': 'host',
+                'endpoints': []
             },
         ]
 
@@ -52,8 +52,8 @@ class NetworkTest(BaseAPIClientTest):
     @requires_api_version('1.21')
     def test_create_network(self):
         network_data = {
-            "id": 'abc12345',
-            "warning": "",
+            'id': 'abc12345',
+            'warning': '',
         }
 
         network_response = response(status_code=200, content=network_data)
@@ -69,7 +69,7 @@ class NetworkTest(BaseAPIClientTest):
 
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
-                {"Name": "foo"})
+                {'CheckDuplicate': True, 'Name': 'foo'})
 
             opts = {
                 'com.docker.network.bridge.enable_icc': False,
@@ -79,27 +79,32 @@ class NetworkTest(BaseAPIClientTest):
 
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
-                {"Name": "foo", "Driver": "bridge", "Options": opts})
+                {'CheckDuplicate': True,
+                 'Name': 'foo',
+                 'Driver': 'bridge',
+                 'Options': opts
+                 })
 
-            ipam_pool_config = IPAMPool(subnet="192.168.52.0/24",
-                                        gateway="192.168.52.254")
+            ipam_pool_config = IPAMPool(subnet='192.168.52.0/24',
+                                        gateway='192.168.52.254')
             ipam_config = IPAMConfig(pool_configs=[ipam_pool_config])
 
-            self.client.create_network("bar", driver="bridge",
+            self.client.create_network('bar', driver='bridge',
                                        ipam=ipam_config)
 
             self.assertEqual(
                 json.loads(post.call_args[1]['data']),
                 {
-                    "Name": "bar",
-                    "Driver": "bridge",
-                    "IPAM": {
-                        "Driver": "default",
-                        "Config": [{
-                            "IPRange": None,
-                            "Gateway": "192.168.52.254",
-                            "Subnet": "192.168.52.0/24",
-                            "AuxiliaryAddresses": None,
+                    'CheckDuplicate': True,
+                    'Name': 'bar',
+                    'Driver': 'bridge',
+                    'IPAM': {
+                        'Driver': 'default',
+                        'Config': [{
+                            'IPRange': None,
+                            'Gateway': '192.168.52.254',
+                            'Subnet': '192.168.52.0/24',
+                            'AuxiliaryAddresses': None,
                         }],
                     }
                 })


### PR DESCRIPTION
In your docs said that checking duplicate for creating network is forced by default. (https://docker-py.readthedocs.io/en/stable/networks.html)
But actually, it isn't true. I fixed this by changing default param in api client.
Also I added functional and unit tests for this case.

Signed-off-by: Dmitry Merkurev <didika914@gmail.com>