### PR TITLE
Fix format in which hosts are being stored for Swarm services

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -137,7 +137,7 @@ class ContainerSpec(dict):
         if labels is not None:
             self['Labels'] = labels
         if hosts is not None:
-            self['Hosts'] = format_extra_hosts(hosts)
+            self['Hosts'] = format_extra_hosts(hosts, task=True)
 
         if mounts is not None:
             parsed_mounts = []

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -566,7 +566,7 @@ def format_environment(environment):
 
 def format_extra_hosts(extra_hosts):
     return [
-        '{}:{}'.format(k, v) for k, v in sorted(six.iteritems(extra_hosts))
+        '{} {}'.format(v, k) for k, v in sorted(six.iteritems(extra_hosts))
     ]
 
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -564,9 +564,15 @@ def format_environment(environment):
     return [format_env(*var) for var in six.iteritems(environment)]
 
 
-def format_extra_hosts(extra_hosts):
+def format_extra_hosts(extra_hosts, task=False):
+    # Use format dictated by Swarm API if container is part of a task
+    if task:
+        return [
+            '{} {}'.format(v, k) for k, v in sorted(six.iteritems(extra_hosts))
+        ]
+
     return [
-        '{} {}'.format(v, k) for k, v in sorted(six.iteritems(extra_hosts))
+        '{}:{}'.format(k, v) for k, v in sorted(six.iteritems(extra_hosts))
     ]
 
 

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -588,8 +588,8 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert 'Hosts' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
         hosts = svc_info['Spec']['TaskTemplate']['ContainerSpec']['Hosts']
         assert len(hosts) == 2
-        assert 'foobar:127.0.0.1' in hosts
-        assert 'baz:8.8.8.8' in hosts
+        assert '127.0.0.1 foobar' in hosts
+        assert '8.8.8.8 baz' in hosts
 
     @requires_api_version('1.25')
     def test_create_service_with_hostname(self):

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -141,7 +141,7 @@ class ContainerCollectionTest(unittest.TestCase):
                 'Dns': ['8.8.8.8'],
                 'DnsOptions': ['foo'],
                 'DnsSearch': ['example.com'],
-                'ExtraHosts': ['foo:1.2.3.4'],
+                'ExtraHosts': ['1.2.3.4 foo'],
                 'GroupAdd': ['blah'],
                 'IpcMode': 'foo',
                 'KernelMemory': 123,

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -141,7 +141,7 @@ class ContainerCollectionTest(unittest.TestCase):
                 'Dns': ['8.8.8.8'],
                 'DnsOptions': ['foo'],
                 'DnsSearch': ['example.com'],
-                'ExtraHosts': ['1.2.3.4 foo'],
+                'ExtraHosts': ['foo:1.2.3.4'],
                 'GroupAdd': ['blah'],
                 'IpcMode': 'foo',
                 'KernelMemory': 123,


### PR DESCRIPTION
Signed off by Michael Hankin mjhankin1@gmail.com

This fixes #1822 by correcting the format of hosts for containers that are managed by a Swarm service.