### PR TITLE
3.6.0 release

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -339,7 +339,14 @@ def process_dockerfile(dockerfile, path):
     abs_dockerfile = dockerfile
     if not os.path.isabs(dockerfile):
         abs_dockerfile = os.path.join(path, dockerfile)
-
+        if constants.IS_WINDOWS_PLATFORM and path.startswith(
+                constants.WINDOWS_LONGPATH_PREFIX):
+            abs_dockerfile = '{}{}'.format(
+                constants.WINDOWS_LONGPATH_PREFIX,
+                os.path.normpath(
+                    abs_dockerfile[len(constants.WINDOWS_LONGPATH_PREFIX):]
+                )
+            )
     if (os.path.splitdrive(path)[0] != os.path.splitdrive(abs_dockerfile)[0] or
             os.path.relpath(abs_dockerfile, path).startswith('..')):
         # Dockerfile not in context - read data to insert into tar later

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -694,6 +694,18 @@ class ContainerApiMixin(object):
         Raises:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
+
+        Example:
+
+            >>> c = docker.APIClient()
+            >>> f = open('./sh_bin.tar', 'wb')
+            >>> bits, stat = c.get_archive(container, '/bin/sh')
+            >>> print(stat)
+            {'name': 'sh', 'size': 1075464, 'mode': 493,
+             'mtime': '2018-10-01T15:37:48-07:00', 'linkTarget': ''}
+            >>> for chunk in bits:
+            ...    f.write(chunk)
+            >>> f.close()
         """
         params = {
             'path': path

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -476,13 +476,7 @@ class ContainerApiMixin(object):
             isolation (str): Isolation technology to use. Default: `None`.
             links (dict or list of tuples): Either a dictionary mapping name
                 to alias or as a list of ``(name, alias)`` tuples.
-            log_config (dict): Logging configuration, as a dictionary with
-                keys:
-
-                - ``type`` The logging driver name.
-                - ``config`` A dictionary of configuration for the logging
-                  driver.
-
+            log_config (LogConfig): Logging configuration
             lxc_conf (dict): LXC config.
             mem_limit (float or str): Memory limit. Accepts float values
                 (which represent the memory limit of the created container in

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -473,9 +473,11 @@ class ContainerApiMixin(object):
                 signals and reaps processes
             init_path (str): Path to the docker-init binary
             ipc_mode (str): Set the IPC mode for the container.
-            isolation (str): Isolation technology to use. Default: `None`.
-            links (dict or list of tuples): Either a dictionary mapping name
-                to alias or as a list of ``(name, alias)`` tuples.
+            isolation (str): Isolation technology to use. Default: ``None``.
+            links (dict): Mapping of links using the
+                ``{'container': 'alias'}`` format. The alias is optional.
+                Containers declared in this dict will be linked to the new
+                container using the provided alias. Default: ``None``.
             log_config (LogConfig): Logging configuration
             lxc_conf (dict): LXC config.
             mem_limit (float or str): Memory limit. Accepts float values
@@ -605,9 +607,10 @@ class ContainerApiMixin(object):
             aliases (:py:class:`list`): A list of aliases for this endpoint.
                 Names in that list can be used within the network to reach the
                 container. Defaults to ``None``.
-            links (:py:class:`list`): A list of links for this endpoint.
-                Containers declared in this list will be linked to this
-                container. Defaults to ``None``.
+            links (dict): Mapping of links for this endpoint using the
+                ``{'container': 'alias'}`` format. The alias is optional.
+                Containers declared in this dict will be linked to this
+                container using the provided alias. Defaults to ``None``.
             ipv4_address (str): The IP address of this container on the
                 network, using the IPv4 protocol. Defaults to ``None``.
             ipv6_address (str): The IP address of this container on the
@@ -622,7 +625,7 @@ class ContainerApiMixin(object):
 
             >>> endpoint_config = client.create_endpoint_config(
                 aliases=['web', 'app'],
-                links=['app_db'],
+                links={'app_db': 'db', 'another': None},
                 ipv4_address='132.65.0.123'
             )
 

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -543,7 +543,7 @@ class ContainerApiMixin(object):
                     }
 
             ulimits (:py:class:`list`): Ulimits to set inside the container,
-                as a list of dicts.
+                as a list of :py:class:`docker.types.Ulimit` instances.
             userns_mode (str): Sets the user namespace mode for the container
                 when user namespace remapping option is enabled. Supported
                 values are: ``host``

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1071,7 +1071,8 @@ class ContainerApiMixin(object):
         Args:
             container (str): The container to stream statistics from
             decode (bool): If set to true, stream will be decoded into dicts
-                on the fly. False by default.
+                on the fly. Only applicable if ``stream`` is True.
+                False by default.
             stream (bool): If set to false, only the current stats will be
                 returned instead of a stream. True by default.
 
@@ -1085,6 +1086,10 @@ class ContainerApiMixin(object):
             return self._stream_helper(self._get(url, stream=True),
                                        decode=decode)
         else:
+            if decode:
+                raise errors.InvalidArgument(
+                    "decode is only available in conjuction with stream=True"
+                )
             return self._result(self._get(url, params={'stream': False}),
                                 json=True)
 

--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -32,7 +32,7 @@ class ImageApiMixin(object):
         Example:
 
             >>> image = cli.get_image("busybox:latest")
-            >>> f = open('/tmp/busybox-latest.tar', 'w')
+            >>> f = open('/tmp/busybox-latest.tar', 'wb')
             >>> for chunk in image:
             >>>   f.write(chunk)
             >>> f.close()

--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -334,7 +334,8 @@ class ImageApiMixin(object):
         Args:
             repository (str): The repository to pull
             tag (str): The tag to pull
-            stream (bool): Stream the output as a generator
+            stream (bool): Stream the output as a generator. Make sure to
+                consume the generator, otherwise pull might get cancelled.
             auth_config (dict): Override the credentials that
                 :py:meth:`~docker.api.daemon.DaemonApiMixin.login` has set for
                 this request. ``auth_config`` should contain the ``username``

--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -197,7 +197,8 @@ class ServiceApiMixin(object):
                 into the service inspect output.
 
         Returns:
-            ``True`` if successful.
+            (dict): A dictionary of the server-side representation of the
+                service, including all relevant properties.
 
         Raises:
             :py:class:`docker.errors.APIError`

--- a/docker/auth.py
+++ b/docker/auth.py
@@ -267,7 +267,7 @@ def load_config(config_path=None, config_dict=None):
         return res
 
     log.debug(
-        "Couldn't find auth-related section ; attempting to interpret"
+        "Couldn't find auth-related section ; attempting to interpret "
         "as auth-only file"
     )
     return {'auths': parse_auth(config_dict)}

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -14,6 +14,7 @@ INSECURE_REGISTRY_DEPRECATION_WARNING = \
     'is deprecated and non-functional. Please remove it.'
 
 IS_WINDOWS_PLATFORM = (sys.platform == 'win32')
+WINDOWS_LONGPATH_PREFIX = '\\\\?\\'
 
 DEFAULT_USER_AGENT = "docker-sdk-python/{0}".format(version)
 DEFAULT_NUM_POOLS = 25

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -574,8 +574,10 @@ class ContainerCollection(Collection):
                 ``{"label1": "value1", "label2": "value2"}``) or a list of
                 names of labels to set with empty values (e.g.
                 ``["label1", "label2"]``)
-            links (dict or list of tuples): Either a dictionary mapping name
-                to alias or as a list of ``(name, alias)`` tuples.
+            links (dict): Mapping of links using the
+                ``{'container': 'alias'}`` format. The alias is optional.
+                Containers declared in this dict will be linked to the new
+                container using the provided alias. Default: ``None``.
             log_config (LogConfig): Logging configuration.
             mac_address (str): MAC address to assign to the container.
             mem_limit (int or str): Memory limit. Accepts float values

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -576,13 +576,7 @@ class ContainerCollection(Collection):
                 ``["label1", "label2"]``)
             links (dict or list of tuples): Either a dictionary mapping name
                 to alias or as a list of ``(name, alias)`` tuples.
-            log_config (dict): Logging configuration, as a dictionary with
-                keys:
-
-                - ``type`` The logging driver name.
-                - ``config`` A dictionary of configuration for the logging
-                  driver.
-
+            log_config (LogConfig): Logging configuration.
             mac_address (str): MAC address to assign to the container.
             mem_limit (int or str): Memory limit. Accepts float values
                 (which represent the memory limit of the created container in

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -233,6 +233,17 @@ class Container(Model):
         Raises:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
+
+        Example:
+
+            >>> f = open('./sh_bin.tar', 'wb')
+            >>> bits, stat = container.get_archive('/bin/sh')
+            >>> print(stat)
+            {'name': 'sh', 'size': 1075464, 'mode': 493,
+             'mtime': '2018-10-01T15:37:48-07:00', 'linkTarget': ''}
+            >>> for chunk in bits:
+            ...    f.write(chunk)
+            >>> f.close()
         """
         return self.client.api.get_archive(self.id, path, chunk_size)
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -385,7 +385,8 @@ class Container(Model):
 
         Args:
             decode (bool): If set to true, stream will be decoded into dicts
