### PR TITLE
3.3.0 release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ def imageNamePy2
 def imageNamePy3
 def images = [:]
 
-
 def buildImage = { name, buildargs, pyTag ->
   img = docker.image(name)
   try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ def imageNamePy2
 def imageNamePy3
 def images = [:]
 
+
 def buildImage = { name, buildargs, pyTag ->
   img = docker.image(name)
   try {

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -305,6 +305,22 @@ class BuildApiMixin(object):
         else:
             log.debug('No auth config found')
 
+    @utils.minimum_version('1.31')
+    def prune_build(self):
+        """
+        Delete builder cache
+
+        Returns:
+            (dict): A dict containing
+            the amount of disk space reclaimed in bytes.
+
+        Raises:
+            :py:class:`docker.errors.APIError`
+                If the server returns an error.
+        """
+        url = self._url("/build/prune")
+        return self._result(self._post(url), True)
+
 
 def process_dockerfile(dockerfile, path):
     if not dockerfile:

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -264,6 +264,23 @@ class BuildApiMixin(object):
 
         return self._stream_helper(response, decode=decode)
 
+    @utils.minimum_version('1.31')
+    def prune_builds(self):
+        """
+        Delete the builder cache
+
+        Returns:
+            (dict): A dictionary containing information about the operation's
+                    result. The ``SpaceReclaimed`` key indicates the amount of
+                    bytes of disk space reclaimed.
+
+        Raises:
+            :py:class:`docker.errors.APIError`
+                If the server returns an error.
+        """
+        url = self._url("/build/prune")
+        return self._result(self._post(url), True)
+
     def _set_auth_headers(self, headers):
         log.debug('Looking for auth config')
 
@@ -304,22 +321,6 @@ class BuildApiMixin(object):
             )
         else:
             log.debug('No auth config found')
-
-    @utils.minimum_version('1.31')
-    def prune_build(self):
-        """
-        Delete builder cache
-
-        Returns:
-            (dict): A dict containing
-            the amount of disk space reclaimed in bytes.
-
-        Raises:
-            :py:class:`docker.errors.APIError`
-                If the server returns an error.
-        """
-        url = self._url("/build/prune")
-        return self._result(self._post(url), True)
 
 
 def process_dockerfile(dockerfile, path):

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -332,10 +332,12 @@ def process_dockerfile(dockerfile, path):
 
     if (os.path.splitdrive(path)[0] != os.path.splitdrive(abs_dockerfile)[0] or
             os.path.relpath(abs_dockerfile, path).startswith('..')):
+        # Dockerfile not in context - read data to insert into tar later
         with open(abs_dockerfile, 'r') as df:
             return (
                 '.dockerfile.{0:x}'.format(random.getrandbits(160)),
                 df.read()
             )
-    else:
-        return (dockerfile, None)
+
+    # Dockerfile is inside the context - return path relative to context root
+    return (os.path.relpath(abs_dockerfile, path), None)

--- a/docker/api/config.py
+++ b/docker/api/config.py
@@ -6,7 +6,7 @@ from .. import utils
 
 
 class ConfigApiMixin(object):
-    @utils.minimum_version('1.25')
+    @utils.minimum_version('1.30')
     def create_config(self, name, data, labels=None):
         """
             Create a config
@@ -35,7 +35,7 @@ class ConfigApiMixin(object):
             self._post_json(url, data=body), True
         )
 
-    @utils.minimum_version('1.25')
+    @utils.minimum_version('1.30')
     @utils.check_resource('id')
     def inspect_config(self, id):
         """
@@ -53,7 +53,7 @@ class ConfigApiMixin(object):
         url = self._url('/configs/{0}', id)
         return self._result(self._get(url), True)
 
-    @utils.minimum_version('1.25')
+    @utils.minimum_version('1.30')
     @utils.check_resource('id')
     def remove_config(self, id):
         """
@@ -73,7 +73,7 @@ class ConfigApiMixin(object):
         self._raise_for_status(res)
         return True
 
-    @utils.minimum_version('1.25')
+    @utils.minimum_version('1.30')
     def configs(self, filters=None):
         """
             List configs

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1018,10 +1018,9 @@ class ContainerApiMixin(object):
         """
         params = {'t': timeout}
         url = self._url("/containers/{0}/restart", container)
-        conn_timeout = self.timeout
-        if conn_timeout:
-            conn_timeout = max(conn_timeout, timeout+15)
-        res = self._post(url, params=params, timeout=conn_timeout)
+        res = self._post(
+            url, params=params, timeout=timeout + (self.timeout or 0)
+        )
         self._raise_for_status(res)
 
     @utils.check_resource('container')
@@ -1113,8 +1112,9 @@ class ContainerApiMixin(object):
         conn_timeout = self.timeout
         if conn_timeout:
             conn_timeout = max(conn_timeout, timeout + 15)
-        res = self._post(url, params=params,
-                         timeout=conn_timeout)
+        res = self._post(
+            url, params=params, timeout=timeout + (self.timeout or 0)
+        )
         self._raise_for_status(res)
 
     @utils.check_resource('container')

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1018,9 +1018,10 @@ class ContainerApiMixin(object):
         """
         params = {'t': timeout}
         url = self._url("/containers/{0}/restart", container)
-        res = self._post(
-            url, params=params, timeout=timeout + (self.timeout or 0)
-        )
+        conn_timeout = self.timeout
+        if conn_timeout is not None:
+            conn_timeout += timeout
+        res = self._post(url, params=params, timeout=conn_timeout)
         self._raise_for_status(res)
 
     @utils.check_resource('container')
@@ -1110,11 +1111,9 @@ class ContainerApiMixin(object):
             params = {'t': timeout}
         url = self._url("/containers/{0}/stop", container)
         conn_timeout = self.timeout
-        if conn_timeout:
-            conn_timeout = max(conn_timeout, timeout + 15)
-        res = self._post(
-            url, params=params, timeout=timeout + (self.timeout or 0)
-        )
+        if conn_timeout is not None:
+            conn_timeout += timeout
+        res = self._post(url, params=params, timeout=conn_timeout)
         self._raise_for_status(res)
 
     @utils.check_resource('container')

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1018,7 +1018,10 @@ class ContainerApiMixin(object):
         """
         params = {'t': timeout}
         url = self._url("/containers/{0}/restart", container)
-        res = self._post(url, params=params)
+        conn_timeout = self.timeout
+        if conn_timeout:
+            conn_timeout = max(conn_timeout, timeout+15)
+        res = self._post(url, params=params, timeout=conn_timeout)
         self._raise_for_status(res)
 
     @utils.check_resource('container')
@@ -1107,9 +1110,11 @@ class ContainerApiMixin(object):
         else:
             params = {'t': timeout}
         url = self._url("/containers/{0}/stop", container)
-
+        conn_timeout = self.timeout
+        if conn_timeout:
+            conn_timeout = max(conn_timeout, timeout + 15)
         res = self._post(url, params=params,
-                         timeout=(timeout + (self.timeout or 0)))
+                         timeout=conn_timeout)
         self._raise_for_status(res)
 
     @utils.check_resource('container')

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -873,9 +873,6 @@ class ContainerCollection(Collection):
                     container. Give the container name or id.
                 - `since` (str): Only containers created after a particular
                     container. Give container name or id.
-            sparse (bool): Do not inspect containers. Returns partial
-                informations, but guaranteed not to block. Use reload() on
-                each container to get the full list of attributes.
 
                 A comprehensive list can be found in the documentation for
                 `docker ps

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -873,6 +873,9 @@ class ContainerCollection(Collection):
                     container. Give the container name or id.
                 - `since` (str): Only containers created after a particular
                     container. Give container name or id.
+            sparse (bool): Do not inspect containers. Returns partial
+                informations, but guaranteed not to block. Use reload() on
+                each container to get the full list of attributes.
 
                 A comprehensive list can be found in the documentation for
                 `docker ps

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -844,7 +844,7 @@ class ContainerCollection(Collection):
         return self.prepare_model(resp)
 
     def list(self, all=False, before=None, filters=None, limit=-1, since=None,
-             sparse=False):
+             sparse=False, ignore_removed=False):
         """
         List containers. Similar to the ``docker ps`` command.
 
@@ -882,6 +882,10 @@ class ContainerCollection(Collection):
                 information, but guaranteed not to block. Use
                 :py:meth:`Container.reload` on resulting objects to retrieve
                 all attributes. Default: ``False``
+            ignore_removed (bool): Ignore failures due to missing containers
+                when attempting to inspect containers from the original list.
+                Set to ``True`` if race conditions are likely. Has no effect
+                if ``sparse=True``. Default: ``False``
 
         Returns:
             (list of :py:class:`Container`)
@@ -902,7 +906,8 @@ class ContainerCollection(Collection):
                     containers.append(self.get(r['Id']))
                 # a container may have been removed while iterating
                 except NotFound:
-                    pass
+                    if not ignore_removed:
+                        raise
             return containers
 
     def prune(self, filters=None):

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -432,6 +432,10 @@ class ImageCollection(Collection):
         return self.client.api.prune_images(filters=filters)
     prune.__doc__ = APIClient.prune_images.__doc__
 
+    def prune_builds(self, *args, **kwargs):
+        return self.client.api.prune_builds(*args, **kwargs)
+    prune_builds.__doc__ = APIClient.prune_builds.__doc__
+
 
 def normalize_platform(platform, engine_info):
     if platform is None:

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "3.2.1"
+version = "3.3.0"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,26 @@
 Change log
 ==========
 
+3.3.0
+-----
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/49?closed=1)
+
+### Features
+
+* Added support for `prune_builds` in `APIClient` and `DockerClient.images`
+* Added support for `ignore_removed` parameter in
+  `DockerClient.containers.list`
+
+### Bugfixes
+
+* Fixed an issue that caused builds to fail when an in-context Dockerfile
+  would be specified using its absolute path
+* Installation with pip 10.0.0 and above no longer fails
+* Connection timeout for `stop` and `restart` now gets properly adjusted to
+  allow for the operation to finish in the specified time
+* Improved docker credential store support on Windows
+
 3.2.1
 -----
 
@@ -16,7 +36,7 @@ Change log
 3.2.0
 -----
 
-[List of PRs/ issues for this release](https://github.com/docker/docker-py/milestone/45?closed=1)
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/45?closed=1)
 
 ### Features
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asn1crypto==0.22.0
 backports.ssl-match-hostname==3.5.0.1
 cffi==1.10.0
 cryptography==1.9
-docker-pycreds==0.2.2
+docker-pycreds==0.2.3
 enum34==1.1.6
 idna==2.5
 ipaddress==1.0.18

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
     'requests >= 2.14.2, != 2.18.0',
     'six >= 1.4.0',
     'websocket-client >= 0.32.0',
-    'docker-pycreds >= 0.2.2'
+    'docker-pycreds >= 0.2.3'
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,16 @@ import pip
 
 from setuptools import setup, find_packages
 
-if 'docker-py' in [x.project_name for x in pip.get_installed_distributions()]:
-    print(
-        'ERROR: "docker-py" needs to be uninstalled before installing this'
-        ' package:\npip uninstall docker-py', file=sys.stderr
-    )
-    sys.exit(1)
+try:
+    if 'docker-py' in [
+            x.project_name for x in pip.get_installed_distributions()]:
+        print(
+            'ERROR: "docker-py" needs to be uninstalled before installing this'
+            ' package:\npip uninstall docker-py', file=sys.stderr
+        )
+        sys.exit(1)
+except AttributeError:
+    pass
 
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,8 @@ from __future__ import print_function
 
 import codecs
 import os
-import sys
-
-import pip
 
 from setuptools import setup, find_packages
-
-try:
-    if 'docker-py' in [
-            x.project_name for x in pip.get_installed_distributions()]:
-        print(
-            'ERROR: "docker-py" needs to be uninstalled before installing this'
-            ' package:\npip uninstall docker-py', file=sys.stderr
-        )
-        sys.exit(1)
-except AttributeError:
-    pass
 
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -452,11 +452,42 @@ class BuildTest(BaseAPIIntegrationTest):
                 'COPY . /src',
                 'WORKDIR /src',
             ]))
