### PR TITLE
Add support for order property when updating a service

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -19,6 +19,10 @@ def _check_api_features(version, task_template, update_config):
             if 'Monitor' in update_config:
                 raise_version_error('UpdateConfig.monitor', '1.25')
 
+        if utils.version_lt(version, '1.29'):
+            if 'Order' in update_config:
+                raise_version_error('UpdateConfig.order', '1.29')
+
     if task_template is not None:
         if 'ForceUpdate' in task_template and utils.version_lt(
                 version, '1.25'):

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -336,10 +336,9 @@ class UpdateConfig(dict):
           floating point number between 0 and 1. Default: 0
         order (string): Specifies the order of operations when rolling out an
           updated task. Either ``start_first`` or ``stop_first`` are accepted.
-          Default: ``stop_first``
     """
     def __init__(self, parallelism=0, delay=None, failure_action='continue',
-                 monitor=None, max_failure_ratio=None, order='stop-first'):
+                 monitor=None, max_failure_ratio=None, order=None):
         self['Parallelism'] = parallelism
         if delay is not None:
             self['Delay'] = delay
@@ -363,11 +362,12 @@ class UpdateConfig(dict):
                 )
             self['MaxFailureRatio'] = max_failure_ratio
 
-        if order not in ('start-first', 'stop-first'):
-            raise errors.InvalidArgument(
-                'order must be either `start-first` or `stop-first`'
-            )
-        self['Order'] = order
+        if order is not None:
+            if order not in ('start-first', 'stop-first'):
+                raise errors.InvalidArgument(
+                    'order must be either `start-first` or `stop-first`'
+                )
+            self['Order'] = order
 
 
 class RestartConditionTypesEnum(object):

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -334,9 +334,12 @@ class UpdateConfig(dict):
         max_failure_ratio (float): The fraction of tasks that may fail during
           an update before the failure action is invoked, specified as a
           floating point number between 0 and 1. Default: 0
+        order (string): Specifies the order of operations when rolling out an
+          updated task. Either ``start_first`` or ``stop_first`` are accepted.
+          Default: ``stop_first``
     """
     def __init__(self, parallelism=0, delay=None, failure_action='continue',
-                 monitor=None, max_failure_ratio=None):
+                 monitor=None, max_failure_ratio=None, order='stop-first'):
         self['Parallelism'] = parallelism
         if delay is not None:
             self['Delay'] = delay
@@ -359,6 +362,12 @@ class UpdateConfig(dict):
                     'max_failure_ratio must be a number between 0 and 1'
                 )
             self['MaxFailureRatio'] = max_failure_ratio
+
+        if order not in ('start-first', 'stop-first'):
+            raise errors.InvalidArgument(
+                'order must be either `start-first` or `stop-first`'
+            )
+        self['Order'] = order
 
 
 class RestartConditionTypesEnum(object):


### PR DESCRIPTION
Resolves #1823 by adding support for order specification when updating a service.

Signed-off-by: Michael Hankin <mjhankin1@gmail.com>