### PR TITLE
Correctly handle longpath prefix in process_dockerfile when joining paths

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -339,7 +339,14 @@ def process_dockerfile(dockerfile, path):
     abs_dockerfile = dockerfile
     if not os.path.isabs(dockerfile):
         abs_dockerfile = os.path.join(path, dockerfile)
-
+        if constants.IS_WINDOWS_PLATFORM and path.startswith(
+                constants.WINDOWS_LONGPATH_PREFIX):
+            abs_dockerfile = '{}{}'.format(
+                constants.WINDOWS_LONGPATH_PREFIX,
+                os.path.normpath(
+                    abs_dockerfile[len(constants.WINDOWS_LONGPATH_PREFIX):]
+                )
+            )
     if (os.path.splitdrive(path)[0] != os.path.splitdrive(abs_dockerfile)[0] or
             os.path.relpath(abs_dockerfile, path).startswith('..')):
         # Dockerfile not in context - read data to insert into tar later

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -14,6 +14,7 @@ INSECURE_REGISTRY_DEPRECATION_WARNING = \
     'is deprecated and non-functional. Please remove it.'
 
 IS_WINDOWS_PLATFORM = (sys.platform == 'win32')
+WINDOWS_LONGPATH_PREFIX = '\\\\?\\'
 
 DEFAULT_USER_AGENT = "docker-sdk-python/{0}".format(version)
 DEFAULT_NUM_POOLS = 25


### PR DESCRIPTION
Bug originally reported in docker/compose#6356