-        print(os.path.join(base_dir, 'custom.dockerfile'))
         img_name = random_name()
         self.tmp_imgs.append(img_name)
         stream = self.client.build(
             path=base_dir, dockerfile='custom.dockerfile', tag=img_name,
+            decode=True
+        )
+        lines = []
+        for chunk in stream:
+            lines.append(chunk)
+        assert 'Successfully tagged' in lines[-1]['stream']
+
+        ctnr = self.client.create_container(img_name, 'ls -a')
+        self.tmp_containers.append(ctnr)
+        self.client.start(ctnr)
+        lsdata = self.client.logs(ctnr).strip().split(b'\n')
+        assert len(lsdata) == 4
+        assert sorted(
+            [b'.', b'..', b'file.txt', b'custom.dockerfile']
+        ) == sorted(lsdata)
+
+    def test_build_in_context_abs_dockerfile(self):
+        base_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, base_dir)
+        abs_dockerfile_path = os.path.join(base_dir, 'custom.dockerfile')
+        with open(os.path.join(base_dir, 'file.txt'), 'w') as f:
+            f.write('hello world')
+        with open(abs_dockerfile_path, 'w') as df:
+            df.write('\n'.join([
+                'FROM busybox',
+                'COPY . /src',
+                'WORKDIR /src',
+            ]))
+        img_name = random_name()
+        self.tmp_imgs.append(img_name)
+        stream = self.client.build(
+            path=base_dir, dockerfile=abs_dockerfile_path, tag=img_name,
             decode=True
         )
         lines = []

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -503,3 +503,9 @@ class BuildTest(BaseAPIIntegrationTest):
         assert sorted(
             [b'.', b'..', b'file.txt', b'custom.dockerfile']
         ) == sorted(lsdata)
