### PR TITLE
Move volume_driver to RUN_HOST_CONFIG_KWARGS

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -964,7 +964,6 @@ RUN_CREATE_KWARGS = [
     'tty',
     'use_config_proxy',
     'user',
-    'volume_driver',
     'working_dir',
 ]
 
@@ -1028,6 +1027,7 @@ RUN_HOST_CONFIG_KWARGS = [
     'userns_mode',
     'uts_mode',
     'version',
+    'volume_driver',
     'volumes_from',
     'runtime'
 ]

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -378,3 +378,13 @@ class ContainerTest(BaseIntegrationTest):
                                           detach=True)
         self.tmp_containers.append(container.id)
         assert container.wait()['StatusCode'] == 1
+
+    def test_create_with_volume_driver(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        container = client.containers.create(
+            'alpine',
+            'sleep 300',
+            volume_driver='foo'
+        )
+        self.tmp_containers.append(container.id)
+        assert container.attrs['HostConfig']['VolumeDriver'] == 'foo'

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -176,6 +176,7 @@ class ContainerCollectionTest(unittest.TestCase):
                 'Ulimits': [{"Name": "nofile", "Soft": 1024, "Hard": 2048}],
                 'UsernsMode': 'host',
                 'UTSMode': 'host',
+                'VolumeDriver': 'some_driver',
                 'VolumesFrom': ['container'],
             },
             healthcheck={'test': 'true'},
@@ -190,7 +191,6 @@ class ContainerCollectionTest(unittest.TestCase):
             stop_signal=9,
             tty=True,
             user='bob',
-            volume_driver='some_driver',
             volumes=[
                 '/mnt/vol2',
                 '/mnt/vol1',


### PR DESCRIPTION
If `volume_driver` is passed to `containers.create` it will crash as it have been moved to `HostConfig` in the `APIClient`.

This PR moves `volume_driver` from `RUN_CREATE_KWARGS` to `RUN_HOST_CONFIG_KWARGS`.

Added a test to verify the fix.

Fixes #2271
