### PR TITLE
Improve error message in case of paramiko failure

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -162,7 +162,7 @@ class APIClient(
                     base_url, timeout, pool_connections=num_pools
                 )
             except NameError as e:
-                # do not hide orrinal exception as it may contain variou
+                # do not hide orriginal exception as it may contain important info
                 raise DockerException(
                     "Paramiko failure while trying ssh:// protocol:\n%s" % e
                 )

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -161,9 +161,10 @@ class APIClient(
                 self._custom_adapter = SSHAdapter(
                     base_url, timeout, pool_connections=num_pools
                 )
-            except NameError:
+            except NameError as e:
+                # do not hide orrinal exception as it may contain variou
                 raise DockerException(
-                    'Install paramiko package to enable ssh:// support'
+                    "Paramiko failure while trying ssh:// protocol:\n%s" % e
                 )
             self.mount('http+docker://ssh', self._custom_adapter)
             self._unmount('http://', 'https://')


### PR DESCRIPTION
Fix issues where essential error about paramiko dealing code was
lost due to ageneric exception that assumed paramiko library was
missing.

To keep backwards compatibility we keep the custom exception but we
also include information from original exception that caused it.

It was wrong to believe that only missing paramiko can cause it, even
code inside docker-py can thow exceptions, and NamedException is very
broad exception class.