### PR TITLE
Fix #1381: Add exit code to exec_run

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -149,10 +149,14 @@ class Container(Model):
                 ``{"PASSWORD": "xxx"}``.
 
         Returns:
-            (generator or str):
-                If ``stream=True``, a generator yielding response chunks.
-                If ``socket=True``, a socket object for the connection.
-                A string containing response data otherwise.
+            dict:
+                output: (generator or str):
+                    If ``stream=True``, a generator yielding response chunks.
+                    If ``socket=True``, a socket object for the connection.
+                    A string containing response data otherwise.
+                exit_code: (int):
+                    Exited code of execution
+
         Raises:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
@@ -161,9 +165,16 @@ class Container(Model):
             self.id, cmd, stdout=stdout, stderr=stderr, stdin=stdin, tty=tty,
             privileged=privileged, user=user, environment=environment
         )
-        return self.client.api.exec_start(
+        exec_output = self.client.api.exec_start(
             resp['Id'], detach=detach, tty=tty, stream=stream, socket=socket
         )
+        exit_code = 0
+        if stream is False:
+            exit_code = self.client.api.exec_inspect(resp['Id'])['ExitCode']
+        return {
+            'exit_code': exit_code,
+            'output': exec_output
+        }
 
     def export(self):
         """

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -153,13 +153,24 @@ class ContainerTest(BaseIntegrationTest):
         container.wait()
         assert container.diff() == [{'Path': '/test', 'Kind': 1}]
 
-    def test_exec_run(self):
+    def test_exec_run_success(self):
         client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run(
             "alpine", "sh -c 'echo \"hello\" > /test; sleep 60'", detach=True
         )
         self.tmp_containers.append(container.id)
-        assert container.exec_run("cat /test") == b"hello\n"
+        exec_output = container.exec_run("cat /test")
+        assert exec_output["output"] == b"hello\n"
+        assert exec_output["exit_code"] == 0
+
+    def test_exec_run_failed(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        container = client.containers.run(
+            "alpine", "sh -c 'sleep 60'", detach=True
+        )
+        self.tmp_containers.append(container.id)
+        exec_output = container.exec_run("docker ps")
+        assert exec_output["exit_code"] == 126
 
     def test_kill(self):
         client = docker.from_env(version=TEST_API_VERSION)

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -400,6 +400,17 @@ class ContainerTest(unittest.TestCase):
         client.api.exec_start.assert_called_with(
             FAKE_EXEC_ID, detach=False, tty=False, stream=True, socket=False
         )
+        container.exec_run("docker ps", privileged=True, stream=False)
+        client.api.exec_create.assert_called_with(
+            FAKE_CONTAINER_ID, "docker ps", stdout=True, stderr=True,
+            stdin=False, tty=False, privileged=True, user='', environment=None
+        )
+        client.api.exec_start.assert_called_with(
+            FAKE_EXEC_ID, detach=False, tty=False, stream=False, socket=False
+        )
+        client.api.exec_start.assert_called_with(
+            FAKE_EXEC_ID, detach=False, tty=False, stream=False, socket=False
+        )
 
     def test_export(self):
         client = make_fake_client()


### PR DESCRIPTION
As described in https://github.com/docker/docker-py/issues/1381, we need to get the exit code after executing a command by `exec_run`.
So I change the returning of `exec_run` to return a dictionary which has `output` and `exit_code`.

Please help me to review this PR. Thank you in advance.