### PR TITLE
return current container status

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -42,7 +42,7 @@ class Container(Model):
         """
         The status of the container. For example, ``running``, or ``exited``.
         """
-        return self.attrs['State']['Status']
+        return self.client.api.inspect_container(self.id)['State']['Status']
 
     def attach(self, **kwargs):
         """


### PR DESCRIPTION
When using the container status it was returning 'created' only. With this change the property should return whatever the current status of the container is.

Signed-off-by: Daniel OBrien <dobrien.nj@gmail.com>