### PR TITLE
Update service from prev spec

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -428,7 +428,8 @@ class ServiceApiMixin(object):
                     if 'ContainerSpec' not in merged:
                         merged['ContainerSpec'] = {}
                     for cs_key, cs_value in override['ContainerSpec'].items():
-                        merged['ContainerSpec'][cs_key] = cs_value
-                else:
+                        if cs_value is not None:
+                            merged['ContainerSpec'][cs_key] = cs_value
+                elif ts_value is not None:
                     merged[ts_key] = ts_value
         return merged

--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -299,10 +299,10 @@ def _get_create_service_kwargs(func_name, kwargs):
         if 'force_update' in kwargs:
             task_template_kwargs['force_update'] = kwargs.pop('force_update')
 
-        # use the current spec by default if updating the service
+        # fetch the current spec by default if updating the service
         # through the model
-        use_current_spec = kwargs.pop('use_current_spec', True)
-        create_kwargs['use_current_spec'] = use_current_spec
+        fetch_current_spec = kwargs.pop('fetch_current_spec', True)
+        create_kwargs['fetch_current_spec'] = fetch_current_spec
 
     # All kwargs should have been consumed by this point, so raise
     # error if any are left

--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -251,6 +251,7 @@ CONTAINER_SPEC_KWARGS = [
 
 # kwargs to copy straight over to TaskTemplate
 TASK_TEMPLATE_KWARGS = [
+    'networks',
     'resources',
     'restart_policy',
 ]
@@ -261,7 +262,6 @@ CREATE_SERVICE_KWARGS = [
     'labels',
     'mode',
     'update_config',
-    'networks',
     'endpoint_spec',
 ]
 
@@ -294,6 +294,15 @@ def _get_create_service_kwargs(func_name, kwargs):
             'Name': kwargs.pop('log_driver'),
             'Options': kwargs.pop('log_driver_options', {})
         }
+
+    if func_name == 'update':
+        if 'force_update' in kwargs:
+            task_template_kwargs['force_update'] = kwargs.pop('force_update')
+
+        # use the current spec by default if updating the service
+        # through the model
+        use_current_spec = kwargs.pop('use_current_spec', True)
+        create_kwargs['use_current_spec'] = use_current_spec
 
     # All kwargs should have been consumed by this point, so raise
     # error if any are left

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -4,7 +4,7 @@ from .. import errors
 from ..constants import IS_WINDOWS_PLATFORM
 from ..utils import (
     check_resource, format_environment, format_extra_hosts, parse_bytes,
-    split_command,
+    split_command, convert_service_networks,
 )
 
 
@@ -26,11 +26,14 @@ class TaskTemplate(dict):
         placement (Placement): Placement instructions for the scheduler.
             If a list is passed instead, it is assumed to be a list of
             constraints as part of a :py:class:`Placement` object.
