### PR TITLE
Minor tweaks in Container.exec_run

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -152,7 +152,8 @@ class Container(Model):
         Returns:
             (tuple): A tuple of (exit_code, output)
                 exit_code: (int):
-                    Exit code for the executed command
+                    Exit code for the executed command or ``None`` if
+                    either ``stream```or ``socket`` is ``True``.
                 output: (generator or str):
                     If ``stream=True``, a generator yielding response chunks.
                     If ``socket=True``, a socket object for the connection.
@@ -170,10 +171,11 @@ class Container(Model):
         exec_output = self.client.api.exec_start(
             resp['Id'], detach=detach, tty=tty, stream=stream, socket=socket
         )
-        exit_code = 0
-        if stream is False:
-            exit_code = self.client.api.exec_inspect(resp['Id'])['ExitCode']
-        return (exit_code, exec_output)
+        if socket or stream:
+            return None, exec_output
+        else:
+            return (self.client.api.exec_inspect(resp['Id'])['ExitCode'],
+                    exec_output)
 
     def export(self):
         """

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -3,7 +3,7 @@ import copy
 from ..api import APIClient
 from ..errors import (ContainerError, ImageNotFound,
                       create_unexpected_kwargs_error)
-from ..types import HostConfig
+from ..types import ExecResult, HostConfig
 from ..utils import version_gte
 from .images import Image
 from .resource import Collection, Model
@@ -150,7 +150,7 @@ class Container(Model):
             workdir (str): Path to working directory for this exec session
 
         Returns:
-            (tuple): A tuple of (exit_code, output)
+            (ExecResult): A tuple of (exit_code, output)
                 exit_code: (int):
                     Exit code for the executed command or ``None`` if
                     either ``stream```or ``socket`` is ``True``.
@@ -172,10 +172,11 @@ class Container(Model):
             resp['Id'], detach=detach, tty=tty, stream=stream, socket=socket
         )
         if socket or stream:
-            return None, exec_output
+            return ExecResult(None, exec_output)
         else:
-            return (self.client.api.exec_inspect(resp['Id'])['ExitCode'],
-                    exec_output)
+            return ExecResult(
+                self.client.api.exec_inspect(resp['Id'])['ExitCode'],
+                exec_output)
 
     def export(self):
         """

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
-from .containers import ContainerConfig, HostConfig, LogConfig, Ulimit
+from .containers import (ContainerConfig, ExecResult, HostConfig, LogConfig,
+                         Ulimit)
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig
 from .services import (

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import six
 import warnings
 
@@ -9,6 +10,11 @@ from ..utils.utils import (
 )
 from .base import DictType
 from .healthcheck import Healthcheck
+
+
+ExecResult = namedtuple('ExecResult', 'exit_code,output')
+""" A result of Container.exec_run with the properties ``exit_code`` and
+    ``output``. """
 
 
 class LogConfigTypesEnum(object):


### PR DESCRIPTION
i think `None` is semantically more appropriate when `Container.exec_run` returns a generator or a socket. then i had the idea with the namedtuple for expressive code.