### PR TITLE
Support for SCTP

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -915,9 +915,10 @@ class ContainerApiMixin(object):
         if '/' in private_port:
             return port_settings.get(private_port)
 
-        h_ports = port_settings.get(private_port + '/tcp')
-        if h_ports is None:
-            h_ports = port_settings.get(private_port + '/udp')
+        for protocol in ['tcp', 'udp', 'sctp']:
+            h_ports = port_settings.get(private_port + '/' + protocol)
+            if h_ports:
+                break
 
         return h_ports
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -649,8 +649,8 @@ class ContainerCollection(Collection):
 
                 The keys of the dictionary are the ports to bind inside the
                 container, either as an integer or a string in the form
-                ``port/protocol``, where the protocol is either ``tcp`` or
-                ``udp``.
+                ``port/protocol``, where the protocol is either ``tcp``,
+                ``udp``, or ``sctp``.
 
                 The values of the dictionary are the corresponding ports to
                 open on the host, which can be either:

--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -7,7 +7,7 @@ PORT_SPEC = re.compile(
     r"(?P<ext>[\d]*)(-(?P<ext_end>[\d]+))?:"  # External range
     ")?"
     r"(?P<int>[\d]+)(-(?P<int_end>[\d]+))?"  # Internal range
-    "(?P<proto>/(udp|tcp))?"  # Protocol
+    "(?P<proto>/(udp|tcp|sctp))?"  # Protocol
     "$"  # Match full string
 )
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -491,9 +491,12 @@ class PortsTest(unittest.TestCase):
         assert external_port == [("127.0.0.1", "1000")]
 
     def test_split_port_with_protocol(self):
-        internal_port, external_port = split_port("127.0.0.1:1000:2000/udp")
-        assert internal_port == ["2000/udp"]
-        assert external_port == [("127.0.0.1", "1000")]
+        for protocol in ['tcp', 'udp', 'sctp']:
+            internal_port, external_port = split_port(
+                "127.0.0.1:1000:2000/" + protocol
+            )
+            assert internal_port == ["2000/" + protocol]
+            assert external_port == [("127.0.0.1", "1000")]
 
     def test_split_port_with_host_ip_no_port(self):
         internal_port, external_port = split_port("127.0.0.1::2000")
@@ -545,6 +548,10 @@ class PortsTest(unittest.TestCase):
     def test_split_port_invalid(self):
         with pytest.raises(ValueError):
             split_port("0.0.0.0:1000:2000:tcp")
+
+    def test_split_port_invalid_protocol(self):
+        with pytest.raises(ValueError):
+            split_port("0.0.0.0:1000:2000/ftp")
 
     def test_non_matching_length_port_ranges(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #2249 by adding `sctp` as an allowed protocol when exposing ports.

Also extends some port related tests to cover protocols.