+        networks (:py:class:`list`): List of network names or IDs to attach
+            the containers to.
         force_update (int): A counter that triggers an update even if no
             relevant parameters have been changed.
     """
     def __init__(self, container_spec, resources=None, restart_policy=None,
-                 placement=None, log_driver=None, force_update=None):
+                 placement=None, log_driver=None, networks=None,
+                 force_update=None):
         self['ContainerSpec'] = container_spec
         if resources:
             self['Resources'] = resources
@@ -42,6 +45,8 @@ class TaskTemplate(dict):
             self['Placement'] = placement
         if log_driver:
             self['LogDriver'] = log_driver
+        if networks:
+            self['Networks'] = convert_service_networks(networks)
 
         if force_update is not None:
             if not isinstance(force_update, int):

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -1150,7 +1150,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         try:
             self.client.update_service(*args, **kwargs)
         except docker.errors.APIError as e:
-            if e.explanation == "update out of sequence":
+            if e.explanation.endswith("update out of sequence"):
                 svc_info = self.client.inspect_service(svc_id)
                 version_index = svc_info['Version']['Index']
 
@@ -1160,3 +1160,5 @@ class ServiceTest(BaseAPIIntegrationTest):
                     kwargs['version'] = version_index
 
                 self.client.update_service(*args, **kwargs)
+            else:
+                raise

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -725,7 +725,9 @@ class ServiceTest(BaseAPIIntegrationTest):
         version_index = svc_info['Version']['Index']
 
         task_tmpl = docker.types.TaskTemplate(container_spec, force_update=10)
-        self.client.update_service(name, version_index, task_tmpl, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, task_tmpl, use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -739,7 +741,9 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()
-        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, labels={'service.label': 'SampleLabel'}
+        )
         svc_info = self.client.inspect_service(svc_id)
         assert 'Labels' in svc_info['Spec']
         assert 'service.label' in svc_info['Spec']['Labels']
@@ -747,7 +751,10 @@ class ServiceTest(BaseAPIIntegrationTest):
         version_index = svc_info['Version']['Index']
 
         task_tmpl = docker.types.TaskTemplate(container_spec, force_update=10)
-        self.client.update_service(name, version_index, task_tmpl, name=name, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, task_tmpl, name=name,
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -761,8 +768,10 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()
-        svc_id = self.client.create_service(task_tmpl, name=name,
-                                            mode=docker.types.ServiceMode(mode='replicated', replicas=2))
+        svc_id = self.client.create_service(
+            task_tmpl, name=name,
+            mode=docker.types.ServiceMode(mode='replicated', replicas=2)
+        )
         svc_info = self.client.inspect_service(svc_id)
         assert 'Mode' in svc_info['Spec']
         assert 'Replicated' in svc_info['Spec']['Mode']
@@ -770,7 +779,10 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert svc_info['Spec']['Mode']['Replicated']['Replicas'] == 2
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, labels={'force': 'update'},
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -786,35 +798,45 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()
-        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, labels={'service.label': 'SampleLabel'}
+        )
         svc_info = self.client.inspect_service(svc_id)
         assert 'TaskTemplate' in svc_info['Spec']
         assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
         assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
-        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+        labels = svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']
+        assert labels['container.label'] == 'SampleLabel'
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, labels={'force': 'update'},
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
         assert 'TaskTemplate' in svc_info['Spec']
         assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
         assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
-        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+        labels = svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']
+        assert labels['container.label'] == 'SampleLabel'
 
         container_spec = docker.types.ContainerSpec(
             'busybox', ['echo', 'hello']
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
-        self.client.update_service(name, new_index, task_tmpl, use_current_spec=True)
+        self._update_service(
+            svc_id, name, new_index, task_tmpl, use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         newer_index = svc_info['Version']['Index']
         assert newer_index > new_index
         assert 'TaskTemplate' in svc_info['Spec']
         assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
         assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
-        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+        labels = svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']
+        assert labels['container.label'] == 'SampleLabel'
 
     def test_update_service_with_defaults_update_config(self):
         container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
@@ -834,7 +856,10 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert update_config['FailureAction'] == uc['FailureAction']
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, labels={'force': 'update'},
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -869,7 +894,10 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, labels={'force': 'update'},
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -878,7 +906,10 @@ class ServiceTest(BaseAPIIntegrationTest):
             {'Target': net1['Id']}, {'Target': net2['Id']}
         ]
 
-        self.client.update_service(name, new_index, networks=[net1['Id']], use_current_spec=True)
+        self._update_service(
+            svc_id, name, new_index, networks=[net1['Id']],
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         assert 'Networks' in svc_info['Spec']['TaskTemplate']
         assert svc_info['Spec']['TaskTemplate']['Networks'] == [
@@ -918,7 +949,10 @@ class ServiceTest(BaseAPIIntegrationTest):
         svc_info = self.client.inspect_service(svc_id)
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, labels={'force': 'update'},
+            use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -968,13 +1002,16 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, task_tmpl, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, task_tmpl, use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
+        container_spec = svc_info['Spec']['TaskTemplate']['ContainerSpec']
         assert (
-            'Healthcheck' not in svc_info['Spec']['TaskTemplate']['ContainerSpec'] or
-            not svc_info['Spec']['TaskTemplate']['ContainerSpec']['Healthcheck']
+            'Healthcheck' not in container_spec or
+            not container_spec['Healthcheck']
         )
 
     def test_update_service_remove_labels(self):
@@ -983,14 +1020,18 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()
-        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, labels={'service.label': 'SampleLabel'}
+        )
         svc_info = self.client.inspect_service(svc_id)
         assert 'Labels' in svc_info['Spec']
         assert 'service.label' in svc_info['Spec']['Labels']
         assert svc_info['Spec']['Labels']['service.label'] == 'SampleLabel'
         version_index = svc_info['Version']['Index']
 
-        self.client.update_service(name, version_index, labels={}, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, labels={}, use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
@@ -1003,12 +1044,15 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         name = self.get_service_name()
-        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, labels={'service.label': 'SampleLabel'}
+        )
         svc_info = self.client.inspect_service(svc_id)
         assert 'TaskTemplate' in svc_info['Spec']
         assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
         assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
-        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+        labels = svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']
+        assert labels['container.label'] == 'SampleLabel'
         version_index = svc_info['Version']['Index']
 
         container_spec = docker.types.ContainerSpec(
@@ -1016,10 +1060,103 @@ class ServiceTest(BaseAPIIntegrationTest):
             labels={}
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
-        self.client.update_service(name, version_index, task_tmpl, use_current_spec=True)
+        self._update_service(
+            svc_id, name, version_index, task_tmpl, use_current_spec=True
+        )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
         assert new_index > version_index
         assert 'TaskTemplate' in svc_info['Spec']
         assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
-        assert not svc_info['Spec']['TaskTemplate']['ContainerSpec'].get('Labels')
+        container_spec = svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        assert not container_spec.get('Labels')
+
+    @requires_api_version('1.29')
+    def test_update_service_with_network_change(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello']
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        net1 = self.client.create_network(
+            'dockerpytest_1', driver='overlay', ipam={'Driver': 'default'}
+        )
+        self.tmp_networks.append(net1['Id'])
+        net2 = self.client.create_network(
+            'dockerpytest_2', driver='overlay', ipam={'Driver': 'default'}
+        )
+        self.tmp_networks.append(net2['Id'])
+        name = self.get_service_name()
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, networks=[net1['Id']]
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Networks' in svc_info['Spec']
+        assert len(svc_info['Spec']['Networks']) > 0
+        assert svc_info['Spec']['Networks'][0]['Target'] == net1['Id']
+
+        svc_info = self.client.inspect_service(svc_id)
+        version_index = svc_info['Version']['Index']
+
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        self._update_service(
+            svc_id, name, version_index, task_tmpl, name=name,
+            networks=[net2['Id']], use_current_spec=True
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        task_template = svc_info['Spec']['TaskTemplate']
+        assert 'Networks' in task_template
+        assert len(task_template['Networks']) > 0
+        assert task_template['Networks'][0]['Target'] == net2['Id']
+
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+
+        self._update_service(
+            svc_id, name, new_index, name=name, networks=[net1['Id']],
+            use_current_spec=True
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        task_template = svc_info['Spec']['TaskTemplate']
+        assert 'ContainerSpec' in task_template
+        new_spec = task_template['ContainerSpec']
+        assert 'Image' in new_spec
+        assert new_spec['Image'].split(':')[0] == 'busybox'
+        assert 'Command' in new_spec
+        assert new_spec['Command'] == ['echo', 'hello']
+        assert 'Networks' in task_template
+        assert len(task_template['Networks']) > 0
+        assert task_template['Networks'][0]['Target'] == net1['Id']
+
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+
+        task_tmpl = docker.types.TaskTemplate(
+            container_spec, networks=[net2['Id']]
+        )
+        self._update_service(
+            svc_id, name, new_index, task_tmpl, name=name,
+            use_current_spec=True
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        task_template = svc_info['Spec']['TaskTemplate']
+        assert 'Networks' in task_template
+        assert len(task_template['Networks']) > 0
+        assert task_template['Networks'][0]['Target'] == net2['Id']
+
+    def _update_service(self, svc_id, *args, **kwargs):
+        # service update tests seem to be a bit flaky
+        # give them a chance to retry the update with a new version index
+        try:
+            self.client.update_service(*args, **kwargs)
+        except docker.errors.APIError as e:
+            if e.explanation == "update out of sequence":
+                svc_info = self.client.inspect_service(svc_id)
+                version_index = svc_info['Version']['Index']
+
+                if len(args) > 1:
+                    args = (args[0], version_index) + args[2:]
+                else:
+                    kwargs['version'] = version_index
+
+                self.client.update_service(*args, **kwargs)

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -710,3 +710,316 @@ class ServiceTest(BaseAPIIntegrationTest):
             svc_info['Spec']['TaskTemplate']['ContainerSpec']['Privileges']
         )
         assert privileges['SELinuxContext']['Disable'] is True
+
+    @requires_api_version('1.25')
+    def test_update_service_with_defaults_name(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello']
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name)
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Name' in svc_info['Spec']
+        assert svc_info['Spec']['Name'] == name
+        version_index = svc_info['Version']['Index']
+
+        task_tmpl = docker.types.TaskTemplate(container_spec, force_update=10)
+        self.client.update_service(name, version_index, task_tmpl, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'Name' in svc_info['Spec']
+        assert svc_info['Spec']['Name'] == name
+
+    @requires_api_version('1.25')
+    def test_update_service_with_defaults_labels(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello']
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Labels' in svc_info['Spec']
+        assert 'service.label' in svc_info['Spec']['Labels']
+        assert svc_info['Spec']['Labels']['service.label'] == 'SampleLabel'
+        version_index = svc_info['Version']['Index']
+
+        task_tmpl = docker.types.TaskTemplate(container_spec, force_update=10)
+        self.client.update_service(name, version_index, task_tmpl, name=name, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'Labels' in svc_info['Spec']
+        assert 'service.label' in svc_info['Spec']['Labels']
+        assert svc_info['Spec']['Labels']['service.label'] == 'SampleLabel'
+
+    def test_update_service_with_defaults_mode(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello']
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name,
+                                            mode=docker.types.ServiceMode(mode='replicated', replicas=2))
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Mode' in svc_info['Spec']
+        assert 'Replicated' in svc_info['Spec']['Mode']
+        assert 'Replicas' in svc_info['Spec']['Mode']['Replicated']
+        assert svc_info['Spec']['Mode']['Replicated']['Replicas'] == 2
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'Mode' in svc_info['Spec']
+        assert 'Replicated' in svc_info['Spec']['Mode']
+        assert 'Replicas' in svc_info['Spec']['Mode']['Replicated']
+        assert svc_info['Spec']['Mode']['Replicated']['Replicas'] == 2
+
+    def test_update_service_with_defaults_container_labels(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello'],
+            labels={'container.label': 'SampleLabel'}
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'TaskTemplate' in svc_info['Spec']
+        assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
+        assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'TaskTemplate' in svc_info['Spec']
+        assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
+        assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello']
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        self.client.update_service(name, new_index, task_tmpl, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        newer_index = svc_info['Version']['Index']
+        assert newer_index > new_index
+        assert 'TaskTemplate' in svc_info['Spec']
+        assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
+        assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+
+    def test_update_service_with_defaults_update_config(self):
+        container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        update_config = docker.types.UpdateConfig(
+            parallelism=10, delay=5, failure_action='pause'
+        )
+        name = self.get_service_name()
+        svc_id = self.client.create_service(
+            task_tmpl, update_config=update_config, name=name
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'UpdateConfig' in svc_info['Spec']
+        uc = svc_info['Spec']['UpdateConfig']
+        assert update_config['Parallelism'] == uc['Parallelism']
+        assert update_config['Delay'] == uc['Delay']
+        assert update_config['FailureAction'] == uc['FailureAction']
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'UpdateConfig' in svc_info['Spec']
+        uc = svc_info['Spec']['UpdateConfig']
+        assert update_config['Parallelism'] == uc['Parallelism']
+        assert update_config['Delay'] == uc['Delay']
+        assert update_config['FailureAction'] == uc['FailureAction']
+
+    def test_update_service_with_defaults_networks(self):
+        net1 = self.client.create_network(
+            'dockerpytest_1', driver='overlay', ipam={'Driver': 'default'}
+        )
+        self.tmp_networks.append(net1['Id'])
+        net2 = self.client.create_network(
+            'dockerpytest_2', driver='overlay', ipam={'Driver': 'default'}
+        )
+        self.tmp_networks.append(net2['Id'])
+        container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, networks=[
+                'dockerpytest_1', {'Target': 'dockerpytest_2'}
+            ]
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Networks' in svc_info['Spec']
+        assert svc_info['Spec']['Networks'] == [
+            {'Target': net1['Id']}, {'Target': net2['Id']}
+        ]
+
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'Networks' in svc_info['Spec']['TaskTemplate']
+        assert svc_info['Spec']['TaskTemplate']['Networks'] == [
+            {'Target': net1['Id']}, {'Target': net2['Id']}
+        ]
+
+        self.client.update_service(name, new_index, networks=[net1['Id']], use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Networks' in svc_info['Spec']['TaskTemplate']
+        assert svc_info['Spec']['TaskTemplate']['Networks'] == [
+            {'Target': net1['Id']}
+        ]
+
+    def test_update_service_with_defaults_endpoint_spec(self):
+        container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        endpoint_spec = docker.types.EndpointSpec(ports={
+            12357: (1990, 'udp'),
+            12562: (678,),
+            53243: 8080,
+        })
+        svc_id = self.client.create_service(
+            task_tmpl, name=name, endpoint_spec=endpoint_spec
+        )
+        svc_info = self.client.inspect_service(svc_id)
+        print(svc_info)
+        ports = svc_info['Spec']['EndpointSpec']['Ports']
+        for port in ports:
+            if port['PublishedPort'] == 12562:
+                assert port['TargetPort'] == 678
+                assert port['Protocol'] == 'tcp'
+            elif port['PublishedPort'] == 53243:
+                assert port['TargetPort'] == 8080
+                assert port['Protocol'] == 'tcp'
+            elif port['PublishedPort'] == 12357:
+                assert port['TargetPort'] == 1990
+                assert port['Protocol'] == 'udp'
+            else:
+                self.fail('Invalid port specification: {0}'.format(port))
+
+        assert len(ports) == 3
+
+        svc_info = self.client.inspect_service(svc_id)
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, labels={'force': 'update'}, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+
+        ports = svc_info['Spec']['EndpointSpec']['Ports']
+        for port in ports:
+            if port['PublishedPort'] == 12562:
+                assert port['TargetPort'] == 678
+                assert port['Protocol'] == 'tcp'
+            elif port['PublishedPort'] == 53243:
+                assert port['TargetPort'] == 8080
+                assert port['Protocol'] == 'tcp'
+            elif port['PublishedPort'] == 12357:
+                assert port['TargetPort'] == 1990
+                assert port['Protocol'] == 'udp'
+            else:
+                self.fail('Invalid port specification: {0}'.format(port))
+
+        assert len(ports) == 3
+
+    @requires_api_version('1.25')
+    def test_update_service_remove_healthcheck(self):
+        second = 1000000000
+        hc = docker.types.Healthcheck(
+            test='true', retries=3, timeout=1 * second,
+            start_period=3 * second, interval=int(second / 2),
+        )
+        container_spec = docker.types.ContainerSpec(
+            BUSYBOX, ['sleep', '999'], healthcheck=hc
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name)
+        svc_info = self.client.inspect_service(svc_id)
+        assert (
+            'Healthcheck' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        )
+        assert (
+            hc ==
+            svc_info['Spec']['TaskTemplate']['ContainerSpec']['Healthcheck']
+        )
+
+        container_spec = docker.types.ContainerSpec(
+            BUSYBOX, ['sleep', '999'], healthcheck={}
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, task_tmpl, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert (
+            'Healthcheck' not in svc_info['Spec']['TaskTemplate']['ContainerSpec'] or
+            not svc_info['Spec']['TaskTemplate']['ContainerSpec']['Healthcheck']
+        )
+
+    def test_update_service_remove_labels(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello']
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Labels' in svc_info['Spec']
+        assert 'service.label' in svc_info['Spec']['Labels']
+        assert svc_info['Spec']['Labels']['service.label'] == 'SampleLabel'
+        version_index = svc_info['Version']['Index']
+
+        self.client.update_service(name, version_index, labels={}, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert not svc_info['Spec'].get('Labels')
+
+    def test_update_service_remove_container_labels(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello'],
+            labels={'container.label': 'SampleLabel'}
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name, labels={'service.label': 'SampleLabel'})
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'TaskTemplate' in svc_info['Spec']
+        assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
+        assert 'Labels' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        assert svc_info['Spec']['TaskTemplate']['ContainerSpec']['Labels']['container.label'] == 'SampleLabel'
+        version_index = svc_info['Version']['Index']
+
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['echo', 'hello'],
+            labels={}
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        self.client.update_service(name, version_index, task_tmpl, use_current_spec=True)
+        svc_info = self.client.inspect_service(svc_id)
+        new_index = svc_info['Version']['Index']
+        assert new_index > version_index
+        assert 'TaskTemplate' in svc_info['Spec']
+        assert 'ContainerSpec' in svc_info['Spec']['TaskTemplate']
+        assert not svc_info['Spec']['TaskTemplate']['ContainerSpec'].get('Labels')

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -726,7 +726,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         task_tmpl = docker.types.TaskTemplate(container_spec, force_update=10)
         self._update_service(
-            svc_id, name, version_index, task_tmpl, use_current_spec=True
+            svc_id, name, version_index, task_tmpl, fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -753,7 +753,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         task_tmpl = docker.types.TaskTemplate(container_spec, force_update=10)
         self._update_service(
             svc_id, name, version_index, task_tmpl, name=name,
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -781,7 +781,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, version_index, labels={'force': 'update'},
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -811,7 +811,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, version_index, labels={'force': 'update'},
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -827,7 +827,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         self._update_service(
-            svc_id, name, new_index, task_tmpl, use_current_spec=True
+            svc_id, name, new_index, task_tmpl, fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         newer_index = svc_info['Version']['Index']
@@ -858,7 +858,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, version_index, labels={'force': 'update'},
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -896,7 +896,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, version_index, labels={'force': 'update'},
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -908,7 +908,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, new_index, networks=[net1['Id']],
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         assert 'Networks' in svc_info['Spec']['TaskTemplate']
@@ -951,7 +951,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, version_index, labels={'force': 'update'},
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -1003,7 +1003,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         version_index = svc_info['Version']['Index']
 
         self._update_service(
-            svc_id, name, version_index, task_tmpl, use_current_spec=True
+            svc_id, name, version_index, task_tmpl, fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -1030,7 +1030,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         version_index = svc_info['Version']['Index']
 
         self._update_service(
-            svc_id, name, version_index, labels={}, use_current_spec=True
+            svc_id, name, version_index, labels={}, fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -1061,7 +1061,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         task_tmpl = docker.types.TaskTemplate(container_spec)
         self._update_service(
-            svc_id, name, version_index, task_tmpl, use_current_spec=True
+            svc_id, name, version_index, task_tmpl, fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         new_index = svc_info['Version']['Index']
@@ -1100,7 +1100,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         task_tmpl = docker.types.TaskTemplate(container_spec)
         self._update_service(
             svc_id, name, version_index, task_tmpl, name=name,
-            networks=[net2['Id']], use_current_spec=True
+            networks=[net2['Id']], fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         task_template = svc_info['Spec']['TaskTemplate']
@@ -1114,7 +1114,7 @@ class ServiceTest(BaseAPIIntegrationTest):
 
         self._update_service(
             svc_id, name, new_index, name=name, networks=[net1['Id']],
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         task_template = svc_info['Spec']['TaskTemplate']
@@ -1136,7 +1136,7 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         self._update_service(
             svc_id, name, new_index, task_tmpl, name=name,
-            use_current_spec=True
+            fetch_current_spec=True
         )
         svc_info = self.client.inspect_service(svc_id)
         task_template = svc_info['Spec']['TaskTemplate']

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -193,15 +193,15 @@ class ServiceTest(unittest.TestCase):
             tasks = service.tasks()
         assert len(tasks) == 1
         service.update(
-            # create argument
-            name=service.name,
             mode=docker.types.ServiceMode('replicated', replicas=2),
-            # ContainerSpec argument
-            command="sleep 600"
         )
         while len(tasks) == 1:
             tasks = service.tasks()
         assert len(tasks) >= 2
+        # check that the container spec is not overridden with None
+        service.reload()
+        spec = service.attrs['Spec']['TaskTemplate']['ContainerSpec']
+        assert spec.get('Command') == ['sleep', '300']
 
     @helpers.requires_api_version('1.25')
     def test_restart_service(self):

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -1,7 +1,6 @@
 import unittest
 
 import docker
-import pytest
 
 from .. import helpers
 from .base import TEST_API_VERSION
@@ -35,6 +34,25 @@ class ServiceTest(unittest.TestCase):
         container_spec = service.attrs['Spec']['TaskTemplate']['ContainerSpec']
         assert "alpine" in container_spec['Image']
         assert container_spec['Labels'] == {'container': 'label'}
+
+    def test_create_with_network(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        name = helpers.random_name()
+        network = client.networks.create(
+            helpers.random_name(), driver='overlay'
+        )
+        service = client.services.create(
+            # create arguments
+            name=name,
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300",
+            networks=[network.id]
+        )
+        assert 'Networks' in service.attrs['Spec']['TaskTemplate']
+        networks = service.attrs['Spec']['TaskTemplate']['Networks']
+        assert len(networks) == 1
+        assert networks[0]['Target'] == network.id
 
     def test_get(self):
         client = docker.from_env(version=TEST_API_VERSION)
@@ -82,7 +100,6 @@ class ServiceTest(unittest.TestCase):
         assert len(tasks) == 1
         assert tasks[0]['ServiceID'] == service2.id
 
-    @pytest.mark.skip(reason="Makes Swarm unstable?")
     def test_update(self):
         client = docker.from_env(version=TEST_API_VERSION)
         service = client.services.create(
@@ -101,3 +118,105 @@ class ServiceTest(unittest.TestCase):
         service.reload()
         container_spec = service.attrs['Spec']['TaskTemplate']['ContainerSpec']
         assert container_spec['Command'] == ["sleep", "600"]
+
+    def test_update_retains_service_labels(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            labels={'service.label': 'SampleLabel'},
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300"
+        )
+        service.update(
+            # create argument
+            name=service.name,
+            # ContainerSpec argument
+            command="sleep 600"
+        )
+        service.reload()
+        labels = service.attrs['Spec']['Labels']
+        assert labels == {'service.label': 'SampleLabel'}
+
+    def test_update_retains_container_labels(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300",
+            container_labels={'container.label': 'SampleLabel'}
+        )
+        service.update(
+            # create argument
+            name=service.name,
+            # ContainerSpec argument
+            command="sleep 600"
+        )
+        service.reload()
+        container_spec = service.attrs['Spec']['TaskTemplate']['ContainerSpec']
+        assert container_spec['Labels'] == {'container.label': 'SampleLabel'}
+
+    def test_update_remove_service_labels(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            labels={'service.label': 'SampleLabel'},
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300"
+        )
+        service.update(
+            # create argument
+            name=service.name,
+            labels={},
+            # ContainerSpec argument
+            command="sleep 600"
+        )
+        service.reload()
+        assert not service.attrs['Spec'].get('Labels')
+
+    def test_scale_service(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300"
+        )
+        assert len(service.tasks()) == 1
+        service.update(
+            # create argument
+            name=service.name,
+            mode=docker.types.ServiceMode('replicated', replicas=2),
+            # ContainerSpec argument
+            command="sleep 600"
+        )
+        service.reload()
+        assert len(service.tasks()) >= 2
+
+    @helpers.requires_api_version('1.25')
+    def test_restart_service(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300"
+        )
+        initial_version = service.version
+        service.update(
+            # create argument
+            name=service.name,
+            # task template argument
+            force_update=10,
+            # ContainerSpec argument
+            command="sleep 600"
+        )
+        service.reload()
+        assert service.version > initial_version

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -188,7 +188,10 @@ class ServiceTest(unittest.TestCase):
             image="alpine",
             command="sleep 300"
         )
-        assert len(service.tasks()) == 1
+        tasks = []
+        while len(tasks) == 0:
+            tasks = service.tasks()
+        assert len(tasks) == 1
         service.update(
             # create argument
             name=service.name,
@@ -196,8 +199,9 @@ class ServiceTest(unittest.TestCase):
             # ContainerSpec argument
             command="sleep 600"
         )
-        service.reload()
-        assert len(service.tasks()) >= 2
+        while len(tasks) == 1:
+            tasks = service.tasks()
+        assert len(tasks) >= 2
 
     @helpers.requires_api_version('1.25')
     def test_restart_service(self):

--- a/tests/unit/models_services_test.py
+++ b/tests/unit/models_services_test.py
@@ -35,18 +35,18 @@ class CreateServiceKwargsTest(unittest.TestCase):
             'labels': {'key': 'value'},
             'mode': 'global',
             'update_config': {'update': 'config'},
-            'networks': ['somenet'],
             'endpoint_spec': {'blah': 'blah'},
         }
         assert set(task_template.keys()) == set([
             'ContainerSpec', 'Resources', 'RestartPolicy', 'Placement',
-            'LogDriver'
+            'LogDriver', 'Networks'
         ])
         assert task_template['Placement'] == {'Constraints': ['foo=bar']}
         assert task_template['LogDriver'] == {
             'Name': 'logdriver',
             'Options': {'foo': 'bar'}
         }
+        assert task_template['Networks'] == [{'Target': 'somenet'}]
         assert set(task_template['ContainerSpec'].keys()) == set([
             'Image', 'Command', 'Args', 'Hostname', 'Env', 'Dir', 'User',
             'Labels', 'Mounts', 'StopGracePeriod'


### PR DESCRIPTION
Allowing the service update to reuse attributes from the current service spec.

With this change, the service model update would use this by default but not the API update.
Any arguments coming as `None` should be replaced with values from the previous spec.
To delete a previously defined one, you'd need to pass in the default value (`{}` for labels for example).

This change should also fix #1660 to avoid the `networks must be migrated to TaskSpec before being changed` error.
Because of this, the PR also makes https://github.com/docker/docker-py/pull/1804 unnecessary as this one has all its changes.

This change technically enables specifying networks on both the TaskTemplate and on the API client call. I wonder if I should check this in the _check_api_features?

Please let me know if this change is any good/useful.

Thanks!