### PR TITLE
Allow cancelling streams from other threads 

### DIFF
--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .containers import ContainerConfig, HostConfig, LogConfig, Ulimit
+from .daemon import CancellableStream
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig
 from .services import (

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -1,0 +1,63 @@
+import socket
+
+try:
+    import requests.packages.urllib3 as urllib3
+except ImportError:
+    import urllib3
+
+
+class CancellableStream(object):
+    """
+    Stream wrapper for real-time events, logs, etc. from the server.
+
+    Example:
+        >>> events = client.events()
+        >>> for event in events:
+        ...   print event
+        >>> # and cancel from another thread
+        >>> events.close()
+    """
+
+    def __init__(self, stream, response):
+        self._stream = stream
+        self._response = response
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return next(self._stream)
+        except urllib3.exceptions.ProtocolError:
+            raise StopIteration
+        except socket.error:
+            raise StopIteration
+
+    next = __next__
+
+    def close(self):
+        """
+        Closes the event streaming.
+        """
+
+        if not self._response.raw.closed:
+            # find the underlying socket object
+            # based on api.client._get_raw_response_socket
+
+            sock_fp = self._response.raw._fp.fp
+
+            if hasattr(sock_fp, 'raw'):
+                sock_raw = sock_fp.raw
+
+                if hasattr(sock_raw, 'sock'):
+                    sock = sock_raw.sock
+
+                elif hasattr(sock_raw, '_sock'):
+                    sock = sock_raw._sock
+
+            else:
+                sock = sock_fp._sock
+
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.makefile().close()
+            sock.close()

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -59,5 +59,4 @@ class CancellableStream(object):
                 sock = sock_fp._sock
 
             sock.shutdown(socket.SHUT_RDWR)
-            sock.makefile().close()
             sock.close()

--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -22,8 +22,7 @@ def read(socket, n=4096):
 
     recoverable_errors = (errno.EINTR, errno.EDEADLK, errno.EWOULDBLOCK)
 
-    # wait for data to become available
-    if not isinstance(socket, NpipeSocket):
+    if six.PY3 and not isinstance(socket, NpipeSocket):
         select.select([socket], [], [])
 
     try:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
+coverage==3.7.1
+flake8==3.4.1
 mock==1.0.1
 pytest==2.9.1
-coverage==3.7.1
 pytest-cov==2.1.0
-flake8==3.4.1
+pytest-timeout==1.2.1

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -881,6 +881,7 @@ Line2'''
 
         assert logs == (snippet + '\n').encode(encoding='ascii')
 
+    @pytest.mark.timeout(5)
     def test_logs_streaming_and_follow_and_cancel(self):
         snippet = 'Flowering Nights (Sakuya Iyazoi)'
         container = self.client.create_container(
@@ -892,16 +893,10 @@ Line2'''
         logs = six.binary_type()
 
         generator = self.client.logs(id, stream=True, follow=True)
-
-        exit_timer = threading.Timer(3, os._exit, args=[1])
-        exit_timer.start()
-
         threading.Timer(1, generator.close).start()
 
         for chunk in generator:
             logs += chunk
-
-        exit_timer.cancel()
 
         assert logs == (snippet + '\n').encode(encoding='ascii')
 
@@ -1251,6 +1246,7 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         output = self.client.attach(container, stream=False, logs=True)
         assert output == 'hello\n'.encode(encoding='ascii')
 
+    @pytest.mark.timeout(5)
     def test_attach_stream_and_cancel(self):
         container = self.client.create_container(
             BUSYBOX, 'sh -c "echo hello && sleep 60"',
@@ -1260,16 +1256,11 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         self.client.start(container)
         output = self.client.attach(container, stream=True, logs=True)
 
-        exit_timer = threading.Timer(3, os._exit, args=[1])
-        exit_timer.start()
-
         threading.Timer(1, output.close).start()
 
         lines = []
         for line in output:
             lines.append(line)
-
-        exit_timer.cancel()
 
         assert len(lines) == 1
         assert lines[0] == 'hello\r\n'.encode(encoding='ascii')

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import threading
 
@@ -143,20 +142,16 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert logs[0] == b'hello\n'
         assert logs[1] == b'world\n'
 
+    @pytest.mark.timeout(5)
     def test_run_with_streamed_logs_and_cancel(self):
         client = docker.from_env(version=TEST_API_VERSION)
         out = client.containers.run(
             'alpine', 'sh -c "echo hello && echo world"', stream=True
         )
 
-        exit_timer = threading.Timer(3, os._exit, args=[1])
-        exit_timer.start()
-
         threading.Timer(1, out.close).start()
 
         logs = [line for line in out]
-
-        exit_timer.cancel()
 
         assert len(logs) == 2
         assert logs[0] == b'hello\n'

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -1,4 +1,6 @@
+import os
 import tempfile
+import threading
 
 import docker
 import pytest
@@ -138,6 +140,25 @@ class ContainerCollectionTest(BaseIntegrationTest):
             'alpine', 'sh -c "echo hello && echo world"', stream=True
         )
         logs = [line for line in out]
+        assert logs[0] == b'hello\n'
+        assert logs[1] == b'world\n'
+
+    def test_run_with_streamed_logs_and_cancel(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        out = client.containers.run(
+            'alpine', 'sh -c "echo hello && echo world"', stream=True
+        )
+
+        exit_timer = threading.Timer(3, os._exit, args=[1])
+        exit_timer.start()
+
+        threading.Timer(1, out.close).start()
+
+        logs = [line for line in out]
+
+        exit_timer.cancel()
+
+        assert len(logs) == 2
         assert logs[0] == b'hello\n'
         assert logs[1] == b'world\n'
 


### PR DESCRIPTION
Based on #1917 

Rebased + small reliability changes

cc @rycus86 PTAL I went with your suggestion to use `pytest-timeout`. I believe I also fixed the 2.7 flakiness by removing the useless `select` call in `socket.py`. 