-                on the fly. False by default.
+                on the fly. Only applicable if ``stream`` is True.
+                False by default.
             stream (bool): If set to false, only the current stats will be
                 returned instead of a stream. True by default.
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -691,8 +691,8 @@ class ContainerCollection(Collection):
                     }
 
             tty (bool): Allocate a pseudo-TTY.
-            ulimits (:py:class:`list`): Ulimits to set inside the container, as
-                a list of dicts.
+            ulimits (:py:class:`list`): Ulimits to set inside the container,
+                as a list of :py:class:`docker.types.Ulimit` instances.
             user (str or int): Username or UID to run commands as inside the
                 container.
             userns_mode (str): Sets the user namespace mode for the container

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -15,7 +15,12 @@ from .resource import Collection, Model
 
 
 class Container(Model):
-
+    """ Local representation of a container object. Detailed configuration may
+        be accessed through the :py:attr:`attrs` attribute. Note that local
+        attributes are cached; users may call :py:meth:`reload` to
+        query the Docker daemon for the current properties, causing
+        :py:attr:`attrs` to be refreshed.
+    """
     @property
     def name(self):
         """

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -425,6 +425,7 @@ class ImageCollection(Collection):
         if not tag:
             repository, tag = parse_repository_tag(repository)
 
+        kwargs['stream'] = False
         self.client.api.pull(repository, tag=tag, **kwargs)
         if tag:
             return self.get('{0}{2}{1}'.format(

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -59,7 +59,7 @@ class Image(Model):
         """
         return self.client.api.history(self.id)
 
-    def save(self, chunk_size=DEFAULT_DATA_CHUNK_SIZE):
+    def save(self, chunk_size=DEFAULT_DATA_CHUNK_SIZE, named=False):
         """
         Get a tarball of an image. Similar to the ``docker save`` command.
 
@@ -67,6 +67,12 @@ class Image(Model):
             chunk_size (int): The generator will return up to that much data
                 per iteration, but may return less. If ``None``, data will be
                 streamed as it is received. Default: 2 MB
+            named (str or bool): If ``False`` (default), the tarball will not
+                retain repository and tag information for this image. If set
+                to ``True``, the first tag in the :py:attr:`~tags` list will
+                be used to identify the image. Alternatively, any element of
+                the :py:attr:`~tags` list can be used as an argument to use
+                that specific tag as the saved identifier.
 
         Returns:
             (generator): A stream of raw archive data.
@@ -83,7 +89,17 @@ class Image(Model):
             >>>   f.write(chunk)
             >>> f.close()
         """
