### PR TITLE
Remove test_update_swarm_name

### DIFF
--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -127,24 +127,6 @@ class SwarmTest(BaseAPIIntegrationTest):
         )
 
     @requires_api_version('1.24')
-    def test_update_swarm_name(self):
-        assert self.init_swarm()
-        swarm_info_1 = self.client.inspect_swarm()
-        spec = self.client.create_swarm_spec(
-            node_cert_expiry=7776000000000000, name='reimuhakurei'
-        )
-        assert self.client.update_swarm(
-            version=swarm_info_1['Version']['Index'], swarm_spec=spec
-        )
-        swarm_info_2 = self.client.inspect_swarm()
-
-        assert (
-            swarm_info_1['Version']['Index'] !=
-            swarm_info_2['Version']['Index']
-        )
-        assert swarm_info_2['Spec']['Name'] == 'reimuhakurei'
-
-    @requires_api_version('1.24')
     def test_list_nodes(self):
         assert self.init_swarm()
         nodes_list = self.client.nodes()


### PR DESCRIPTION
Docker currently only supports the "default" cluster in Swarm-mode. This test used a different name for the cluster, which will produce an error, causing the test to fail;

```
00:53:16 _______________________ SwarmTest.test_update_swarm_name _______________________
00:53:16 /docker-py/tests/integration/api_swarm_test.py:98: in test_update_swarm_name
00:53:16     assert self.client.update_swarm(
00:53:16 /docker-py/docker/utils/decorators.py:34: in wrapper
00:53:16     return f(self, *args, **kwargs)
00:53:16 /docker-py/docker/api/swarm.py:325: in update_swarm
00:53:16     self._raise_for_status(response)
00:53:16 /docker-py/docker/api/client.py:224: in _raise_for_status
00:53:16     raise create_api_error_from_http_exception(e)
00:53:16 /docker-py/docker/errors.py:31: in create_api_error_from_http_exception
00:53:16     raise cls(e, response=response, explanation=explanation)
00:53:16 E   APIError: 500 Server Error: Internal Server Error ("invalid Name "reimuhakurei": swarm spec must be named "default"")
```

relates to https://github.com/moby/moby/pull/35464 / https://github.com/docker/swarmkit/pull/2436

ping @shin- 