### PR TITLE
Require at least requests v2.14.2 to update old chardet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'requests >= 2.5.2, != 2.11.0, != 2.12.2, != 2.18.0',
+    'requests >= 2.14.2, != 2.18.0',
     'six >= 1.4.0',
     'websocket-client >= 0.32.0',
     'docker-pycreds >= 0.2.1'


### PR DESCRIPTION
`docker-py` is having trouble with `requests<2.14` because it may use an old version of `chardet`. Some new function is used that does not exist in older versions of the dependency, causing it to crash in some cases.

When using `docker-py` with Ansible, using modules like `docker_network` result in an error with old versions of `chardet` installed. These errors are resolved when using `chardet>=3.0`. `requests` now requires this version since 2.14.

This problem would only happen if an earlier version of `requests` was already installed by some other package, where the version was still satisfied by the current `docker-py` configuration and was below 2.14. When the dependency is freshly installed, this problem would not occur as a version higher than 2.14 would be chosen.

It could be manually fixed by installing `chardet>=3.0.1` in the command line using pip, but this is of course not desired.

Therefore I've changed the configuration to require at least `requests>=2.14.2` (where the patch version `.2` fixed some bugs) to fix this issue as a whole.