### PR TITLE
Regression 443 test: relax status-code check

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -63,6 +63,9 @@ class APIError(requests.exceptions.HTTPError, DockerException):
         if self.response is not None:
             return self.response.status_code
 
+    def is_error(self):
+        return self.is_client_error() or self.is_server_error()
+
     def is_client_error(self):
         if self.status_code is None:
             return False

--- a/tests/integration/regression_test.py
+++ b/tests/integration/regression_test.py
@@ -14,7 +14,7 @@ class TestRegressions(BaseAPIIntegrationTest):
         with pytest.raises(docker.errors.APIError) as exc:
             for line in self.client.build(fileobj=dfile, tag="a/b/c"):
                 pass
-        assert exc.value.response.status_code == 500
+        assert exc.value.is_error()
         dfile.close()
 
     def test_542_truncate_ids_client_side(self):

--- a/tests/unit/errors_test.py
+++ b/tests/unit/errors_test.py
@@ -79,6 +79,27 @@ class APIErrorTest(unittest.TestCase):
         err = APIError('', response=resp)
         assert err.is_client_error() is True
 
+    def test_is_error_300(self):
+        """Report no error on 300 response."""
+        resp = requests.Response()
+        resp.status_code = 300
+        err = APIError('', response=resp)
+        assert err.is_error() is False
+
+    def test_is_error_400(self):
+        """Report error on 400 response."""
+        resp = requests.Response()
+        resp.status_code = 400
+        err = APIError('', response=resp)
+        assert err.is_error() is True
+
+    def test_is_error_500(self):
+        """Report error on 500 response."""
+        resp = requests.Response()
+        resp.status_code = 500
+        err = APIError('', response=resp)
+        assert err.is_error() is True
+
     def test_create_error_from_exception(self):
             resp = requests.Response()
             resp.status_code = 500


### PR DESCRIPTION
This test was testing for a 500 status, but this status is actually a bug in the API (as it's due to an invalid request), and the API should actually return a 400 status.

To make this test handle both situations, relax the test to accept either a 4xx or 5xx status.


relates to https://github.com/moby/moby/pull/38487#issuecomment-452484199

@shin- @LinuxMercedes 