### PR TITLE
Fixing #2046

### DIFF
--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -276,7 +276,7 @@ CONTAINER_SPEC_KWARGS = [
     'labels',
     'mounts',
     'open_stdin',
-    'privileges'
+    'privileges',
     'read_only',
     'secrets',
     'stop_grace_period',


### PR DESCRIPTION
Fixing syntax error caused by missing comma on CONTAINER_SPEC_KWARGS list.

Related issue: [#2046](https://github.com/docker/docker-py/issues/2046)