### PR TITLE
ImageCollection.build now also returns build logs

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -140,8 +140,11 @@ class StreamParseError(RuntimeError):
         self.msg = reason
 
 
-class BuildError(Exception):
-    pass
+class BuildError(DockerException):
+    def __init__(self, reason, build_log):
+        super(BuildError, self).__init__(reason)
+        self.msg = reason
+        self.build_log = build_log
 
 
 class ImageLoadError(DockerException):


### PR DESCRIPTION
Additionally, `BuildError.build_logs` has a copy of the logs generator

Fixes #1702 