+
+    @requires_api_version('1.31')
+    def test_prune_builds(self):
+        prune_result = self.client.prune_builds()
+        assert 'SpaceReclaimed' in prune_result
+        assert isinstance(prune_result['SpaceReclaimed'], int)

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1165,7 +1165,7 @@ class RestartContainerTest(BaseAPIIntegrationTest):
         assert info2['State']['Running'] is True
         self.client.kill(id)
 
-    def test_restart_with_hight_timeout(self):
+    def test_restart_with_high_timeout(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         id = container['Id']
         self.client.start(id)

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1165,16 +1165,14 @@ class RestartContainerTest(BaseAPIIntegrationTest):
         assert info2['State']['Running'] is True
         self.client.kill(id)
 
-    def test_restart_with_high_timeout(self):
+    def test_restart_with_low_timeout(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
-        id = container['Id']
-        self.client.start(id)
+        self.client.start(container)
         self.client.timeout = 1
-        self.client.restart(id, timeout=3)
+        self.client.restart(container, timeout=3)
         self.client.timeout = None
-        self.client.restart(id, timeout=3)
-        self.client.timeout = 1
-        self.client.stop(id, timeout=3)
+        self.client.restart(container, timeout=3)
+        self.client.kill(container)
 
     def test_restart_with_dict_instead_of_id(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1165,6 +1165,17 @@ class RestartContainerTest(BaseAPIIntegrationTest):
         assert info2['State']['Running'] is True
         self.client.kill(id)
 
+    def test_restart_with_hight_timeout(self):
+        container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
+        id = container['Id']
+        self.client.start(id)
+        self.client.timeout = 1
+        self.client.restart(id, timeout=3)
+        self.client.timeout = None
+        self.client.restart(id, timeout=3)
+        self.client.timeout = 1
+        self.client.stop(id, timeout=3)
+
     def test_restart_with_dict_instead_of_id(self):
         container = self.client.create_container(BUSYBOX, ['sleep', '9999'])
         assert 'Id' in container

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1264,7 +1264,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/stop',
             params={'t': timeout},
-            timeout=(DEFAULT_TIMEOUT_SECONDS)
+            timeout=(DEFAULT_TIMEOUT_SECONDS + timeout)
         )
 
     def test_stop_container_with_dict_instead_of_id(self):
@@ -1277,7 +1277,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/stop',
             params={'t': timeout},
-            timeout=(DEFAULT_TIMEOUT_SECONDS)
+            timeout=(DEFAULT_TIMEOUT_SECONDS + timeout)
         )
 
     def test_pause_container(self):
@@ -1335,7 +1335,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/restart',
             params={'t': 2},
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=(DEFAULT_TIMEOUT_SECONDS + 2)
         )
 
     def test_restart_container_with_dict_instead_of_id(self):
