### PR TITLE
Update doc for container.exec_run about demux

### DIFF
--- a/docker/api/exec_api.py
+++ b/docker/api/exec_api.py
@@ -137,7 +137,8 @@ class ExecApiMixin(object):
             (generator or str or tuple): If ``stream=True``, a generator
             yielding response chunks. If ``socket=True``, a socket object for
             the connection. A string containing response data otherwise. If
-            ``demux=True``, stdout and stderr are separated.
+            ``demux=True``, a tuple with two elements of type byte: stdout and
+            stderr.
 
         Raises:
             :py:class:`docker.errors.APIError`

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -173,9 +173,10 @@ class Container(Model):
                 exit_code: (int):
                     Exit code for the executed command or ``None`` if
                     either ``stream```or ``socket`` is ``True``.
-                output: (generator or bytes):
+                output: (generator, bytes, or tuple):
                     If ``stream=True``, a generator yielding response chunks.
                     If ``socket=True``, a socket object for the connection.
+                    If ``demux=True``, a tuple of two bytes: stdout and stderr.
                     A bytestring containing response data otherwise.
 
         Raises:


### PR DESCRIPTION
The origin doc about `container.exec_run()` stated that it will only return **generator or bytes**, but in fact, this function will return a **tuple** when ``demux=True``. 

This problem contribute to a severe bug to our project, sincerely hope this doc could be updated. Thanks!