### PR TITLE
Fixes to logs --follow

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -777,16 +777,15 @@ class ContainerCollection(Collection):
         logging_driver = container.attrs['HostConfig']['LogConfig']['Type']
 
         out = None
-        if logging_driver == 'json-file' or logging_driver == 'journald':
-            out = container.logs(
-                stdout=stdout, stderr=stderr, stream=True, follow=True
-            )
-
         exit_status = container.wait()['StatusCode']
         if exit_status != 0:
-            out = None
             if not kwargs.get('auto_remove'):
                 out = container.logs(stdout=False, stderr=True)
+        else:
+            if logging_driver == 'json-file' or logging_driver == 'journald':
+                out = container.logs(
+                    stdout=stdout, stderr=stderr, stream=True, follow=False
+                )
 
         if remove:
             container.remove()

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -873,12 +873,11 @@ Line2'''
         id = container['Id']
         self.tmp_containers.append(id)
         self.client.start(id)
+        threading.Timer(1, self.client.remove_container,
+                        [id], {'force': True}).start()
         logs = six.binary_type()
         for chunk in self.client.logs(id, stream=True, follow=True):
             logs += chunk
-
-        exitcode = self.client.wait(id)['StatusCode']
-        assert exitcode == 0
 
         assert logs == (snippet + '\n').encode(encoding='ascii')
 

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -27,7 +27,7 @@ class ContainerCollectionTest(unittest.TestCase):
         client.api.wait.assert_called_with(FAKE_CONTAINER_ID)
         client.api.logs.assert_called_with(
             FAKE_CONTAINER_ID, stderr=False, stdout=True, stream=True,
-            follow=True
+            follow=False
         )
 
     def test_create_container_args(self):


### PR DESCRIPTION
Since https://github.com/moby/moby/pull/37656 (because it fixes https://github.com/moby/moby/issues/37630), logs --follow do not send EOF once a container is stopped.

1. `test_logs_streaming_and_follow()` is modified to remove a container,
otherwise it will stuck forever waiting for more logs. As the container
is forcibly killed, the check for exit code is removed.

2. `ContainerCollection.run()` is modified to have `follow=False` for logs.
The `follow=True` that was there is probably from some ancient times
when it meant to read all the saved logs and then attach to container's
live stdout/stderr stream. This is not the case anymore.

Without this change, `test_run_with_json_file_driver()` is stuck forever.

NOTE these changes are backward-compatible, i.e. they do not require the
above mentioned PR to work; any (decent) version of docker engine is
fine.