### PR TITLE
On SSHAdapter, close channel after getting the response (#2248)

### DIFF
--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -102,6 +102,13 @@ class SSHAdapter(requests.adapters.HTTPAdapter):
 
         return pool
 
+    def build_response(self, req, resp):
+        sock = resp._connection.sock
+        res = requests.adapters.HTTPAdapter.build_response(self, req, resp)
+        len(res.text)  # make sure the response is fully received
+        sock.close()
+        return res
+
     def close(self):
         self.pools.clear()
         self.ssh_client.close()


### PR DESCRIPTION
This is a fix proposal for #2248.

It adds a build_response function on the SSHAdapter object to close the ssh channel oncy the response is received.

Is there a more elegant way to make requests do it ?

The versions are
* python-docker 3.7.0-1
* docker 18.09.2-ce (on Archlinux)
* Python 3.7.2
