### PR TITLE
Workaround requests resolving our unix socket URL on macosx.

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -119,7 +119,9 @@ class APIClient(
             )
             self.mount('http+docker://', self._custom_adapter)
             self._unmount('http://', 'https://')
-            self.base_url = 'http+docker://localunixsocket'
+            # host part of URL should be unused, but is resolved by requests
+            # module in proxy_bypass_macosx_sysconf()
+            self.base_url = 'http+docker://localhost'
         elif base_url.startswith('npipe://'):
             if not IS_WINDOWS_PLATFORM:
                 raise DockerException(

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -512,7 +512,7 @@ def post_fake_network_disconnect():
 
 
 # Maps real api url to fake response callback
-prefix = 'http+docker://localunixsocket'
+prefix = 'http+docker://localhost'
 if constants.IS_WINDOWS_PLATFORM:
     prefix = 'http+docker://localnpipe'
 


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>