### PR TITLE
tests: fix failure due to pytest deprecation

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ mock==1.0.1
 pytest==2.9.1; python_version == '3.3'
 pytest==3.6.3; python_version > '3.3'
 pytest-cov==2.1.0
-pytest-timeout==1.2.1
+pytest-timeout==1.3.3


### PR DESCRIPTION
tests are failing due to a fixture being deprecated in pytest. For instance: https://travis-ci.org/docker/docker-py/jobs/458206472

```
_________________ FindConfigFileTest.test_find_config_fallback _________________
tests/unit/utils_config_test.py:24: in test_find_config_fallback
    tmpdir = self.tmpdir('test_find_config_fallback')
tests/unit/utils_config_test.py:19: in tmpdir
    tmpdir = ensuretemp(name)
.tox/py27/lib/python2.7/site-packages/_pytest/tmpdir.py:96: in ensuretemp
    warnings.warn(PYTEST_ENSURETEMP, stacklevel=2)
E   RemovedInPytest4Warning: pytest/tmpdir_factory.ensuretemp is deprecated, 
E   please use the tmp_path fixture or tmp_path_factory.mktemp
```