### PR TITLE
Allow cancelling the events stream from other threads

### DIFF
--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .containers import ContainerConfig, HostConfig, LogConfig, Ulimit
+from .daemon import CancellableStream
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig
 from .services import (

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -1,0 +1,63 @@
+import socket
+
+try:
+    import requests.packages.urllib3 as urllib3
+except ImportError:
+    import urllib3
+
+
+class CancellableStream(object):
+    """
+    Stream wrapper for real-time events, logs, etc. from the server.
+
+    Example:
+        >>> events = client.events()
+        >>> for event in events:
+        ...   print event
+        >>> # and cancel from another thread
+        >>> events.close()
+    """
+
+    def __init__(self, stream, response):
+        self._stream = stream
+        self._response = response
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return next(self._stream)
+        except urllib3.exceptions.ProtocolError:
+            raise StopIteration
+        except socket.error:
+            raise StopIteration
+
+    next = __next__
+
+    def close(self):
+        """
+        Closes the event streaming.
+        """
+
+        if not self._response.raw.closed:
+            # find the underlying socket object
+            # based on api.client._get_raw_response_socket
+
+            sock_fp = self._response.raw._fp.fp
+
+            if hasattr(sock_fp, 'raw'):
+                sock_raw = sock_fp.raw
+
+                if hasattr(sock_raw, 'sock'):
+                    sock = sock_raw.sock
+
+                elif hasattr(sock_raw, '_sock'):
+                    sock = sock_raw._sock
+
+            else:
+                sock = sock_fp._sock
+
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.makefile().close()
+            sock.close()


### PR DESCRIPTION
Hi,

These changes would allow wrapping the original `client.events()` response into an object, that allows you to close it from another thread. This also means you need to call another method on the original thread to start consuming events from the generator.

Example:
```python
client = docker.from_env()
events = client.events(cancellable=True)

for event in events.stream():  # we're blocked here
  print event

print 'After reading the event stream'  # once closed

# from another thread:
events.close()
```

Not sure if this is the best design choice, so please tell me any feedback. The change introduces a new `CancellableEvents` type for the wrapper, and modifies the `DaemonApiMixin.events(..)` method to accept a new `cancellable` bool flag. When false, the generator is returned as before, if true, the wrapped object.

This PR would be a potential fix for https://github.com/docker/docker-py/issues/1358 and the implementation idea was based on https://stackoverflow.com/a/36511714 (mentioned on the issue).

Thank you!