### PR TITLE
Add support for device_cgroup_rules parameter in host config

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -438,6 +438,8 @@ class ContainerApiMixin(object):
                 ``0,1``).
             cpuset_mems (str): Memory nodes (MEMs) in which to allow execution
                 (``0-3``, ``0,1``). Only effective on NUMA systems.
+            device_cgroup_rules (:py:class:`list`): A list of cgroup rules to
+                apply to the container.
             device_read_bps: Limit read rate (bytes per second) from a device
                 in the form of: `[{"Path": "device_path", "Rate": rate}]`
             device_read_iops: Limit read rate (IO per second) from a device.

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -515,6 +515,8 @@ class ContainerCollection(Collection):
                 (``0-3``, ``0,1``). Only effective on NUMA systems.
             detach (bool): Run container in the background and return a
                 :py:class:`Container` object.
+            device_cgroup_rules (:py:class:`list`): A list of cgroup rules to
+                apply to the container.
             device_read_bps: Limit read rate (bytes per second) from a device
                 in the form of: `[{"Path": "device_path", "Rate": rate}]`
             device_read_iops: Limit read rate (IO per second) from a device.
@@ -912,6 +914,7 @@ RUN_HOST_CONFIG_KWARGS = [
     'cpuset_mems',
     'cpu_rt_period',
     'cpu_rt_runtime',
+    'device_cgroup_rules',
     'device_read_bps',
     'device_read_iops',
     'device_write_bps',

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -120,7 +120,8 @@ class HostConfig(dict):
                  init=None, init_path=None, volume_driver=None,
                  cpu_count=None, cpu_percent=None, nano_cpus=None,
                  cpuset_mems=None, runtime=None, mounts=None,
-                 cpu_rt_period=None, cpu_rt_runtime=None):
+                 cpu_rt_period=None, cpu_rt_runtime=None,
+                 device_cgroup_rules=None):
 
         if mem_limit is not None:
             self['Memory'] = parse_bytes(mem_limit)
@@ -465,6 +466,15 @@ class HostConfig(dict):
             if version_lt(version, '1.30'):
                 raise host_config_version_error('mounts', '1.30')
             self['Mounts'] = mounts
+
+        if device_cgroup_rules is not None:
+            if version_lt(version, '1.28'):
+                raise host_config_version_error('device_cgroup_rules', '1.28')
+            if not isinstance(device_cgroup_rules, list):
+                raise host_config_type_error(
+                    'device_cgroup_rules', device_cgroup_rules, 'list'
+                )
+            self['DeviceCgroupRules'] = device_cgroup_rules
 
 
 def host_config_type_error(param, param_value, expected):


### PR DESCRIPTION
Originally requested in docker/compose#5622