### PR TITLE
Clean up created volume from test_run_with_named_volume

### DIFF
--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -55,7 +55,8 @@ class ContainerCollectionTest(BaseIntegrationTest):
 
     def test_run_with_named_volume(self):
         client = docker.from_env(version=TEST_API_VERSION)
-        client.volumes.create(name="somevolume")
+        volume = client.volumes.create(name="somevolume")
+        self.tmp_volumes.append(volume.id)
 
         container = client.containers.run(
             "alpine", "sh -c 'echo \"hello\" > /insidecontainer/test'",


### PR DESCRIPTION
This fix adds the volume id to the list so that it could be
cleaned up on test teardown.

The issue was originally from https://github.com/moby/moby/pull/36292
where an additional `somevolume` pre-exists in tests.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>