### PR TITLE
Make PlacementPreference build correct context

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -692,7 +692,7 @@ class PlacementPreference(dict):
                 'PlacementPreference strategy value is invalid ({}):'
                 ' must be "spread".'.format(strategy)
             )
-        self['SpreadOver'] = descriptor
+        self['Spread'] = {'SpreadDescriptor': descriptor}
 
 
 class DNSConfig(dict):

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -427,6 +427,21 @@ class ServiceTest(BaseAPIIntegrationTest):
         assert 'Placement' in svc_info['Spec']['TaskTemplate']
         assert svc_info['Spec']['TaskTemplate']['Placement'] == placemt
 
+    @requires_api_version('1.27')
+    def test_create_service_with_placement_preferences_tuple(self):
+        container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
+        placemt = docker.types.Placement(preferences=(
+            ('spread', 'com.dockerpy.test'),
+        ))
+        task_tmpl = docker.types.TaskTemplate(
+            container_spec, placement=placemt
+        )
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name)
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Placement' in svc_info['Spec']['TaskTemplate']
+        assert svc_info['Spec']['TaskTemplate']['Placement'] == placemt
+
     def test_create_service_with_endpoint_spec(self):
         container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
         task_tmpl = docker.types.TaskTemplate(container_spec)


### PR DESCRIPTION
`types.services.PlacementPreference` currently builds an invalid context. 

It will generate the the following context:
 ```python
{'Preferences': [{'SpreadOver': 'com.dockerpy.test'}]}
``` 
The correct one is: 
```python
{'Preferences': [{'Spread': {'SpreadDescriptor': 'com.dockerpy.test'}}]}`
```