### PR TITLE
Fix appveyor tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ packaging==16.8
 pycparser==2.17
 pyOpenSSL==17.0.0
 pyparsing==2.2.0
+pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
+pypiwin32==220; sys_platform == 'win32' and python_version >= '3.6'
 requests==2.14.2
 six==1.10.0
 websocket-client==0.40.0

--- a/setup.py
+++ b/setup.py
@@ -26,15 +26,18 @@ requirements = [
     'docker-pycreds >= 0.2.1'
 ]
 
-if sys.platform == 'win32':
-    requirements.append('pypiwin32 >= 219')
-
 extras_require = {
     ':python_version < "3.5"': 'backports.ssl_match_hostname >= 3.5',
     # While not imported explicitly, the ipaddress module is required for
     # ssl_match_hostname to verify hosts match with certificates via
     # ServerAltname: https://pypi.python.org/pypi/backports.ssl_match_hostname
     ':python_version < "3.3"': 'ipaddress >= 1.0.16',
+
+    # win32 APIs if on Windows (required for npipe support)
+    # Python 3.6 is only compatible with v220 ; Python < 3.5 is not supported
+    # on v220 ; ALL versions are broken for v222 (as of 2018-01-26)
+    ':sys_platform == "win32" and python_version < "3.6"': 'pypiwin32==219',
+    ':sys_platform == "win32" and python_version >= "3.6"': 'pypiwin32==220',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.

--- a/win32-requirements.txt
+++ b/win32-requirements.txt
@@ -1,2 +1,1 @@
 -r requirements.txt
-pypiwin32>=219


### PR DESCRIPTION

    # win32 APIs if on Windows (required for npipe support)
    # Python 3.6 is only compatible with v220 ; Python < 3.5 is not supported
    # on v220 ; ALL versions are broken for v222 (as of 2018-01-26)

This is why everyone hates Windows.