### PR TITLE
Fix service network regression on API < 1.25

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -137,6 +137,8 @@ class ServiceApiMixin(object):
         auth_header = auth.get_config_header(self, registry)
         if auth_header:
             headers['X-Registry-Auth'] = auth_header
+        if utils.version_lt(self._version, '1.25'):
+            networks = networks or task_template.pop('Networks', None)
         data = {
             'Name': name,
             'Labels': labels,
@@ -411,7 +413,12 @@ class ServiceApiMixin(object):
 
         if networks is not None:
             converted_networks = utils.convert_service_networks(networks)
-            data['TaskTemplate']['Networks'] = converted_networks
+            if utils.version_lt(self._version, '1.25'):
+                data['Networks'] = converted_networks
+            else:
+                data['TaskTemplate']['Networks'] = converted_networks
+        elif utils.version_lt(self._version, '1.25'):
+            data['Networks'] = current.get('Networks')
         elif data['TaskTemplate'].get('Networks') is None:
             current_task_template = current.get('TaskTemplate', {})
             current_networks = current_task_template.get('Networks')


### PR DESCRIPTION
Hi,

A user has reported to me that my change (https://github.com/docker/docker-py/commit/b2d08e64bceb81b75df8de6b0ad1948488bb4b28#diff-627477fe9d783a0f4c5f8627948efbb1) has broken service network create/update on Docker version 1.12.

> I'm now exploring Docker versions between 1.12.6 and 17.09.0. When I ported my code from 17.09.0 to 1.12.6 for compatibility test, I found probably a python SDK issue made my swarm service unexpectedly created. The service didn't attach to the specified network but to the default one 'ingress'.
> 
> Looked at the code, probably the git commit as below introduced this issue. In this commit on source file docker/models/services.py, the argument "networks" removed from the array of "CREATE_SERVICE_KWARGS". I manually added it then the issue gone.
> 
> BTW, the APIClient() call "create_service()" doesn't have such issue. and also it works well with docker 17.xx.

Below API level 1.25 `Networks` was specified on the `Spec`, not on the `TaskTemplate`.

This change moves the `Network` back to `Spec` before invoking the service create/update endpoints.

Thanks!