### PR TITLE
fixes create_api_error_from_http_exception()

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -18,7 +18,7 @@ def create_api_error_from_http_exception(e):
     try:
         explanation = response.json()['message']
     except ValueError:
-        explanation = response.content.strip()
+        explanation = (response.content or '').strip()
     cls = APIError
     if response.status_code == 404:
         if explanation and ('No such image' in str(explanation) or

--- a/tests/unit/errors_test.py
+++ b/tests/unit/errors_test.py
@@ -3,7 +3,8 @@ import unittest
 import requests
 
 from docker.errors import (APIError, ContainerError, DockerException,
-                           create_unexpected_kwargs_error)
+                           create_unexpected_kwargs_error,
+                           create_api_error_from_http_exception)
 from .fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID
 from .fake_api_client import make_fake_client
 
@@ -77,6 +78,19 @@ class APIErrorTest(unittest.TestCase):
         resp.status_code = 400
         err = APIError('', response=resp)
         assert err.is_client_error() is True
+
+    def test_create_error_from_exception(self):
+            resp = requests.Response()
+            resp.status_code = 500
+            err = APIError('')
+            try:
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as e:
+                try:
+                    create_api_error_from_http_exception(e)
+                except APIError as e:
+                    err = e
+            assert err.is_server_error() is True
 
 
 class ContainerErrorTest(unittest.TestCase):


### PR DESCRIPTION
`create_api_error_from_http_exception()` is never tested in the original code
and will fail miserably when fed with empty `HTTPError` object
see fixes in requests for this behaviour: https://github.com/requests/requests/pull/3179

Signed-off-by: Constantine Peresypkin <pconstantine@gmail.com>