@@ -1345,7 +1345,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/restart',
             params={'t': 2},
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=(DEFAULT_TIMEOUT_SECONDS + 2)
         )
 
     def test_remove_container(self):

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1264,7 +1264,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/stop',
             params={'t': timeout},
-            timeout=(DEFAULT_TIMEOUT_SECONDS + timeout)
+            timeout=(DEFAULT_TIMEOUT_SECONDS)
         )
 
     def test_stop_container_with_dict_instead_of_id(self):
@@ -1277,7 +1277,7 @@ class ContainerTest(BaseAPIClientTest):
             'POST',
             url_prefix + 'containers/3cc2351ab11b/stop',
             params={'t': timeout},
-            timeout=(DEFAULT_TIMEOUT_SECONDS + timeout)
+            timeout=(DEFAULT_TIMEOUT_SECONDS)
         )
 
     def test_pause_container(self):

--- a/tests/unit/fake_api_client.py
+++ b/tests/unit/fake_api_client.py
@@ -20,15 +20,18 @@ class CopyReturnMagicMock(mock.MagicMock):
         return ret
 
 
-def make_fake_api_client():
+def make_fake_api_client(overrides=None):
     """
     Returns non-complete fake APIClient.
 
     This returns most of the default cases correctly, but most arguments that
     change behaviour will not work.
     """
