### PR TITLE
Fix BaseHTTPAdapter for the SSL case

### DIFF
--- a/docker/transport/basehttpadapter.py
+++ b/docker/transport/basehttpadapter.py
@@ -3,4 +3,6 @@ import requests.adapters
 
 class BaseHTTPAdapter(requests.adapters.HTTPAdapter):
     def close(self):
-        self.pools.clear()
+        super(BaseHTTPAdapter, self).close()
+        if hasattr(self, 'pools'):
+            self.pools.clear()


### PR DESCRIPTION
As SSL adapter has no `pools` attribute, there is nothing to clean there, just the `poolmanager` that is clean by the super call.

Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>