### PR TITLE
Update deps for 3.3 & 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true
     - env: TOXENV=flake8
 
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ appdirs==1.4.3
 asn1crypto==0.22.0
 backports.ssl-match-hostname==3.5.0.1
 cffi==1.10.0
-cryptography==1.9
+cryptography==1.9; python_version == '3.3'
+cryptography==2.3; python_version > '3.3'
 docker-pycreds==0.3.0
 enum34==1.1.6
 idna==2.5
@@ -12,7 +13,8 @@ pycparser==2.17
 pyOpenSSL==17.0.0
 pyparsing==2.2.0
 pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
-pypiwin32==220; sys_platform == 'win32' and python_version >= '3.6'
+pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'
 requests==2.14.2
 six==1.10.0
 websocket-client==0.40.0
+urllib3==1.21.1; python_version == '3.3'

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'requests >= 2.14.2, != 2.18.0',
     'six >= 1.4.0',
     'websocket-client >= 0.32.0',
-    'docker-pycreds >= 0.3.0'
+    'docker-pycreds >= 0.3.0',
+    'requests >= 2.14.2, != 2.18.0',
 ]
 
 extras_require = {
@@ -27,7 +27,10 @@ extras_require = {
     # Python 3.6 is only compatible with v220 ; Python < 3.5 is not supported
     # on v220 ; ALL versions are broken for v222 (as of 2018-01-26)
     ':sys_platform == "win32" and python_version < "3.6"': 'pypiwin32==219',
-    ':sys_platform == "win32" and python_version >= "3.6"': 'pypiwin32==220',
+    ':sys_platform == "win32" and python_version >= "3.6"': 'pypiwin32==223',
+
+    # urllib3 drops support for Python 3.3 in 1.23
+    ':python_version == "3.3"': 'urllib3 < 1.23',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.
@@ -38,6 +41,7 @@ extras_require = {
     # installing the extra dependencies, install the following instead:
     # 'requests[security] >= 2.5.2, != 2.11.0, != 2.12.2'
     'tls': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
+
 }
 
 version = None
@@ -81,6 +85,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Utilities',
         'License :: OSI Approved :: Apache Software License',
     ],

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 coverage==3.7.1
 flake8==3.4.1
 mock==1.0.1
-pytest==2.9.1
+pytest==2.9.1; python_version == '3.3'
+pytest==3.6.3; python_version > '3.3'
 pytest-cov==2.1.0
 pytest-timeout==1.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, flake8
+envlist = py27, py34, py35, py36, py37, flake8
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
Note: py33 removed from envlist in tox.ini as it's incompatible with newer version of wheels, meaning the env setup is broken even with older versions of `tox`. Support for Python 3.3 will be dropped in the 4.0 release.