### PR TITLE
Add support for rotate_manager_unlock_key

### DIFF
--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -151,7 +151,7 @@ class Swarm(Model):
     unlock.__doc__ = APIClient.unlock_swarm.__doc__
 
     def update(self, rotate_worker_token=False, rotate_manager_token=False,
-               **kwargs):
+               rotate_manager_unlock_key=False, **kwargs):
         """
         Update the swarm's configuration.
 
@@ -164,7 +164,8 @@ class Swarm(Model):
                 ``False``.
             rotate_manager_token (bool): Rotate the manager join token.
                 Default: ``False``.
-
+            rotate_manager_unlock_key (bool): Rotate the manager unlock key.
+                Default: ``False``.
         Raises:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
@@ -178,5 +179,6 @@ class Swarm(Model):
             version=self.version,
             swarm_spec=self.client.api.create_swarm_spec(**kwargs),
             rotate_worker_token=rotate_worker_token,
-            rotate_manager_token=rotate_manager_token
+            rotate_manager_token=rotate_manager_token,
+            rotate_manager_unlock_key=rotate_manager_unlock_key
         )

--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -236,6 +236,19 @@ class SwarmTest(BaseAPIIntegrationTest):
 
         assert e.value.response.status_code >= 400
 
+    @requires_api_version('1.25')
+    def test_rotate_manager_unlock_key(self):
+        spec = self.client.create_swarm_spec(autolock_managers=True)
+        assert self.init_swarm(swarm_spec=spec)
+        swarm_info = self.client.inspect_swarm()
+        key_1 = self.client.get_unlock_key()
+        assert self.client.update_swarm(
+            version=swarm_info['Version']['Index'],
+            rotate_manager_unlock_key=True
+        )
+        key_2 = self.client.get_unlock_key()
+        assert key_1['UnlockKey'] != key_2['UnlockKey']
+
     @requires_api_version('1.30')
     def test_init_swarm_data_path_addr(self):
         assert self.init_swarm(data_path_addr='eth0')


### PR DESCRIPTION
This PR adds support for rotating the manager unlock key on swarm update.

See https://docs.docker.com/engine/api/v1.39/#operation/SwarmUpdate