+
+    if overrides is None:
+        overrides = {}
     api_client = docker.APIClient()
-    mock_client = CopyReturnMagicMock(**{
+    mock_attrs = {
         'build.return_value': fake_api.FAKE_IMAGE_ID,
         'commit.return_value': fake_api.post_fake_commit()[1],
         'containers.return_value': fake_api.get_fake_containers()[1],
@@ -47,15 +50,18 @@ def make_fake_api_client():
         'networks.return_value': fake_api.get_fake_network_list()[1],
         'start.return_value': None,
         'wait.return_value': {'StatusCode': 0},
-    })
+    }
+    mock_attrs.update(overrides)
+    mock_client = CopyReturnMagicMock(**mock_attrs)
+
     mock_client._version = docker.constants.DEFAULT_DOCKER_API_VERSION
     return mock_client
 
 
-def make_fake_client():
+def make_fake_client(overrides=None):
     """
     Returns a Client with a fake APIClient.
     """
     client = docker.DockerClient()
-    client.api = make_fake_api_client()
+    client.api = make_fake_api_client(overrides)
     return client

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -359,6 +359,18 @@ class ContainerCollectionTest(unittest.TestCase):
         assert isinstance(containers[0], Container)
         assert containers[0].id == FAKE_CONTAINER_ID
 
+    def test_list_ignore_removed(self):
+        def side_effect(*args, **kwargs):
+            raise docker.errors.NotFound('Container not found')
+        client = make_fake_client({
+            'inspect_container.side_effect': side_effect
+        })
+
+        with pytest.raises(docker.errors.NotFound):
+            client.containers.list(all=True, ignore_removed=False)
+
+        assert client.containers.list(all=True, ignore_removed=True) == []
+
 
 class ContainerTest(unittest.TestCase):
     def test_name(self):


### PR DESCRIPTION
[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/49?closed=1)

### Features

* Added support for `prune_builds` in `APIClient` and `DockerClient.images`
* Added support for `ignore_removed` parameter in
  `DockerClient.containers.list`

### Bugfixes

* Fixed an issue that caused builds to fail when an in-context Dockerfile
  would be specified using its absolute path
* Installation with pip 10.0.0 and above no longer fails
* Connection timeout for `stop` and `restart` now gets properly adjusted to
  allow for the operation to finish in the specified time
* Improved docker credential store support on Windows