### PR TITLE
Improve docs for service list filters

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -201,7 +201,8 @@ class ServiceApiMixin(object):
 
         Args:
             filters (dict): Filters to process on the nodes list. Valid
-                filters: ``id`` and ``name``. Default: ``None``.
+                filters: ``id``, ``name`` , ``label`` and ``mode``.
+                Default: ``None``.
 
         Returns:
             A list of dictionaries containing data about each service.

--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -201,7 +201,8 @@ class ServiceCollection(Collection):
 
         Args:
             filters (dict): Filters to process on the nodes list. Valid
-                filters: ``id`` and ``name``. Default: ``None``.
+                filters: ``id``, ``name`` , ``label`` and ``mode``.
+                Default: ``None``.
 
         Returns:
             (list of :py:class:`Service`): The services.


### PR DESCRIPTION
Referencing issue #1785 

- add "label" to the list of available filter keys in the high-level service API
- add "label" to the list of available filter keys in the low-level service API
- add integration tests

Signed-off-by: Alessandro Baldo <git@baldoalessandro.net>