### PR TITLE
Ignore comment line from the .dockerignore file 

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -143,7 +143,8 @@ class BuildApiMixin(object):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(
-                        lambda x: x != '' and x[0] != '#', [l.strip() for l in f.read().splitlines()]
+                        lambda x: x != '' and x[0] != '#',
+                        [l.strip() for l in f.read().splitlines()]
                     ))
             context = utils.tar(
                 path, exclude=exclude, dockerfile=dockerfile, gzip=gzip

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -143,7 +143,7 @@ class BuildApiMixin(object):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(
-                        bool, [l.strip() for l in f.read().splitlines()]
+                        lambda x: x != '' and x[0] != '#', [l.strip() for l in f.read().splitlines()]
                     ))
             context = utils.tar(
                 path, exclude=exclude, dockerfile=dockerfile, gzip=gzip

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -62,7 +62,7 @@ class BuildTest(BaseAPIIntegrationTest):
                 '.dockerignore',
                 '!ignored/subdir/excepted-file',
                 '',  # empty line,
-                '#', # comment line
+                '#',  # comment line
             ]))
 
         with open(os.path.join(base_dir, 'not-ignored'), 'w') as f:

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -61,7 +61,8 @@ class BuildTest(BaseAPIIntegrationTest):
                 'Dockerfile',
                 '.dockerignore',
                 '!ignored/subdir/excepted-file',
-                '',  # empty line
+                '',  # empty line,
+                '#', # comment line
             ]))
 
         with open(os.path.join(base_dir, 'not-ignored'), 'w') as f:


### PR DESCRIPTION
This fixed the bug that test comment line in .dockerignore file as ignore rule
bug.

Add test for "# comment" patterns in .dockerignore.