### PR TITLE
Log everything onto a single logger

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -9,7 +9,7 @@ from .. import errors
 from .. import utils
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('docker-py')
 
 
 class BuildApiMixin(object):

--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -6,7 +6,7 @@ import six
 from .. import auth, errors, utils
 from ..constants import DEFAULT_DATA_CHUNK_SIZE
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('docker-py')
 
 
 class ImageApiMixin(object):

--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -5,7 +5,7 @@ from .. import errors
 from .. import types
 from .. import utils
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('docker-py')
 
 
 class SwarmApiMixin(object):

--- a/docker/auth.py
+++ b/docker/auth.py
@@ -12,7 +12,7 @@ INDEX_NAME = 'docker.io'
 INDEX_URL = 'https://index.{0}/v1/'.format(INDEX_NAME)
 TOKEN_USERNAME = '<token>'
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('docker-py')
 
 
 def resolve_repository_name(repo_name):

--- a/docker/utils/config.py
+++ b/docker/utils/config.py
@@ -7,7 +7,7 @@ from ..constants import IS_WINDOWS_PLATFORM
 DOCKER_CONFIG_FILENAME = os.path.join('.docker', 'config.json')
 LEGACY_DOCKER_CONFIG_FILENAME = '.dockercfg'
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('docker-py')
 
 
 def find_config_file(config_path=None):


### PR DESCRIPTION
This is to ease configuration of the logger in the applications code
that use the library.  So instead of having to configure all the loggers
corresponding to various `__name__`s, it is enough to configure just one,
named `docker-py`.