### PR TITLE
Fixed a typo in the configs api doc

### DIFF
--- a/docker/api/config.py
+++ b/docker/api/config.py
@@ -42,7 +42,7 @@ class ConfigApiMixin(object):
             Retrieve config metadata
 
             Args:
-                id (string): Full ID of the config to remove
+                id (string): Full ID of the config to inspect
 
             Returns (dict): A dictionary of metadata
 


### PR DESCRIPTION
The documentation for id in ConfigApiMixin inspect_config was wrongly
mentioning removal of a config (instead of inspecting)