### PR TITLE
3.2.0 release

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,12 +11,15 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
+			"shin-",
+		]
+	[Org.Alumni]
+		people = [
 			"aanand",
 			"bfirsh",
 			"dnephin",
 			"mnowster",
 			"mpetazzoni",
-			"shin-",
 		]
 
 [people]

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -18,7 +18,7 @@ class BuildApiMixin(object):
               forcerm=False, dockerfile=None, container_limits=None,
               decode=False, buildargs=None, gzip=False, shmsize=None,
               labels=None, cache_from=None, target=None, network_mode=None,
-              squash=None, extra_hosts=None, platform=None):
+              squash=None, extra_hosts=None, platform=None, isolation=None):
         """
         Similar to the ``docker build`` command. Either ``path`` or ``fileobj``
         needs to be set. ``path`` can be a local path (to a directory
@@ -100,6 +100,8 @@ class BuildApiMixin(object):
             extra_hosts (dict): Extra hosts to add to /etc/hosts in building
                 containers, as a mapping of hostname to IP address.
             platform (str): Platform in the format ``os[/arch[/variant]]``
+            isolation (str): Isolation technology used during build.
+                Default: `None`.
 
         Returns:
             A generator for the build output.
@@ -231,6 +233,13 @@ class BuildApiMixin(object):
                     'platform was only introduced in API version 1.32'
                 )
             params['platform'] = platform
+
+        if isolation is not None:
+            if utils.version_lt(self._version, '1.24'):
+                raise errors.InvalidVersion(
+                    'isolation was only introduced in API version 1.24'
+                )
+            params['isolation'] = isolation
 
         if context is not None:
             headers = {'Content-Type': 'application/tar'}

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import random
 
 from .. import auth
 from .. import constants
@@ -148,6 +149,15 @@ class BuildApiMixin(object):
                         lambda x: x != '' and x[0] != '#',
                         [l.strip() for l in f.read().splitlines()]
                     ))
+            if dockerfile and os.path.relpath(dockerfile, path).startswith(
+                    '..'):
+                with open(dockerfile, 'r') as df:
+                    dockerfile = (
+                        '.dockerfile.{0:x}'.format(random.getrandbits(160)),
+                        df.read()
+                    )
+            else:
+                dockerfile = (dockerfile, None)
             context = utils.tar(
                 path, exclude=exclude, dockerfile=dockerfile, gzip=gzip
             )

--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -245,6 +245,27 @@ class ImageApiMixin(object):
             self._get(self._url("/images/{0}/json", image)), True
         )
 
+    @utils.minimum_version('1.30')
+    @utils.check_resource('image')
+    def inspect_distribution(self, image):
+        """
+        Get image digest and platform information by contacting the registry.
+
+        Args:
+            image (str): The image name to inspect
+
+        Returns:
+            (dict): A dict containing distribution data
+
+        Raises:
+            :py:class:`docker.errors.APIError`
+                If the server returns an error.
+        """
+
+        return self._result(
+            self._get(self._url("/distribution/{0}/json", image)), True
+        )
+
     def load_image(self, data, quiet=None):
         """
         Load an image that was previously saved using

--- a/docker/client.py
+++ b/docker/client.py
@@ -186,6 +186,10 @@ class DockerClient(object):
         return self.api.version(*args, **kwargs)
     version.__doc__ = APIClient.version.__doc__
 
+    def close(self):
+        return self.api.close()
+    close.__doc__ = APIClient.close.__doc__
+
     def __getattr__(self, name):
         s = ["'DockerClient' object has no attribute '{}'".format(name)]
         # If a user calls a method on APIClient, they

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -833,7 +833,8 @@ class ContainerCollection(Collection):
         resp = self.client.api.inspect_container(container_id)
         return self.prepare_model(resp)
 
