### PR TITLE
Avoid race condition on short execution

### DIFF
--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -123,7 +123,9 @@ class ContainerCollectionTest(BaseIntegrationTest):
     def test_run_with_auto_remove(self):
         client = docker.from_env(version=TEST_API_VERSION)
         out = client.containers.run(
-            'alpine', 'echo hello', auto_remove=True
+            # sleep(2) to allow any communication with the container
+            # before it gets removed by the host.
+            'alpine', 'sh -c "echo hello && sleep 2"', auto_remove=True
         )
         assert out == b'hello\n'
 
@@ -132,7 +134,10 @@ class ContainerCollectionTest(BaseIntegrationTest):
         client = docker.from_env(version=TEST_API_VERSION)
         with pytest.raises(docker.errors.ContainerError) as e:
             client.containers.run(
-                'alpine', 'sh -c ">&2 echo error && exit 1"', auto_remove=True
+                # sleep(2) to allow any communication with the container
+                # before it gets removed by the host.
+                'alpine', 'sh -c ">&2 echo error && sleep 2 && exit 1"',
+                auto_remove=True
             )
         assert e.value.exit_status == 1
         assert e.value.stderr is None


### PR DESCRIPTION
- Add a sleep of 5 seconds to be sure the logs
can be requested before the daemon removes the
container when run with auto_remove=True

This avoids to fail in line https://github.com/docker/docker-py/blob/master/docker/models/containers.py#L811

Signed-off-by: Ulysses Souza <ulysses.souza@docker.com>