### PR TITLE
Bump pyopenssl to prevent installation of vulnerable version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ idna==2.5
 ipaddress==1.0.18
 packaging==16.8
 pycparser==2.17
-pyOpenSSL==17.0.0
+pyOpenSSL==18.0.0
 pyparsing==2.2.0
 pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
 pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require = {
     # https://github.com/pypa/pip/issues/4391).  Once that's fixed, instead of
     # installing the extra dependencies, install the following instead:
     # 'requests[security] >= 2.5.2, != 2.11.0, != 2.12.2'
-    'tls': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
+    'tls': ['pyOpenSSL>=17.5.0', 'cryptography>=1.3.4', 'idna>=2.0.0'],
 
 }
 


### PR DESCRIPTION
CVE refs:
- CVE-2018-1000807
- CVE-2018-1000808
