### PR TITLE
Fix Windows path building

### DIFF
--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -138,7 +138,7 @@ def build_file_list(root):
         for filename in fnames + dirnames:
             longpath = os.path.join(dirname, filename)
             files.append(
-                longpath.replace(root, '', 1).lstrip('/')
+                longpath.replace(root, '', 1).lstrip('/').lstrip('\\')
             )
 
     return files


### PR DESCRIPTION
On Windows, backslash pathing is sometimes used. When building out the full path, the code removes leading '/' but doesn't consider '\\'
This error causes the build to fail.

`
Building test
Traceback (most recent call last):
  File "docker-compose", line 6, in <module>
  File "compose\cli\main.py", line 71, in main
  File "compose\cli\main.py", line 127, in perform_command
  File "compose\cli\main.py", line 282, in build
  File "compose\project.py", line 373, in build
  File "compose\service.py", line 1027, in build
  File "site-packages\docker\api\build.py", line 154, in build
  File "site-packages\docker\utils\build.py", line 31, in tar
  File "site-packages\docker\utils\build.py", line 162, in create_archive
  File "tarfile.py", line 1802, in gettarinfo
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\docker\\test.txt'
[5696] Failed to execute script docker-compose
`

Signed-off-by: Ryan Konkul <rkonkul@gmail.com>