-    def list(self, all=False, before=None, filters=None, limit=-1, since=None):
+    def list(self, all=False, before=None, filters=None, limit=-1, since=None,
+             sparse=False):
         """
         List containers. Similar to the ``docker ps`` command.
 
@@ -862,6 +863,9 @@ class ContainerCollection(Collection):
                     container. Give the container name or id.
                 - `since` (str): Only containers created after a particular
                     container. Give container name or id.
+            sparse (bool): Do not inspect containers. Returns partial
+                informations, but guaranteed not to block. Use reload() on
+                each container to get the full list of attributes.
 
                 A comprehensive list can be found in the documentation for
                 `docker ps
@@ -877,7 +881,10 @@ class ContainerCollection(Collection):
         resp = self.client.api.containers(all=all, before=before,
                                           filters=filters, limit=limit,
                                           since=since)
-        return [self.get(r['Id']) for r in resp]
+        if sparse:
+            return [self.prepare_model(r) for r in resp]
+        else:
+            return [self.get(r['Id']) for r in resp]
 
     def prune(self, filters=None):
         return self.client.api.prune_containers(filters=filters)

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -164,6 +164,8 @@ class ImageCollection(Collection):
             extra_hosts (dict): Extra hosts to add to /etc/hosts in building
                 containers, as a mapping of hostname to IP address.
             platform (str): Platform in the format ``os[/arch[/variant]]``.
+            isolation (str): Isolation technology used during build.
+                Default: `None`.
 
         Returns:
             (tuple): The first item is the :py:class:`Image` object for the

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .containers import ContainerConfig, HostConfig, LogConfig, Ulimit
+from .daemon import CancellableStream
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig
 from .services import (

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -1,0 +1,63 @@
+import socket
+
+try:
+    import requests.packages.urllib3 as urllib3
+except ImportError:
+    import urllib3
+
+
+class CancellableStream(object):
+    """
+    Stream wrapper for real-time events, logs, etc. from the server.
+
+    Example:
+        >>> events = client.events()
+        >>> for event in events:
+        ...   print event
+        >>> # and cancel from another thread
+        >>> events.close()
+    """
+
+    def __init__(self, stream, response):
+        self._stream = stream
+        self._response = response
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return next(self._stream)
+        except urllib3.exceptions.ProtocolError:
+            raise StopIteration
+        except socket.error:
+            raise StopIteration
+
+    next = __next__
+
+    def close(self):
+        """
+        Closes the event streaming.
+        """
+
+        if not self._response.raw.closed:
+            # find the underlying socket object
+            # based on api.client._get_raw_response_socket
+
+            sock_fp = self._response.raw._fp.fp
+
+            if hasattr(sock_fp, 'raw'):
+                sock_raw = sock_fp.raw
+
+                if hasattr(sock_raw, 'sock'):
+                    sock = sock_raw.sock
+
+                elif hasattr(sock_raw, '_sock'):
+                    sock = sock_raw._sock
+
+            else:
+                sock = sock_fp._sock
+
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.makefile().close()
+            sock.close()

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -59,5 +59,4 @@ class CancellableStream(object):
                 sock = sock_fp._sock
 
             sock.shutdown(socket.SHUT_RDWR)
-            sock.makefile().close()
             sock.close()

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -1,13 +1,13 @@
 # flake8: noqa
-from .build import tar, exclude_paths
+from .build import create_archive, exclude_paths, mkbuildcontext, tar
 from .decorators import check_resource, minimum_version, update_headers
 from .utils import (
     compare_version, convert_port_bindings, convert_volume_binds,
-    mkbuildcontext, parse_repository_tag, parse_host,
+    parse_repository_tag, parse_host,
     kwargs_from_env, convert_filters, datetime_to_timestamp,
     create_host_config, parse_bytes, parse_env_file, version_lt,
     version_gte, decode_json_header, split_command, create_ipam_config,
     create_ipam_pool, parse_devices, normalize_links, convert_service_networks,
-    format_environment, create_archive, format_extra_hosts
+    format_environment, format_extra_hosts
 )
 

--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -152,8 +152,9 @@ def create_archive(root, files=None, fileobj=None, gzip=False,
     t = tarfile.open(mode='w:gz' if gzip else 'w', fileobj=fileobj)
     if files is None:
         files = build_file_list(root)
+    extra_names = set(e[0] for e in extra_files)
     for path in files:
-        if path in [e[0] for e in extra_files]:
+        if path in extra_names:
             # Extra files override context files with the same name
             continue
         full_path = os.path.join(root, path)

--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -1,8 +1,11 @@
+import io
 import os
 import re
+import six
+import tarfile
+import tempfile
 
 from ..constants import IS_WINDOWS_PLATFORM
-from .utils import create_archive
 from fnmatch import fnmatch
 from itertools import chain
 
@@ -127,3 +130,89 @@ def walk(root, patterns, default=True):
                 yield f
         elif matched:
             yield f
+
+
+def build_file_list(root):
+    files = []
+    for dirname, dirnames, fnames in os.walk(root):
+        for filename in fnames + dirnames:
+            longpath = os.path.join(dirname, filename)
+            files.append(
+                longpath.replace(root, '', 1).lstrip('/')
+            )
+
+    return files
+
+
+def create_archive(root, files=None, fileobj=None, gzip=False,
+                   extra_files=None):
+    extra_files = extra_files or []
+    if not fileobj:
+        fileobj = tempfile.NamedTemporaryFile()
+    t = tarfile.open(mode='w:gz' if gzip else 'w', fileobj=fileobj)
+    if files is None:
+        files = build_file_list(root)
+    for path in files:
+        if path in [e[0] for e in extra_files]:
+            # Extra files override context files with the same name
+            continue
+        full_path = os.path.join(root, path)
+
+        i = t.gettarinfo(full_path, arcname=path)
+        if i is None:
+            # This happens when we encounter a socket file. We can safely
+            # ignore it and proceed.
+            continue
+
+        # Workaround https://bugs.python.org/issue32713
+        if i.mtime < 0 or i.mtime > 8**11 - 1:
+            i.mtime = int(i.mtime)
+
+        if IS_WINDOWS_PLATFORM:
+            # Windows doesn't keep track of the execute bit, so we make files
+            # and directories executable by default.
+            i.mode = i.mode & 0o755 | 0o111
+
+        if i.isfile():
+            try:
+                with open(full_path, 'rb') as f:
+                    t.addfile(i, f)
+            except IOError:
+                raise IOError(
+                    'Can not read file in context: {}'.format(full_path)
+                )
+        else:
+            # Directories, FIFOs, symlinks... don't need to be read.
+            t.addfile(i, None)
+
+    for name, contents in extra_files:
+        info = tarfile.TarInfo(name)
+        info.size = len(contents)
+        t.addfile(info, io.BytesIO(contents.encode('utf-8')))
+
+    t.close()
+    fileobj.seek(0)
+    return fileobj
+
+
+def mkbuildcontext(dockerfile):
+    f = tempfile.NamedTemporaryFile()
+    t = tarfile.open(mode='w', fileobj=f)
+    if isinstance(dockerfile, io.StringIO):
+        dfinfo = tarfile.TarInfo('Dockerfile')
+        if six.PY3:
+            raise TypeError('Please use io.BytesIO to create in-memory '
+                            'Dockerfiles with Python 3')
+        else:
+            dfinfo.size = len(dockerfile.getvalue())
+            dockerfile.seek(0)
+    elif isinstance(dockerfile, io.BytesIO):
+        dfinfo = tarfile.TarInfo('Dockerfile')
+        dfinfo.size = len(dockerfile.getvalue())
+        dockerfile.seek(0)
+    else:
+        dfinfo = t.gettarinfo(fileobj=dockerfile, arcname='Dockerfile')
+    t.addfile(dfinfo, dockerfile)
+    t.close()
+    f.seek(0)
+    return f

--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -22,8 +22,7 @@ def read(socket, n=4096):
 
     recoverable_errors = (errno.EINTR, errno.EDEADLK, errno.EWOULDBLOCK)
 
-    # wait for data to become available
-    if not isinstance(socket, NpipeSocket):
+    if six.PY3 and not isinstance(socket, NpipeSocket):
         select.select([socket], [], [])
 
     try:

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "3.1.4"
+version = "3.2.0"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,11 +1,30 @@
 Change log
 ==========
 
+3.2.0
+-----
+
+[List of PRs/ issues for this release](https://github.com/docker/docker-py/milestone/45?closed=1)
+
+### Features
+
+* Generators returned by `attach()`, `logs()` and `events()` now have a
+  `cancel()` method to let consumers stop the iteration client-side.
+* `build()` methods can now handle Dockerfiles supplied outside of the
+  build context.
+* Added `sparse` argument to `DockerClient.containers.list()`
+* Added `isolation` parameter to `build()` methods.
+* Added `close()` method to `DockerClient`
+* Added `APIClient.inspect_distribution()` method and
+  `DockerClient.images.get_registry_data()`
+  * The latter returns an instance of the new `RegistryData` class
+
 3.1.4
 -----
 
 [List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/48?closed=1)
 
+### Bugfixes
 
 * Fixed a bug where build contexts containing directory symlinks would produce
   invalid tar archives

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -26,6 +26,7 @@ Client reference
   .. autoattribute:: swarm
   .. autoattribute:: volumes
 
+  .. automethod:: close()
   .. automethod:: df()
   .. automethod:: events()
   .. automethod:: info()

--- a/docs/images.rst
+++ b/docs/images.rst
@@ -12,6 +12,7 @@ Methods available on ``client.images``:
 
   .. automethod:: build
   .. automethod:: get
+  .. automethod:: get_registry_data
   .. automethod:: list(**kwargs)
   .. automethod:: load
   .. automethod:: prune
@@ -41,3 +42,21 @@ Image objects
   .. automethod:: reload
   .. automethod:: save
   .. automethod:: tag
+
+RegistryData objects
+--------------------
+
+.. autoclass:: RegistryData()
+
+  .. py:attribute:: attrs
+
+    The raw representation of this object from the server.
+
+  .. autoattribute:: id
+  .. autoattribute:: short_id
+
+
+
+  .. automethod:: has_platform
+  .. automethod:: pull
+  .. automethod:: reload

--- a/scripts/versions.py
+++ b/scripts/versions.py
@@ -1,0 +1,71 @@
+import operator
+import re
+from collections import namedtuple
+
+import requests
+
+base_url = 'https://download.docker.com/linux/static/{0}/x86_64/'
+categories = [
+    'edge',
+    'stable',
+    'test'
+]
+
+
+class Version(namedtuple('_Version', 'major minor patch rc edition')):
+
+    @classmethod
+    def parse(cls, version):
+        edition = None
+        version = version.lstrip('v')
+        version, _, rc = version.partition('-')
+        if rc:
+            if 'rc' not in rc:
+                edition = rc
+                rc = None
+            elif '-' in rc:
+                edition, rc = rc.split('-')
+
+        major, minor, patch = version.split('.', 3)
+        return cls(major, minor, patch, rc, edition)
+
+    @property
+    def major_minor(self):
+        return self.major, self.minor
+
+    @property
+    def order(self):
+        """Return a representation that allows this object to be sorted
+        correctly with the default comparator.
+        """
+        # rc releases should appear before official releases
+        rc = (0, self.rc) if self.rc else (1, )
+        return (int(self.major), int(self.minor), int(self.patch)) + rc
+
+    def __str__(self):
+        rc = '-{}'.format(self.rc) if self.rc else ''
+        edition = '-{}'.format(self.edition) if self.edition else ''
+        return '.'.join(map(str, self[:3])) + edition + rc
+
+
+def main():
+    results = set()
+    for url in [base_url.format(cat) for cat in categories]:
+        res = requests.get(url)
+        content = res.text
+        versions = [
+            Version.parse(
+                v.strip('"').lstrip('docker-').rstrip('.tgz').rstrip('-x86_64')
+            ) for v in re.findall(
+                r'"docker-[0-9]+\.[0-9]+\.[0-9]+-.*tgz"', content
+            )
+        ]
+        sorted_versions = sorted(
+            versions, reverse=True, key=operator.attrgetter('order')
+        )
+        latest = sorted_versions[0]
+        results.add(str(latest))
+    print(' '.join(results))
+
+if __name__ == '__main__':
+    main()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
+coverage==3.7.1
+flake8==3.4.1
 mock==1.0.1
 pytest==2.9.1
-coverage==3.7.1
 pytest-cov==2.1.0
-flake8==3.4.1
+pytest-timeout==1.2.1

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -138,6 +138,21 @@ class BuildTest(BaseAPIIntegrationTest):
         # There is currently no way to get the shmsize
         # that was used to build the image
 
+    @requires_api_version('1.24')
+    def test_build_isolation(self):
+        script = io.BytesIO('\n'.join([
+            'FROM scratch',
+            'CMD sh -c "echo \'Deaf To All But The Song\''
+        ]).encode('ascii'))
+
+        stream = self.client.build(
+            fileobj=script, tag='isolation',
+            isolation='default'
+        )
+
+        for chunk in stream:
+            pass
+
     @requires_api_version('1.23')
     def test_build_labels(self):
         script = io.BytesIO('\n'.join([

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -881,6 +881,7 @@ Line2'''
 
         assert logs == (snippet + '\n').encode(encoding='ascii')
 
+    @pytest.mark.timeout(5)
     def test_logs_streaming_and_follow_and_cancel(self):
         snippet = 'Flowering Nights (Sakuya Iyazoi)'
         container = self.client.create_container(
@@ -892,16 +893,10 @@ Line2'''
         logs = six.binary_type()
 
         generator = self.client.logs(id, stream=True, follow=True)
-
-        exit_timer = threading.Timer(3, os._exit, args=[1])
-        exit_timer.start()
-
         threading.Timer(1, generator.close).start()
 
         for chunk in generator:
             logs += chunk
-
-        exit_timer.cancel()
 
         assert logs == (snippet + '\n').encode(encoding='ascii')
 
@@ -1251,6 +1246,7 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         output = self.client.attach(container, stream=False, logs=True)
         assert output == 'hello\n'.encode(encoding='ascii')
 
+    @pytest.mark.timeout(5)
     def test_attach_stream_and_cancel(self):
         container = self.client.create_container(
             BUSYBOX, 'sh -c "echo hello && sleep 60"',
@@ -1260,16 +1256,11 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         self.client.start(container)
         output = self.client.attach(container, stream=True, logs=True)
 
-        exit_timer = threading.Timer(3, os._exit, args=[1])
-        exit_timer.start()
-
         threading.Timer(1, output.close).start()
 
         lines = []
         for line in output:
             lines.append(line)
-
-        exit_timer.cancel()
 
         assert len(lines) == 1
         assert lines[0] == 'hello\r\n'.encode(encoding='ascii')

--- a/tests/integration/api_image_test.py
+++ b/tests/integration/api_image_test.py
@@ -357,3 +357,12 @@ class SaveLoadImagesTest(BaseAPIIntegrationTest):
                     success = True
                     break
         assert success is True
+
+
+@requires_api_version('1.30')
+class InspectDistributionTest(BaseAPIIntegrationTest):
+    def test_inspect_distribution(self):
+        data = self.client.inspect_distribution('busybox:latest')
+        assert data is not None
+        assert 'Platforms' in data
+        assert {'os': 'linux', 'architecture': 'amd64'} in data['Platforms']

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import threading
 
@@ -143,20 +142,16 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert logs[0] == b'hello\n'
         assert logs[1] == b'world\n'
 
+    @pytest.mark.timeout(5)
     def test_run_with_streamed_logs_and_cancel(self):
         client = docker.from_env(version=TEST_API_VERSION)
         out = client.containers.run(
             'alpine', 'sh -c "echo hello && echo world"', stream=True
         )
 
-        exit_timer = threading.Timer(3, os._exit, args=[1])
-        exit_timer.start()
-
         threading.Timer(1, out.close).start()
 
         logs = [line for line in out]
-
-        exit_timer.cancel()
 
         assert len(logs) == 2
         assert logs[0] == b'hello\n'

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -159,6 +159,28 @@ class ContainerCollectionTest(BaseIntegrationTest):
 
         container = containers[0]
         assert container.attrs['Config']['Image'] == 'alpine'
+        assert container.status == 'running'
+        assert container.image == client.images.get('alpine')
+
+        container.kill()
+        container.remove()
+        assert container_id not in [c.id for c in client.containers.list()]
+
+    def test_list_sparse(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        container_id = client.containers.run(
+            "alpine", "sleep 300", detach=True).id
+        self.tmp_containers.append(container_id)
+        containers = [c for c in client.containers.list(sparse=True) if c.id ==
+                      container_id]
+        assert len(containers) == 1
+
+        container = containers[0]
+        assert container.attrs['Image'] == 'alpine'
+        assert container.status == 'running'
+        assert container.image == client.images.get('alpine')
+        with pytest.raises(docker.errors.DockerException):
+            container.labels
 
         container.kill()
         container.remove()

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -1,4 +1,6 @@
+import os
 import tempfile
+import threading
 
 import docker
 import pytest
@@ -138,6 +140,25 @@ class ContainerCollectionTest(BaseIntegrationTest):
             'alpine', 'sh -c "echo hello && echo world"', stream=True
         )
         logs = [line for line in out]
+        assert logs[0] == b'hello\n'
+        assert logs[1] == b'world\n'
+
+    def test_run_with_streamed_logs_and_cancel(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        out = client.containers.run(
+            'alpine', 'sh -c "echo hello && echo world"', stream=True
+        )
+
+        exit_timer = threading.Timer(3, os._exit, args=[1])
+        exit_timer.start()
+
+        threading.Timer(1, out.close).start()
+
+        logs = [line for line in out]
+
+        exit_timer.cancel()
+
+        assert len(logs) == 2
         assert logs[0] == b'hello\n'
         assert logs[1] == b'world\n'
 


### PR DESCRIPTION
[List of PRs/ issues for this release](https://github.com/docker/docker-py/milestone/45?closed=1)

### Features

* Generators returned by `attach()`, `logs()` and `events()` now have a
  `cancel()` method to let consumers stop the iteration client-side.
* `build()` methods can now handle Dockerfiles supplied outside of the
  build context.
* Added `sparse` argument to `DockerClient.containers.list()`
* Added `isolation` parameter to `build()` methods.
* Added `close()` method to `DockerClient`
* Added `APIClient.inspect_distribution()` method and
  `DockerClient.images.get_registry_data()`
  * The latter returns an instance of the new `RegistryData` class