### PR TITLE
Cleanup containers during the tests

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -36,7 +36,7 @@ class BaseIntegrationTest(unittest.TestCase):
                 pass
         for container in self.tmp_containers:
             try:
-                client.api.remove_container(container, force=True)
+                client.api.remove_container(container, force=True, v=True)
             except docker.errors.APIError:
                 pass
         for network in self.tmp_networks:

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -47,10 +47,13 @@ class ContainerCollectionTest(BaseIntegrationTest):
         self.tmp_containers.append(container.id)
         container.wait()
 
+        name = "container_volume_test"
         out = client.containers.run(
             "alpine", "cat /insidecontainer/test",
-            volumes=["%s:/insidecontainer" % path]
+            volumes=["%s:/insidecontainer" % path],
+            name=name
         )
+        self.tmp_containers.append(name)
         assert out == b'hello\n'
 
     def test_run_with_named_volume(self):
@@ -66,10 +69,13 @@ class ContainerCollectionTest(BaseIntegrationTest):
         self.tmp_containers.append(container.id)
         container.wait()
 
+        name = "container_volume_test"
         out = client.containers.run(
             "alpine", "cat /insidecontainer/test",
-            volumes=["somevolume:/insidecontainer"]
+            volumes=["somevolume:/insidecontainer"],
+            name=name
         )
+        self.tmp_containers.append(name)
         assert out == b'hello\n'
 
     def test_run_with_network(self):


### PR DESCRIPTION
This fix tries to clean up the containers during the tests
so that no pre-existing volumes left in docker integration tests.

This fix adds `-v` when removing containers, and makes sure
containers launched in non-daemon mode are removed.

This fix is realted to https://github.com/moby/moby/pull/36292

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>