### PR TITLE
Add support for `uts_mode` parameter in `Client.create_host_config`.

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -547,6 +547,8 @@ class ContainerApiMixin(object):
             userns_mode (str): Sets the user namespace mode for the container
                 when user namespace remapping option is enabled. Supported
                 values are: ``host``
+            uts_mode (str): Sets the UTS namespace mode for the container.
+                Supported values are: ``host``
             volumes_from (:py:class:`list`): List of container names or IDs to
                 get volumes from.
             runtime (str): Runtime to use with this container.

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -995,6 +995,7 @@ RUN_HOST_CONFIG_KWARGS = [
     'tmpfs',
     'ulimits',
     'userns_mode',
+    'uts_mode',
     'version',
     'volumes_from',
     'runtime'

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -115,11 +115,11 @@ class HostConfig(dict):
                  device_read_iops=None, device_write_iops=None,
                  oom_kill_disable=False, shm_size=None, sysctls=None,
                  tmpfs=None, oom_score_adj=None, dns_opt=None, cpu_shares=None,
-                 cpuset_cpus=None, userns_mode=None, pids_limit=None,
-                 isolation=None, auto_remove=False, storage_opt=None,
-                 init=None, init_path=None, volume_driver=None,
-                 cpu_count=None, cpu_percent=None, nano_cpus=None,
-                 cpuset_mems=None, runtime=None, mounts=None,
+                 cpuset_cpus=None, userns_mode=None, uts_mode=None,
+                 pids_limit=None, isolation=None, auto_remove=False,
+                 storage_opt=None, init=None, init_path=None,
+                 volume_driver=None, cpu_count=None, cpu_percent=None,
+                 nano_cpus=None, cpuset_mems=None, runtime=None, mounts=None,
                  cpu_rt_period=None, cpu_rt_runtime=None,
                  device_cgroup_rules=None):
 
@@ -391,6 +391,11 @@ class HostConfig(dict):
             if userns_mode != "host":
                 raise host_config_value_error("userns_mode", userns_mode)
             self['UsernsMode'] = userns_mode
+
+        if uts_mode:
+            if uts_mode != "host":
+                raise host_config_value_error("uts_mode", uts_mode)
+            self['UTSMode'] = uts_mode
 
         if pids_limit:
             if not isinstance(pids_limit, int):

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -490,6 +490,16 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         self.client.start(ctnr)
         assert rule in self.client.logs(ctnr).decode('utf-8')
 
+    def test_create_with_uts_mode(self):
+        container = self.client.create_container(
+            BUSYBOX, ['echo'], host_config=self.client.create_host_config(
+                uts_mode='host'
+            )
+        )
+        self.tmp_containers.append(container)
+        config = self.client.inspect_container(container)
+        assert config['HostConfig']['UTSMode'] == 'host'
+
 
 @pytest.mark.xfail(
     IS_WINDOWS_PLATFORM, reason='Test not designed for Windows platform'

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -85,6 +85,12 @@ class HostConfigTest(unittest.TestCase):
         with pytest.raises(ValueError):
             create_host_config(version='1.23', userns_mode='host12')
 
+    def test_create_host_config_with_uts(self):
+        config = create_host_config(version='1.15', uts_mode='host')
+        assert config.get('UTSMode') == 'host'
+        with pytest.raises(ValueError):
+            create_host_config(version='1.15', uts_mode='host12')
+
     def test_create_host_config_with_oom_score_adj(self):
         config = create_host_config(version='1.22', oom_score_adj=100)
         assert config.get('OomScoreAdj') == 100

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -95,6 +95,7 @@ class ContainerCollectionTest(unittest.TestCase):
             ulimits=[{"Name": "nofile", "Soft": 1024, "Hard": 2048}],
             user='bob',
             userns_mode='host',
+            uts_mode='host',
             version='1.23',
             volume_driver='some_driver',
             volumes=[
@@ -174,6 +175,7 @@ class ContainerCollectionTest(unittest.TestCase):
                 'Tmpfs': {'/blah': ''},
                 'Ulimits': [{"Name": "nofile", "Soft": 1024, "Hard": 2048}],
                 'UsernsMode': 'host',
+                'UTSMode': 'host',
                 'VolumesFrom': ['container'],
             },
             healthcheck={'test': 'true'},


### PR DESCRIPTION
This parameter allows to set the UTS namespace of the container, as in the
`--uts=X` attribute of Docker CLI:
<https://docs.docker.com/engine/reference/run/#uts-settings---uts>
The only allowed value, if set, is "host".

Also included are changes to the tests to reflect the new added parameter.

Signed-off-by: Marco Trillo <martri@arantia.com>
Signed-off-by: Diego Alvarez <dyako.developer@gmail.com>