-        return self.client.api.get_image(self.id, chunk_size)
+        img = self.id
+        if named:
+            img = self.tags[0] if self.tags else img
+            if isinstance(named, six.string_types):
+                if named not in self.tags:
+                    raise InvalidArgument(
+                        "{} is not a valid tag for this image".format(named)
+                    )
+                img = named
+
+        return self.client.api.get_image(img, chunk_size)
 
     def tag(self, repository, tag=None, **kwargs):
         """

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -1,5 +1,6 @@
 import itertools
 import re
+import warnings
 
 import six
 
@@ -425,8 +426,21 @@ class ImageCollection(Collection):
         if not tag:
             repository, tag = parse_repository_tag(repository)
 
-        kwargs['stream'] = False
-        self.client.api.pull(repository, tag=tag, **kwargs)
+        if 'stream' in kwargs:
+            warnings.warn(
+                '`stream` is not a valid parameter for this method'
+                ' and will be overridden'
+            )
+            del kwargs['stream']
+
+        pull_log = self.client.api.pull(
+            repository, tag=tag, stream=True, **kwargs
+        )
+        for _ in pull_log:
+            # We don't do anything with the logs, but we need
+            # to keep the connection alive and wait for the image
+            # to be pulled.
+            pass
         if tag:
             return self.get('{0}{2}{1}'.format(
                 repository, tag, '@' if tag.startswith('sha256:') else ':'

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -84,7 +84,7 @@ class Image(Model):
         Example:
 
             >>> image = cli.get_image("busybox:latest")
-            >>> f = open('/tmp/busybox-latest.tar', 'w')
+            >>> f = open('/tmp/busybox-latest.tar', 'wb')
             >>> for chunk in image:
             >>>   f.write(chunk)
             >>> f.close()

--- a/docker/transport/__init__.py
+++ b/docker/transport/__init__.py
@@ -6,3 +6,8 @@ try:
     from .npipesocket import NpipeSocket
 except ImportError:
     pass
+
+try:
+    from .sshconn import SSHAdapter
+except ImportError:
+    pass

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -87,10 +87,6 @@ class NpipeSocket(object):
     def dup(self):
         return NpipeSocket(self._handle)
 
-    @check_closed
-    def fileno(self):
-        return int(self._handle)
-
     def getpeername(self):
         return self._address
 

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -1,9 +1,6 @@
-import urllib.parse
-
 import paramiko
 import requests.adapters
 import six
-
 
 from .. import constants
 
@@ -82,7 +79,7 @@ class SSHAdapter(requests.adapters.HTTPAdapter):
         self.ssh_client = paramiko.SSHClient()
         self.ssh_client.load_system_host_keys()
 
-        parsed = urllib.parse.urlparse(base_url)
+        parsed = six.moves.urllib_parse.urlparse(base_url)
         self.ssh_client.connect(
             parsed.hostname, parsed.port, parsed.username,
         )

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -1,0 +1,110 @@
+import urllib.parse
+
+import paramiko
+import requests.adapters
+import six
+
+
+from .. import constants
+
+if six.PY3:
+    import http.client as httplib
+else:
+    import httplib
+
+try:
+    import requests.packages.urllib3 as urllib3
+except ImportError:
+    import urllib3
+
+RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
+
+
+class SSHConnection(httplib.HTTPConnection, object):
+    def __init__(self, ssh_transport, timeout=60):
+        super(SSHConnection, self).__init__(
+            'localhost', timeout=timeout
+        )
+        self.ssh_transport = ssh_transport
+        self.timeout = timeout
+
+    def connect(self):
+        sock = self.ssh_transport.open_session()
+        sock.settimeout(self.timeout)
+        sock.exec_command('docker system dial-stdio')
+        self.sock = sock
+
+
+class SSHConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
+    scheme = 'ssh'
+
+    def __init__(self, ssh_client, timeout=60, maxsize=10):
+        super(SSHConnectionPool, self).__init__(
+            'localhost', timeout=timeout, maxsize=maxsize
+        )
+        self.ssh_transport = ssh_client.get_transport()
+        self.timeout = timeout
+
+    def _new_conn(self):
+        return SSHConnection(self.ssh_transport, self.timeout)
+
+    # When re-using connections, urllib3 calls fileno() on our
+    # SSH channel instance, quickly overloading our fd limit. To avoid this,
+    # we override _get_conn
+    def _get_conn(self, timeout):
+        conn = None
+        try:
+            conn = self.pool.get(block=self.block, timeout=timeout)
+
+        except AttributeError:  # self.pool is None
+            raise urllib3.exceptions.ClosedPoolError(self, "Pool is closed.")
+
+        except six.moves.queue.Empty:
+            if self.block:
+                raise urllib3.exceptions.EmptyPoolError(
+                    self,
+                    "Pool reached maximum size and no more "
+                    "connections are allowed."
+                )
+            pass  # Oh well, we'll create a new connection then
+
+        return conn or self._new_conn()
+
+
+class SSHAdapter(requests.adapters.HTTPAdapter):
+
+    __attrs__ = requests.adapters.HTTPAdapter.__attrs__ + [
+        'pools', 'timeout', 'ssh_client',
+    ]
+
+    def __init__(self, base_url, timeout=60,
+                 pool_connections=constants.DEFAULT_NUM_POOLS):
+        self.ssh_client = paramiko.SSHClient()
+        self.ssh_client.load_system_host_keys()
+
+        parsed = urllib.parse.urlparse(base_url)
+        self.ssh_client.connect(
+            parsed.hostname, parsed.port, parsed.username,
+        )
+        self.timeout = timeout
+        self.pools = RecentlyUsedContainer(
+            pool_connections, dispose_func=lambda p: p.close()
+        )
+        super(SSHAdapter, self).__init__()
+
+    def get_connection(self, url, proxies=None):
+        with self.pools.lock:
+            pool = self.pools.get(url)
+            if pool:
+                return pool
+
+            pool = SSHConnectionPool(
+                self.ssh_client, self.timeout
+            )
+            self.pools[url] = pool
+
+        return pool
+
+    def close(self):
+        self.pools.clear()
+        self.ssh_client.close()

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -58,6 +58,23 @@ class LogConfig(DictType):
 
 
 class Ulimit(DictType):
+    """
+    Create a ulimit declaration to be used with
+    :py:meth:`~docker.api.container.ContainerApiMixin.create_host_config`.
+
+    Args:
+
+        name (str): Which ulimit will this apply to. A list of valid names can
+            be found `here <http://tinyurl.me/ZWRkM2Ztwlykf>`_.
+        soft (int): The soft limit for this ulimit. Optional.
+        hard (int): The hard limit for this ulimit. Optional.
+
+    Example:
+
+        nproc_limit = docker.types.Ulimit(name='nproc', soft=1024)
+        hc = client.create_host_config(ulimits=[nproc_limit])
+        container = client.create_container('busybox', 'true', host_config=hc)
+    """
     def __init__(self, **kwargs):
         name = kwargs.get('name', kwargs.get('Name'))
         soft = kwargs.get('soft', kwargs.get('Soft'))

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -23,6 +23,36 @@ class LogConfigTypesEnum(object):
 
 
 class LogConfig(DictType):
+    """
+    Configure logging for a container, when provided as an argument to
+    :py:meth:`~docker.api.container.ContainerApiMixin.create_host_config`.
+    You may refer to the
+    `official logging driver documentation <https://docs.docker.com/config/containers/logging/configure/>`_
+    for more information.
+
+    Args:
+        type (str): Indicate which log driver to use. A set of valid drivers
+            is provided as part of the :py:attr:`LogConfig.types`
+            enum. Other values may be accepted depending on the engine version
+            and available logging plugins.
+        config (dict): A driver-dependent configuration dictionary. Please
+            refer to the driver's documentation for a list of valid config
+            keys.
+
+    Example:
+
+        >>> from docker.types import LogConfig
+        >>> lc = LogConfig(type=LogConfig.types.JSON, config={
+        ...   'max-size': '1g',
+        ...   'labels': 'production_status,geo'
+        ... })
+        >>> hc = client.create_host_config(log_config=lc)
+        >>> container = client.create_container('busybox', 'true',
+        ...    host_config=hc)
+        >>> client.inspect_container(container)['HostConfig']['LogConfig']
+        {'Type': 'json-file', 'Config': {'labels': 'production_status,geo', 'max-size': '1g'}}
+
+    """ # flake8: noqa
     types = LogConfigTypesEnum
 
     def __init__(self, **kwargs):
@@ -50,9 +80,13 @@ class LogConfig(DictType):
         return self['Config']
 
     def set_config_value(self, key, value):
+        """ Set a the value for ``key`` to ``value`` inside the ``config``
+            dict.
+        """
         self.config[key] = value
 
     def unset_config(self, key):
+        """ Remove the ``key`` property from the ``config`` dict. """
         if key in self.config:
             del self.config[key]
 
@@ -71,9 +105,14 @@ class Ulimit(DictType):
 
     Example:
 
-        nproc_limit = docker.types.Ulimit(name='nproc', soft=1024)
-        hc = client.create_host_config(ulimits=[nproc_limit])
-        container = client.create_container('busybox', 'true', host_config=hc)
+        >>> nproc_limit = docker.types.Ulimit(name='nproc', soft=1024)
+        >>> hc = client.create_host_config(ulimits=[nproc_limit])
+        >>> container = client.create_container(
+                'busybox', 'true', host_config=hc
+            )
+        >>> client.inspect_container(container)['HostConfig']['Ulimits']
+        [{'Name': 'nproc', 'Hard': 0, 'Soft': 1024}]
+
     """
     def __init__(self, **kwargs):
         name = kwargs.get('name', kwargs.get('Name'))

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -441,7 +441,7 @@ def normalize_links(links):
     if isinstance(links, dict):
         links = six.iteritems(links)
 
