### PR TITLE
Fix descriptions of the default API version in docs

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -82,7 +82,7 @@ class APIClient(
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
         version (str): The version of the API to use. Set to ``auto`` to
-            automatically detect the server's version. Default: ``1.30``
+            automatically detect the server's version. Default: ``1.35``
         timeout (int): Default timeout for API calls, in seconds.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a

--- a/docker/client.py
+++ b/docker/client.py
@@ -26,7 +26,7 @@ class DockerClient(object):
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
         version (str): The version of the API to use. Set to ``auto`` to
-            automatically detect the server's version. Default: ``1.30``
+            automatically detect the server's version. Default: ``1.35``
         timeout (int): Default timeout for API calls, in seconds.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a
@@ -62,7 +62,7 @@ class DockerClient(object):
 
         Args:
             version (str): The version of the API to use. Set to ``auto`` to
-                automatically detect the server's version. Default: ``1.30``
+                automatically detect the server's version. Default: ``1.35``
             timeout (int): Default timeout for API calls, in seconds.
             ssl_version (int): A valid `SSL version`_.
             assert_hostname (bool): Verify the hostname of the server.

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -727,7 +727,7 @@ class ContainerCollection(Collection):
             uts_mode (str): Sets the UTS namespace mode for the container.
                 Supported values are: ``host``
             version (str): The version of the API to use. Set to ``auto`` to
-                automatically detect the server's version. Default: ``1.30``
+                automatically detect the server's version. Default: ``1.35``
             volume_driver (str): The name of a volume driver/plugin.
             volumes (dict or list): A dictionary to configure volumes mounted
                 inside the container. The key is either the host path or a


### PR DESCRIPTION
The default value of the version of APIClient described as `1.30` in the `docker-py` document.
However, it is actually `1.35`.
`self._version` assigned `DEFAULT_DOCKER_API_VERSION` if passing `None` to `version`, and its value is `1.35`

https://github.com/docker/docker-py/blob/e1e4048753aafc96571752cf54d96df7b24156d3/docker/constants.py#L4
