### PR TITLE
Make the error message of logs() clearer

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -838,7 +838,8 @@ class ContainerApiMixin(object):
                         params['since'] = since
                     else:
                         raise errors.InvalidArgument(
-                            'since value should be datetime or int, not {}'.
+                            'since value should be datetime or positive int\
+                            , not {}'.
                             format(type(since))
                         )
             url = self._url("/containers/{0}/logs", container)


### PR DESCRIPTION
If we assign 0 to `since`, the error message is not clear enough to users (giving it a value of `int` but being told the value isn't within a valid type).

This PR give users clearer message about what is going on.