### PR TITLE
stop(), restart(): Adapt request timeout to user-provided graceful timeout

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1007,7 +1007,10 @@ class ContainerApiMixin(object):
         """
         params = {'t': timeout}
         url = self._url("/containers/{0}/restart", container)
-        res = self._post(url, params=params)
+        conn_timeout = self.timeout
+        if conn_timeout:
+            conn_timeout = max(conn_timeout, timeout+15)
+        res = self._post(url, params=params, timeout=conn_timeout)
         self._raise_for_status(res)
 
     @utils.check_resource('container')
@@ -1096,9 +1099,11 @@ class ContainerApiMixin(object):
         else:
             params = {'t': timeout}
         url = self._url("/containers/{0}/stop", container)
-
+        conn_timeout = self.timeout
+        if conn_timeout:
+            conn_timeout = max(conn_timeout, timeout + 15)
         res = self._post(url, params=params,
-                         timeout=(timeout + (self.timeout or 0)))
+                         timeout=conn_timeout)
         self._raise_for_status(res)
 
     @utils.check_resource('container')

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1145,6 +1145,17 @@ class RestartContainerTest(BaseAPIIntegrationTest):
         assert info2['State']['Running'] is True
         self.client.kill(id)
 
+    def test_restart_with_hight_timeout(self):
+        container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
+        id = container['Id']
+        self.client.start(id)
+        self.client.timeout = 1
+        self.client.restart(id, timeout=3)
+        self.client.timeout = None
+        self.client.restart(id, timeout=3)
+        self.client.timeout = 1
+        self.client.stop(id, timeout=3)
+
     def test_restart_with_dict_instead_of_id(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         assert 'Id' in container

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1264,7 +1264,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/stop',
             params={'t': timeout},
-            timeout=(DEFAULT_TIMEOUT_SECONDS + timeout)
+            timeout=(DEFAULT_TIMEOUT_SECONDS)
         )
 
     def test_stop_container_with_dict_instead_of_id(self):
@@ -1277,7 +1277,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/stop',
             params={'t': timeout},
-            timeout=(DEFAULT_TIMEOUT_SECONDS + timeout)
+            timeout=(DEFAULT_TIMEOUT_SECONDS)
         )
 
     def test_pause_container(self):


### PR DESCRIPTION
Signed-off-by: Matthieu Nottale <matthieu.nottale@docker.com>