### PR TITLE
Issue 2232 - Added missing options from RUN_HOST_CONFIG_KWARGS list in docker.mode…

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -540,12 +540,15 @@ class ContainerCollection(Collection):
             cap_add (list of str): Add kernel capabilities. For example,
                 ``["SYS_ADMIN", "MKNOD"]``.
             cap_drop (list of str): Drop kernel capabilities.
+            cgroup_parent (str): Override the default parent cgroup.
             cpu_count (int): Number of usable CPUs (Windows only).
             cpu_percent (int): Usable percentage of the available CPUs
                 (Windows only).
             cpu_period (int): The length of a CPU period in microseconds.
             cpu_quota (int): Microseconds of CPU time that the container can
                 get in a CPU period.
+            cpu_rt_period (int): Limit CPU real-time period in microseconds.
+            cpu_rt_runtime (int): Limit CPU real-time runtime in microseconds.
             cpu_shares (int): CPU shares (relative weight).
             cpuset_cpus (str): CPUs in which to allow execution (``0-3``,
                 ``0,1``).
@@ -589,6 +592,7 @@ class ContainerCollection(Collection):
             init_path (str): Path to the docker-init binary
             ipc_mode (str): Set the IPC mode for the container.
             isolation (str): Isolation technology to use. Default: `None`.
+            kernel_memory (int or str): Kernel memory limit
             labels (dict or list): A dictionary of name-value labels (e.g.
                 ``{"label1": "value1", "label2": "value2"}``) or a list of
                 names of labels to set with empty values (e.g.
@@ -598,6 +602,7 @@ class ContainerCollection(Collection):
                 Containers declared in this dict will be linked to the new
                 container using the provided alias. Default: ``None``.
             log_config (LogConfig): Logging configuration.
+            lxc_conf (dict): LXC config.
             mac_address (str): MAC address to assign to the container.
             mem_limit (int or str): Memory limit. Accepts float values
                 (which represent the memory limit of the created container in
@@ -605,6 +610,7 @@ class ContainerCollection(Collection):
                 (``100000b``, ``1000k``, ``128m``, ``1g``). If a string is
                 specified without a units character, bytes are assumed as an
                 intended unit.
+            mem_reservation (int or str): Memory soft limit
             mem_swappiness (int): Tune a container's memory swappiness
                 behavior. Accepts number between 0 and 100.
             memswap_limit (str or int): Maximum amount of memory + swap a
@@ -718,6 +724,10 @@ class ContainerCollection(Collection):
             userns_mode (str): Sets the user namespace mode for the container
                 when user namespace remapping option is enabled. Supported
                 values are: ``host``
+            uts_mode (str): Sets the UTS namespace mode for the container.
+                Supported values are: ``host``
+            version (str): The version of the API to use. Set to ``auto`` to
+                automatically detect the server's version. Default: ``1.30``
             volume_driver (str): The name of a volume driver/plugin.
             volumes (dict or list): A dictionary to configure volumes mounted
                 inside the container. The key is either the host path or a


### PR DESCRIPTION
Added missing options from RUN_HOST_CONFIG_KWARGS list in docker.models.containers to the docstring for client.containers.run()

