### PR TITLE
Fix #1660 : Move Networks to TaskTemplate

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -368,7 +368,11 @@ class ServiceApiMixin(object):
             data['UpdateConfig'] = update_config
 
         if networks is not None:
-            data['Networks'] = utils.convert_service_networks(networks)
+            if task_template is None:
+                service_spec = self.inspect_service(service)['Spec']
+                data['TaskTemplate'] = service_spec['TaskTemplate']
+            api_networks = utils.convert_service_networks(networks)
+            data['TaskTemplate']['Networks'] = api_networks
         if endpoint_spec is not None:
             data['EndpointSpec'] = endpoint_spec
 

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -4,7 +4,7 @@ from .. import errors
 from ..constants import IS_WINDOWS_PLATFORM
 from ..utils import (
     check_resource, format_environment, format_extra_hosts, parse_bytes,
-    split_command,
+    split_command, convert_service_networks,
 )
 
 
@@ -26,11 +26,14 @@ class TaskTemplate(dict):
         placement (Placement): Placement instructions for the scheduler.
             If a list is passed instead, it is assumed to be a list of
             constraints as part of a :py:class:`Placement` object.
+        networks (:py:class:`list`): List of network names or IDs to attach
+            the containers to.
         force_update (int): A counter that triggers an update even if no
             relevant parameters have been changed.
     """
     def __init__(self, container_spec, resources=None, restart_policy=None,
-                 placement=None, log_driver=None, force_update=None):
+                 placement=None, log_driver=None, networks=None,
+                 force_update=None):
         self['ContainerSpec'] = container_spec
         if resources:
             self['Resources'] = resources
@@ -42,6 +45,8 @@ class TaskTemplate(dict):
             self['Placement'] = placement
         if log_driver:
             self['LogDriver'] = log_driver
+        if networks:
+            self['Networks'] = convert_service_networks(networks)
 
         if force_update is not None:
             if not isinstance(force_update, int):

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -521,7 +521,9 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert len(task_template['Networks']) > 0
         assert task_template['Networks'][0]['Target'] == net1['Id']
 
-        task_tmpl = docker.types.TaskTemplate(container_spec, networks=[net2['Id']])
+        task_tmpl = docker.types.TaskTemplate(
+            container_spec, networks=[net2['Id']]
+        )
         self.client.update_service(
             name, new_index, task_tmpl, name=name
         )

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -491,6 +491,8 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert 'Networks' in svc_info['Spec']
         assert len(svc_info['Spec']['Networks']) > 0
         assert svc_info['Spec']['Networks'][0]['Target'] == net1['Id']
+
+        svc_info = self.client.inspect_service(svc_id)
         version_index = svc_info['Version']['Index']
 
         task_tmpl = docker.types.TaskTemplate(container_spec)
@@ -504,6 +506,9 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert 'Networks' in task_template
         assert len(task_template['Networks']) > 0
         assert task_template['Networks'][0]['Target'] == net2['Id']
+
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
 
         self.client.update_service(
             name, new_index, name=name, networks=[net1['Id']]
@@ -520,6 +525,9 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert 'Networks' in task_template
         assert len(task_template['Networks']) > 0
         assert task_template['Networks'][0]['Target'] == net1['Id']
+
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
 
         task_tmpl = docker.types.TaskTemplate(
             container_spec, networks=[net2['Id']]


### PR DESCRIPTION
This change should fix #1660 to avoid the `networks must be migrated to TaskSpec before being changed` error.
I have changed the API client to put the `Networks` on the `TaskTemplate` object and also added it as a parameter to the `TaskTemplate` class.
The new test should cover each of these changes.
I'm actually switching networks in the test and that seems to need version 1.29 of the API at least.

Thanks!