### PR TITLE
honor placement preferences via services.create()

### DIFF
--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -321,10 +321,15 @@ def _get_create_service_kwargs(func_name, kwargs):
     if 'container_labels' in kwargs:
         container_spec_kwargs['labels'] = kwargs.pop('container_labels')
 
+    placement = {}
+
     if 'constraints' in kwargs:
-        task_template_kwargs['placement'] = {
-            'Constraints': kwargs.pop('constraints')
-        }
+        placement['Constraints'] = kwargs.pop('constraints')
+
+    if 'preferences' in kwargs:
+        placement['Preferences'] = kwargs.pop('preferences')
+
+    task_template_kwargs['placement'] = placement
 
     if 'log_driver' in kwargs:
         task_template_kwargs['log_driver'] = {


### PR DESCRIPTION
this allows creating a service with placement preferences when
calling services.create().  only constraints were being honored
before.

related to https://github.com/docker/docker-py/pull/1615