### PR TITLE
Return API response on service update

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -387,7 +387,7 @@ class ServiceApiMixin(object):
                 current specification of the service. Default: ``False``
 
         Returns:
-            ``True`` if successful.
+            A dictionary containing a ``Warnings`` key.
 
         Raises:
             :py:class:`docker.errors.APIError`
@@ -471,5 +471,4 @@ class ServiceApiMixin(object):
         resp = self._post_json(
             url, data=data, params={'version': version}, headers=headers
         )
-        self._raise_for_status(resp)
-        return True
+        return self._result(resp, json=True)


### PR DESCRIPTION
The response contains a `Warnings` key that should be returned so it can be handled by the caller. 

See the 200 Response documentation here: https://docs.docker.com/engine/api/v1.39/#operation/ServiceUpdate

Currently the only return value from this method is `True`. It can never return `False` (it will raise instead). 

With this change checks like this on the return value will still work:
```python
response = client.update_service(...)
if response:
  ...
```

But it would break backwards compatability if used like this:
```python
response = client.update_service(...)
if response is True:
  ...
```

As previously stated both these checks does not make sense as the only possible return value is `True`. 