-    return ['{0}:{1}'.format(k, v) for k, v in sorted(links)]
+    return ['{0}:{1}'.format(k, v) if v else k for k, v in sorted(links)]
 
 
 def parse_env_file(env_file):

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -386,7 +386,10 @@ def convert_filters(filters):
             v = 'true' if v else 'false'
         if not isinstance(v, list):
             v = [v, ]
-        result[k] = v
+        result[k] = [
+            str(item) if not isinstance(item, six.string_types) else item
+            for item in v
+        ]
     return json.dumps(result)
 
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -1,10 +1,11 @@
 import base64
+import json
 import os
 import os.path
-import json
 import shlex
-from distutils.version import StrictVersion
+import string
 from datetime import datetime
+from distutils.version import StrictVersion
 
 import six
 
@@ -13,11 +14,12 @@ from .. import tls
 
 if six.PY2:
     from urllib import splitnport
+    from urlparse import urlparse
 else:
-    from urllib.parse import splitnport
+    from urllib.parse import splitnport, urlparse
 
 DEFAULT_HTTP_HOST = "127.0.0.1"
-DEFAULT_UNIX_SOCKET = "http+unix://var/run/docker.sock"
+DEFAULT_UNIX_SOCKET = "http+unix:///var/run/docker.sock"
 DEFAULT_NPIPE = 'npipe:////./pipe/docker_engine'
 
 BYTE_UNITS = {
@@ -212,81 +214,93 @@ def parse_repository_tag(repo_name):
     return repo_name, None
 
 
-# Based on utils.go:ParseHost http://tinyurl.com/nkahcfh
-# fd:// protocol unsupported (for obvious reasons)
-# Added support for http and https
-# Protocol translation: tcp -> http, unix -> http+unix
 def parse_host(addr, is_win32=False, tls=False):
-    proto = "http+unix"
-    port = None
     path = ''
+    port = None
+    host = None
 
+    # Sensible defaults
     if not addr and is_win32:
-        addr = DEFAULT_NPIPE
-
+        return DEFAULT_NPIPE
     if not addr or addr.strip() == 'unix://':
         return DEFAULT_UNIX_SOCKET
 
     addr = addr.strip()
-    if addr.startswith('http://'):
-        addr = addr.replace('http://', 'tcp://')
-    if addr.startswith('http+unix://'):
-        addr = addr.replace('http+unix://', 'unix://')
 
-    if addr == 'tcp://':
+    parsed_url = urlparse(addr)
+    proto = parsed_url.scheme
+    if not proto or any([x not in string.ascii_letters + '+' for x in proto]):
+        # https://bugs.python.org/issue754016
+        parsed_url = urlparse('//' + addr, 'tcp')
+        proto = 'tcp'
+
+    if proto == 'fd':
+        raise errors.DockerException('fd protocol is not implemented')
+
+    # These protos are valid aliases for our library but not for the
+    # official spec
+    if proto == 'http' or proto == 'https':
+        tls = proto == 'https'
+        proto = 'tcp'
+    elif proto == 'http+unix':
+        proto = 'unix'
+
+    if proto not in ('tcp', 'unix', 'npipe', 'ssh'):
         raise errors.DockerException(
-            "Invalid bind address format: {0}".format(addr)
+            "Invalid bind address protocol: {}".format(addr)
         )
-    elif addr.startswith('unix://'):
-        addr = addr[7:]
-    elif addr.startswith('tcp://'):
-        proto = 'http{0}'.format('s' if tls else '')
-        addr = addr[6:]
-    elif addr.startswith('https://'):
-        proto = "https"
-        addr = addr[8:]
-    elif addr.startswith('npipe://'):
-        proto = 'npipe'
-        addr = addr[8:]
-    elif addr.startswith('fd://'):
-        raise errors.DockerException("fd protocol is not implemented")
-    elif addr.startswith('ssh://'):
-        proto = 'ssh'
-        addr = addr[6:]
+
+    if proto == 'tcp' and not parsed_url.netloc:
+        # "tcp://" is exceptionally disallowed by convention;
+        # omitting a hostname for other protocols is fine
+        raise errors.DockerException(
+            'Invalid bind address format: {}'.format(addr)
+        )
+
+    if any([
+        parsed_url.params, parsed_url.query, parsed_url.fragment,
+        parsed_url.password
+    ]):
+        raise errors.DockerException(
+            'Invalid bind address format: {}'.format(addr)
+        )
+
+    if parsed_url.path and proto == 'ssh':
+        raise errors.DockerException(
+            'Invalid bind address format: no path allowed for this protocol:'
+            ' {}'.format(addr)
+        )
     else:
-        if "://" in addr:
-            raise errors.DockerException(
-                "Invalid bind address protocol: {0}".format(addr)
-            )
-        proto = "https" if tls else "http"
+        path = parsed_url.path
+        if proto == 'unix' and parsed_url.hostname is not None:
+            # For legacy reasons, we consider unix://path
+            # to be valid and equivalent to unix:///path
+            path = '/'.join((parsed_url.hostname, path))
 
-    if proto in ("http", "https", "ssh"):
-        address_parts = addr.split('/', 1)
-        host = address_parts[0]
-        if len(address_parts) == 2:
-            path = '/' + address_parts[1]
-        host, port = splitnport(host)
-
+    if proto in ('tcp', 'ssh'):
+        # parsed_url.hostname strips brackets from IPv6 addresses,
+        # which can be problematic hence our use of splitnport() instead.
+        host, port = splitnport(parsed_url.netloc)
         if port is None or port < 0:
-            if proto == 'ssh':
-                port = 22
-            else:
+            if proto != 'ssh':
                 raise errors.DockerException(
-                    "Invalid port: {0}".format(addr)
+                    'Invalid bind address format: port is required:'
+                    ' {}'.format(addr)
                 )
+            port = 22
 
         if not host:
             host = DEFAULT_HTTP_HOST
-    else:
-        host = addr
 
-    if proto in ("http", "https") and port == -1:
-        raise errors.DockerException(
-            "Bind address needs a port: {0}".format(addr))
+    # Rewrite schemes to fit library internals (requests adapters)
+    if proto == 'tcp':
+        proto = 'http{}'.format('s' if tls else '')
+    elif proto == 'unix':
+        proto = 'http+unix'
 
-    if proto == "http+unix" or proto == 'npipe':
-        return "{0}://{1}".format(proto, host).rstrip('/')
-    return "{0}://{1}:{2}{3}".format(proto, host, port, path).rstrip('/')
+    if proto in ('http+unix', 'npipe'):
+        return "{}://{}".format(proto, path).rstrip('/')
+    return '{0}://{1}:{2}{3}'.format(proto, host, port, path).rstrip('/')
 
 
 def parse_devices(devices):

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "3.5.1"
+version = "3.6.0"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -140,6 +140,7 @@ Configuration types
 .. autoclass:: Healthcheck
 .. autoclass:: IPAMConfig
 .. autoclass:: IPAMPool
+.. autoclass:: LogConfig
 .. autoclass:: Mount
 .. autoclass:: Placement
 .. autoclass:: Privileges

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -151,4 +151,5 @@ Configuration types
 .. autoclass:: SwarmExternalCA
 .. autoclass:: SwarmSpec(*args, **kwargs)
 .. autoclass:: TaskTemplate
+.. autoclass:: Ulimit
 .. autoclass:: UpdateConfig

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,31 @@
 Change log
 ==========
 
+3.6.0
+-----
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone=55?closed=1)
+
+### Features
+
+* Added support for connecting to the Docker Engine over SSH. Additional
+  dependencies for this feature can be installed with
+  `pip install "docker[ssh]"`
+* Added support for the `named` parameter in `Image.save`, which may be
+  used to ensure the resulting tarball retains the image's name on save.
+
+### Bugfixes
+
+* Fixed a bug where builds on Windows with a context path using the `\\?\`
+  prefix would fail with some relative Dockerfile paths.
+* Fixed an issue where pulls made with the `DockerClient` would fail when
+  setting the `stream` parameter to `True`.
+
+### Miscellaneous
+
+* The minimum requirement for the `requests` dependency has been bumped
+  to 2.20.0
+
 3.5.1
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ enum34==1.1.6
 idna==2.5
 ipaddress==1.0.18
 packaging==16.8
+paramiko==2.4.2
 pycparser==2.17
 pyOpenSSL==18.0.0
 pyparsing==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pyOpenSSL==18.0.0
 pyparsing==2.2.0
 pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
 pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'
-requests==2.14.2
+requests==2.20.0
 six==1.10.0
 websocket-client==0.40.0
 urllib3==1.21.1; python_version == '3.3'

--- a/scripts/versions.py
+++ b/scripts/versions.py
@@ -66,7 +66,7 @@ def main():
             Version.parse(
                 v.strip('"').lstrip('docker-').rstrip('.tgz').rstrip('-x86_64')
             ) for v in re.findall(
-                r'"docker-[0-9]+\.[0-9]+\.[0-9]+-.*tgz"', content
+                r'"docker-[0-9]+\.[0-9]+\.[0-9]+-?.*tgz"', content
             )
         ]
         sorted_versions = sorted(

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ extras_require = {
     # 'requests[security] >= 2.5.2, != 2.11.0, != 2.12.2'
     'tls': ['pyOpenSSL>=17.5.0', 'cryptography>=1.3.4', 'idna>=2.0.0'],
 
+    # Only required when connecting using the ssh:// protocol
+    'ssh': ['paramiko>=2.4.2'],
+
 }
 
 version = None

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ mock==1.0.1
 pytest==2.9.1; python_version == '3.3'
 pytest==3.6.3; python_version > '3.3'
 pytest-cov==2.1.0
-pytest-timeout==1.2.1
+pytest-timeout==1.3.3

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,6 +10,7 @@ import six
 import socket
 
 import docker
+import paramiko
 import pytest
 
 
@@ -120,6 +121,9 @@ def assert_cat_socket_detached_with_keys(sock, inputs):
     # but will not raise an error
     if getattr(sock, 'family', -9) == getattr(socket, 'AF_UNIX', -1):
         with pytest.raises(socket.error):
+            sock.sendall(b'make sure the socket is closed\n')
+    elif isinstance(sock, paramiko.Channel):
+        with pytest.raises(OSError):
             sock.sendall(b'make sure the socket is closed\n')
     else:
         sock.sendall(b"make sure the socket is closed\n")

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -540,6 +540,11 @@ class BuildTest(BaseAPIIntegrationTest):
         ) == sorted(lsdata)
 
     @requires_api_version('1.31')
+    @pytest.mark.xfail(
+        True,
+        reason='Currently fails on 18.09: '
+               'https://github.com/moby/moby/issues/37920'
+    )
     def test_prune_builds(self):
         prune_result = self.client.prune_builds()
         assert 'SpaceReclaimed' in prune_result

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1255,6 +1255,7 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         assert output == 'hello\n'.encode(encoding='ascii')
 
     @pytest.mark.timeout(5)
+    @pytest.mark.xfail(True, reason='Cancellable events broken over SSH')
     def test_attach_stream_and_cancel(self):
         container = self.client.create_container(
             BUSYBOX, 'sh -c "echo hello && sleep 60"',

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -883,6 +883,8 @@ Line2'''
         assert logs == (snippet + '\n').encode(encoding='ascii')
 
     @pytest.mark.timeout(5)
+    @pytest.mark.skipif(os.environ.get('DOCKER_HOST', '').startswith('ssh://'),
+                        reason='No cancellable streams over SSH')
     def test_logs_streaming_and_follow_and_cancel(self):
         snippet = 'Flowering Nights (Sakuya Iyazoi)'
         container = self.client.create_container(
@@ -1255,7 +1257,8 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         assert output == 'hello\n'.encode(encoding='ascii')
 
     @pytest.mark.timeout(5)
-    @pytest.mark.xfail(True, reason='Cancellable events broken over SSH')
+    @pytest.mark.skipif(os.environ.get('DOCKER_HOST', '').startswith('ssh://'),
+                        reason='No cancellable streams over SSH')
     def test_attach_stream_and_cancel(self):
         container = self.client.create_container(
             BUSYBOX, 'sh -c "echo hello && sleep 60"',

--- a/tests/integration/api_network_test.py
+++ b/tests/integration/api_network_test.py
@@ -8,8 +8,8 @@ from .base import BaseAPIIntegrationTest, BUSYBOX
 
 class TestNetworks(BaseAPIIntegrationTest):
     def tearDown(self):
-        super(TestNetworks, self).tearDown()
         self.client.leave_swarm(force=True)
+        super(TestNetworks, self).tearDown()
 
     def create_network(self, *args, **kwargs):
         net_name = random_name()

--- a/tests/integration/api_plugin_test.py
+++ b/tests/integration/api_plugin_test.py
@@ -3,7 +3,7 @@ import os
 import docker
 import pytest
 
-from .base import BaseAPIIntegrationTest, TEST_API_VERSION
+from .base import BaseAPIIntegrationTest
 from ..helpers import requires_api_version
 
 SSHFS = 'vieux/sshfs:latest'
@@ -13,26 +13,26 @@ SSHFS = 'vieux/sshfs:latest'
 class PluginTest(BaseAPIIntegrationTest):
     @classmethod
     def teardown_class(cls):
-        c = docker.APIClient(
-            version=TEST_API_VERSION, timeout=60,
-            **docker.utils.kwargs_from_env()
-        )
+        client = cls.get_client_instance()
         try:
-            c.remove_plugin(SSHFS, force=True)
+            client.remove_plugin(SSHFS, force=True)
         except docker.errors.APIError:
             pass
 
     def teardown_method(self, method):
+        client = self.get_client_instance()
         try:
-            self.client.disable_plugin(SSHFS)
+            client.disable_plugin(SSHFS)
         except docker.errors.APIError:
             pass
 
         for p in self.tmp_plugins:
             try:
-                self.client.remove_plugin(p, force=True)
+                client.remove_plugin(p, force=True)
             except docker.errors.APIError:
                 pass
+
+        client.close()
 
     def ensure_plugin_installed(self, plugin_name):
         try:

--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -13,14 +13,13 @@ class SwarmTest(BaseAPIIntegrationTest):
         self._unlock_key = None
 
     def tearDown(self):
-        super(SwarmTest, self).tearDown()
         try:
             if self._unlock_key:
                 self.client.unlock_swarm(self._unlock_key)
         except docker.errors.APIError:
             pass
-
         force_leave_swarm(self.client)
+        super(SwarmTest, self).tearDown()
 
     @requires_api_version('1.24')
     def test_init_swarm_simple(self):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -29,41 +29,44 @@ class BaseIntegrationTest(unittest.TestCase):
 
     def tearDown(self):
         client = docker.from_env(version=TEST_API_VERSION)
-        for img in self.tmp_imgs:
-            try:
-                client.api.remove_image(img)
-            except docker.errors.APIError:
-                pass
-        for container in self.tmp_containers:
-            try:
-                client.api.remove_container(container, force=True, v=True)
-            except docker.errors.APIError:
-                pass
-        for network in self.tmp_networks:
-            try:
-                client.api.remove_network(network)
-            except docker.errors.APIError:
-                pass
-        for volume in self.tmp_volumes:
-            try:
-                client.api.remove_volume(volume)
-            except docker.errors.APIError:
-                pass
+        try:
+            for img in self.tmp_imgs:
+                try:
+                    client.api.remove_image(img)
+                except docker.errors.APIError:
+                    pass
+            for container in self.tmp_containers:
+                try:
+                    client.api.remove_container(container, force=True, v=True)
+                except docker.errors.APIError:
+                    pass
+            for network in self.tmp_networks:
+                try:
+                    client.api.remove_network(network)
+                except docker.errors.APIError:
+                    pass
+            for volume in self.tmp_volumes:
+                try:
+                    client.api.remove_volume(volume)
+                except docker.errors.APIError:
+                    pass
 
-        for secret in self.tmp_secrets:
-            try:
-                client.api.remove_secret(secret)
-            except docker.errors.APIError:
-                pass
+            for secret in self.tmp_secrets:
+                try:
+                    client.api.remove_secret(secret)
+                except docker.errors.APIError:
+                    pass
 
-        for config in self.tmp_configs:
-            try:
-                client.api.remove_config(config)
-            except docker.errors.APIError:
-                pass
+            for config in self.tmp_configs:
+                try:
+                    client.api.remove_config(config)
+                except docker.errors.APIError:
+                    pass
 
-        for folder in self.tmp_folders:
-            shutil.rmtree(folder)
+            for folder in self.tmp_folders:
+                shutil.rmtree(folder)
+        finally:
+            client.close()
 
 
 class BaseAPIIntegrationTest(BaseIntegrationTest):

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import threading
 
@@ -146,6 +147,8 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert logs[1] == b'world\n'
 
     @pytest.mark.timeout(5)
+    @pytest.mark.skipif(os.environ.get('DOCKER_HOST', '').startswith('ssh://'),
+                        reason='No cancellable streams over SSH')
     def test_run_with_streamed_logs_and_cancel(self):
         client = docker.from_env(version=TEST_API_VERSION)
         out = client.containers.run(

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -232,8 +232,9 @@ class ContainerCollectionTest(unittest.TestCase):
         container = client.containers.run('alpine', 'sleep 300', detach=True)
 
         assert container.id == FAKE_CONTAINER_ID
-        client.api.pull.assert_called_with('alpine', platform=None, tag=None,
-                                           stream=False)
+        client.api.pull.assert_called_with(
+            'alpine', platform=None, tag=None, stream=True
+        )
 
     def test_run_with_error(self):
         client = make_fake_client()

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -232,7 +232,8 @@ class ContainerCollectionTest(unittest.TestCase):
         container = client.containers.run('alpine', 'sleep 300', detach=True)
 
         assert container.id == FAKE_CONTAINER_ID
-        client.api.pull.assert_called_with('alpine', platform=None, tag=None)
+        client.api.pull.assert_called_with('alpine', platform=None, tag=None,
+                                           stream=False)
 
     def test_run_with_error(self):
         client = make_fake_client()

--- a/tests/unit/models_images_test.py
+++ b/tests/unit/models_images_test.py
@@ -1,6 +1,8 @@
+import unittest
+import warnings
+
 from docker.constants import DEFAULT_DATA_CHUNK_SIZE
 from docker.models.images import Image
-import unittest
 
 from .fake_api import FAKE_IMAGE_ID
 from .fake_api_client import make_fake_client
@@ -43,8 +45,9 @@ class ImageCollectionTest(unittest.TestCase):
     def test_pull(self):
         client = make_fake_client()
         image = client.images.pull('test_image:latest')
-        client.api.pull.assert_called_with('test_image', tag='latest',
-                                           stream=False)
+        client.api.pull.assert_called_with(
+            'test_image', tag='latest', stream=True
+        )
         client.api.inspect_image.assert_called_with('test_image:latest')
         assert isinstance(image, Image)
         assert image.id == FAKE_IMAGE_ID
@@ -52,8 +55,9 @@ class ImageCollectionTest(unittest.TestCase):
     def test_pull_multiple(self):
         client = make_fake_client()
         images = client.images.pull('test_image')
-        client.api.pull.assert_called_with('test_image', tag=None,
-                                           stream=False)
+        client.api.pull.assert_called_with(
+            'test_image', tag=None, stream=True
+        )
         client.api.images.assert_called_with(
             all=False, name='test_image', filters=None
         )
@@ -62,6 +66,16 @@ class ImageCollectionTest(unittest.TestCase):
         image = images[0]
         assert isinstance(image, Image)
         assert image.id == FAKE_IMAGE_ID
+
+    def test_pull_with_stream_param(self):
+        client = make_fake_client()
+        with warnings.catch_warnings(record=True) as w:
+            client.images.pull('test_image', stream=True)
+
+        assert len(w) == 1
+        assert str(w[0].message).startswith(
+            '`stream` is not a valid parameter'
+        )
 
     def test_push(self):
         client = make_fake_client()

--- a/tests/unit/models_images_test.py
+++ b/tests/unit/models_images_test.py
@@ -43,7 +43,8 @@ class ImageCollectionTest(unittest.TestCase):
     def test_pull(self):
         client = make_fake_client()
         image = client.images.pull('test_image:latest')
-        client.api.pull.assert_called_with('test_image', tag='latest')
+        client.api.pull.assert_called_with('test_image', tag='latest',
+                                           stream=False)
         client.api.inspect_image.assert_called_with('test_image:latest')
         assert isinstance(image, Image)
         assert image.id == FAKE_IMAGE_ID
@@ -51,7 +52,8 @@ class ImageCollectionTest(unittest.TestCase):
     def test_pull_multiple(self):
         client = make_fake_client()
         images = client.images.pull('test_image')
-        client.api.pull.assert_called_with('test_image', tag=None)
+        client.api.pull.assert_called_with('test_image', tag=None,
+                                           stream=False)
         client.api.images.assert_called_with(
             all=False, name='test_image', filters=None
         )

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -457,8 +457,8 @@ class UtilsTest(unittest.TestCase):
         tests = [
             ({'dangling': True}, '{"dangling": ["true"]}'),
             ({'dangling': "true"}, '{"dangling": ["true"]}'),
-            ({'exited': 0}, '{"exited": [0]}'),
-            ({'exited': [0, 1]}, '{"exited": [0, 1]}'),
+            ({'exited': 0}, '{"exited": ["0"]}'),
+            ({'exited': [0, 1]}, '{"exited": ["0", "1"]}'),
         ]
 
         for filters, expected in tests:

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -272,6 +272,11 @@ class ParseHostTest(unittest.TestCase):
             'tcp://',
             'udp://127.0.0.1',
             'udp://127.0.0.1:2375',
+            'ssh://:22/path',
+            'tcp://netloc:3333/path?q=1',
+            'unix:///sock/path#fragment',
+            'https://netloc:3333/path;params',
+            'ssh://:clearpassword@host:22',
         ]
 
         valid_hosts = {
@@ -281,7 +286,7 @@ class ParseHostTest(unittest.TestCase):
             'http://:7777': 'http://127.0.0.1:7777',
             'https://kokia.jp:2375': 'https://kokia.jp:2375',
             'unix:///var/run/docker.sock': 'http+unix:///var/run/docker.sock',
-            'unix://': 'http+unix://var/run/docker.sock',
+            'unix://': 'http+unix:///var/run/docker.sock',
             '12.234.45.127:2375/docker/engine': (
                 'http://12.234.45.127:2375/docker/engine'
             ),
@@ -294,6 +299,9 @@ class ParseHostTest(unittest.TestCase):
             '[fd12::82d1]:2375/docker/engine': (
                 'http://[fd12::82d1]:2375/docker/engine'
             ),
+            'ssh://': 'ssh://127.0.0.1:22',
+            'ssh://user@localhost:22': 'ssh://user@localhost:22',
+            'ssh://user@remote': 'ssh://user@remote:22',
         }
 
         for host in invalid_hosts:
@@ -304,7 +312,7 @@ class ParseHostTest(unittest.TestCase):
             assert parse_host(host, None) == expected
 
     def test_parse_host_empty_value(self):
-        unix_socket = 'http+unix://var/run/docker.sock'
+        unix_socket = 'http+unix:///var/run/docker.sock'
         npipe = 'npipe:////./pipe/docker_engine'
 
         for val in [None, '']:


### PR DESCRIPTION
[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone=55?closed=1)

### Features

* Added support for connecting to the Docker Engine over SSH. Additional
  dependencies for this feature can be installed with
  `pip install "docker[ssh]"`
* Added support for the `named` parameter in `Image.save`, which may be
  used to ensure the resulting tarball retains the image's name on save.

### Bugfixes

* Fixed a bug where builds on Windows with a context path using the `\\?\`
  prefix would fail with some relative Dockerfile paths.
* Fixed an issue where pulls made with the `DockerClient` would fail when
  setting the `stream` parameter to `True`.

### Miscellaneous

* The minimum requirement for the `requests` dependency has been bumped
  to 2.20.0