### PR TITLE
3.1.1 release

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -143,7 +143,8 @@ class BuildApiMixin(object):
             if os.path.exists(dockerignore):
                 with open(dockerignore, 'r') as f:
                     exclude = list(filter(
-                        bool, [l.strip() for l in f.read().splitlines()]
+                        lambda x: x != '' and x[0] != '#',
+                        [l.strip() for l in f.read().splitlines()]
                     ))
             context = utils.tar(
                 path, exclude=exclude, dockerfile=dockerfile, gzip=gzip

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -119,7 +119,9 @@ class APIClient(
             )
             self.mount('http+docker://', self._custom_adapter)
             self._unmount('http://', 'https://')
-            self.base_url = 'http+docker://localunixsocket'
+            # host part of URL should be unused, but is resolved by requests
+            # module in proxy_bypass_macosx_sysconf()
+            self.base_url = 'http+docker://localhost'
         elif base_url.startswith('npipe://'):
             if not IS_WINDOWS_PLATFORM:
                 raise DockerException(

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "3.2.0-dev"
+version = "3.1.1"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "3.1.0"
+version = "3.2.0-dev"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,18 @@
 Change log
 ==========
 
+3.1.1
+-----
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/46?closed=1)
+
+### Bugfixes
+
+* Fixed a bug that caused costly DNS lookups on Mac OSX when connecting to the
+  engine through UNIX socket
+* Fixed a bug that caused `.dockerignore` comments to be read as exclusion
+  patterns
+
 3.1.0
 -----
 

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -61,11 +61,15 @@ class BuildTest(BaseAPIIntegrationTest):
                 'Dockerfile',
                 '.dockerignore',
                 '!ignored/subdir/excepted-file',
-                '',  # empty line
+                '',  # empty line,
+                '#*',  # comment line
             ]))
 
         with open(os.path.join(base_dir, 'not-ignored'), 'w') as f:
             f.write("this file should not be ignored")
+
+        with open(os.path.join(base_dir, '#file.txt'), 'w') as f:
+            f.write('this file should not be ignored')
 
         subdir = os.path.join(base_dir, 'ignored', 'subdir')
         os.makedirs(subdir)
@@ -92,6 +96,7 @@ class BuildTest(BaseAPIIntegrationTest):
             logs = logs.decode('utf-8')
 
         assert sorted(list(filter(None, logs.split('\n')))) == sorted([
+            '/test/#file.txt',
             '/test/ignored/subdir/excepted-file',
             '/test/not-ignored'
         ])

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -36,7 +36,7 @@ class BaseIntegrationTest(unittest.TestCase):
                 pass
         for container in self.tmp_containers:
             try:
-                client.api.remove_container(container, force=True)
+                client.api.remove_container(container, force=True, v=True)
             except docker.errors.APIError:
                 pass
         for network in self.tmp_networks:

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -47,10 +47,13 @@ class ContainerCollectionTest(BaseIntegrationTest):
         self.tmp_containers.append(container.id)
         container.wait()
 
+        name = "container_volume_test"
         out = client.containers.run(
             "alpine", "cat /insidecontainer/test",
-            volumes=["%s:/insidecontainer" % path]
+            volumes=["%s:/insidecontainer" % path],
+            name=name
         )
+        self.tmp_containers.append(name)
         assert out == b'hello\n'
 
     def test_run_with_named_volume(self):
@@ -66,10 +69,13 @@ class ContainerCollectionTest(BaseIntegrationTest):
         self.tmp_containers.append(container.id)
         container.wait()
 
+        name = "container_volume_test"
         out = client.containers.run(
             "alpine", "cat /insidecontainer/test",
-            volumes=["somevolume:/insidecontainer"]
+            volumes=["somevolume:/insidecontainer"],
+            name=name
         )
+        self.tmp_containers.append(name)
         assert out == b'hello\n'
 
     def test_run_with_network(self):

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -512,7 +512,7 @@ def post_fake_network_disconnect():
 
 
 # Maps real api url to fake response callback
-prefix = 'http+docker://localunixsocket'
+prefix = 'http+docker://localhost'
 if constants.IS_WINDOWS_PLATFORM:
     prefix = 'http+docker://localnpipe'
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -902,6 +902,22 @@ class ExcludePathsTest(unittest.TestCase):
             ['*.md', '!README*.md', 'README-secret.md']
         ) == set(['README.md', 'README-bis.md'])
 
+    def test_parent_directory(self):
+        base = make_tree(
+            [],
+            ['a.py',
+             'b.py',
+             'c.py'])
+        # Dockerignore reference stipulates that absolute paths are
+        # equivalent to relative paths, hence /../foo should be
+        # equivalent to ../foo. It also stipulates that paths are run
+        # through Go's filepath.Clean, which explicitely "replace
+        # "/.."  by "/" at the beginning of a path".
+        assert exclude_paths(
+            base,
+            ['../a.py', '/../b.py']
+        ) == set(['c.py'])
+
 
 class TarTest(unittest.TestCase):
     def test_tar_with_excludes(self):


### PR DESCRIPTION
[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/46?closed=1)

### Bugfixes

* Fixed a bug that caused costly DNS lookups on Mac OSX when connecting to the
  engine through UNIX socket
* Fixed a bug that caused `.dockerignore` comments to be read as exclusion
  patterns
