### PR TITLE
Shorthand method for service.restart()

### DIFF
--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -69,6 +69,11 @@ class Service(Model):
             spec = self.attrs['Spec']['TaskTemplate']['ContainerSpec']
             kwargs['image'] = spec['Image']
 
+        if kwargs.get('force_update') is True:
+            task_template = self.attrs['Spec']['TaskTemplate']
+            current_value = int(task_template.get('ForceUpdate', 0))
+            kwargs['force_update'] = current_value + 1
+
         create_kwargs = _get_create_service_kwargs('update', kwargs)
 
         return self.client.api.update_service(
@@ -123,6 +128,16 @@ class Service(Model):
         return self.client.api.update_service(self.id, self.version,
                                               service_mode,
                                               fetch_current_spec=True)
+
+    def force_update(self):
+        """
+        Force update the service even if no changes require it.
+
+        Returns:
+            ``True``if successful.
+        """
+
+        return self.update(force_update=True, fetch_current_spec=True)
 
 
 class ServiceCollection(Collection):

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -276,7 +276,7 @@ class ServiceTest(unittest.TestCase):
         assert spec.get('Command') == ['sleep', '300']
 
     @helpers.requires_api_version('1.25')
-    def test_restart_service(self):
+    def test_force_update_service(self):
         client = docker.from_env(version=TEST_API_VERSION)
         service = client.services.create(
             # create arguments
@@ -286,7 +286,7 @@ class ServiceTest(unittest.TestCase):
             command="sleep 300"
         )
         initial_version = service.version
-        service.update(
+        assert service.update(
             # create argument
             name=service.name,
             # task template argument
@@ -294,5 +294,42 @@ class ServiceTest(unittest.TestCase):
             # ContainerSpec argument
             command="sleep 600"
         )
+        service.reload()
+        assert service.version > initial_version
+
+    @helpers.requires_api_version('1.25')
+    def test_force_update_service_using_bool(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300"
+        )
+        initial_version = service.version
+        assert service.update(
+            # create argument
+            name=service.name,
+            # task template argument
+            force_update=True,
+            # ContainerSpec argument
+            command="sleep 600"
+        )
+        service.reload()
+        assert service.version > initial_version
+
+    @helpers.requires_api_version('1.25')
+    def test_force_update_service_using_shorthand_method(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        service = client.services.create(
+            # create arguments
+            name=helpers.random_name(),
+            # ContainerSpec arguments
+            image="alpine",
+            command="sleep 300"
+        )
+        initial_version = service.version
+        assert service.force_update()
         service.reload()
         assert service.version > initial_version


### PR DESCRIPTION
This PR would add a new shorthand method to restart a service, similarly to the recently added `scale` method.

Usage:
```python
service = client.services.create(..)
service.restart()
```

Thanks!