### PR TITLE
Fixed typo in ContainerSpec Docs

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -82,7 +82,7 @@ class ContainerSpec(dict):
         args (:py:class:`list`): Arguments to the command.
         hostname (string): The hostname to set on the container.
         env (dict): Environment variables.
-        dir (string): The working directory for commands to run in.
+        workdir (string): The working directory for commands to run in.
         user (string): The user inside the container.
         labels (dict): A map of labels to associate with the service.
         mounts (:py:class:`list`): A list of specifications for mounts to be


### PR DESCRIPTION
Signed-off-by: Alexander Lloyd <axl639@student.bham.ac.uk>

Fixes a typo in the ContainerSpec docs