### PR TITLE
Return node id on swarm init

### DIFF
--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -117,7 +117,7 @@ class SwarmApiMixin(object):
                 networks created from the default subnet pool. Default: None
 
         Returns:
-            ``True`` if successful.
+            (str): The ID of the created node.
 
         Raises:
             :py:class:`docker.errors.APIError`
@@ -155,8 +155,7 @@ class SwarmApiMixin(object):
             'Spec': swarm_spec,
         }
         response = self._post_json(url, data=data)
-        self._raise_for_status(response)
-        return True
+        return self._result(response, json=True)
 
     @utils.minimum_version('1.24')
     def inspect_swarm(self):

--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -96,7 +96,7 @@ class Swarm(Model):
                 created in the orchestrator.
 
         Returns:
-            ``True`` if the request went through.
+            (str): The ID of the created node.
 
         Raises:
             :py:class:`docker.errors.APIError`
@@ -120,9 +120,9 @@ class Swarm(Model):
             'subnet_size': subnet_size
         }
         init_kwargs['swarm_spec'] = self.client.api.create_swarm_spec(**kwargs)
-        self.client.api.init_swarm(**init_kwargs)
+        node_id = self.client.api.init_swarm(**init_kwargs)
         self.reload()
-        return True
+        return node_id
 
     def join(self, *args, **kwargs):
         return self.client.api.join_swarm(*args, **kwargs)

--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -186,12 +186,14 @@ class SwarmTest(BaseAPIIntegrationTest):
 
     @requires_api_version('1.24')
     def test_inspect_node(self):
-        assert self.init_swarm()
+        node_id = self.init_swarm()
+        assert node_id
         nodes_list = self.client.nodes()
         assert len(nodes_list) == 1
         node = nodes_list[0]
         node_data = self.client.inspect_node(node['ID'])
         assert node['ID'] == node_data['ID']
+        assert node_id == node['ID']
         assert node['Version'] == node_data['Version']
 
     @requires_api_version('1.24')


### PR DESCRIPTION
This PR changes so that the return value of `init_swarm` is not a boolean (which will always be `True` as we raise on HTTP errors). It will now return the Node ID of the created node.

See https://docs.docker.com/engine/api/v1.39/#operation/SwarmInit

It does somewhat break backwards compatibility if used like this:
```python
result = client.init_swarm()
if result is True:
   ...
```

So I guess it makes sense to release this in the next major if merged.
 