### PR TITLE
Add support for setting init on services

### DIFF
--- a/docker/api/service.py
+++ b/docker/api/service.py
@@ -88,6 +88,10 @@ def _check_api_features(version, task_template, update_config, endpoint_spec,
                 if container_spec.get('Isolation') is not None:
                     raise_version_error('ContainerSpec.isolation', '1.35')
 
+            if utils.version_lt(version, '1.38'):
+                if container_spec.get('Init') is not None:
+                    raise_version_error('ContainerSpec.init', '1.38')
+
         if task_template.get('Resources'):
             if utils.version_lt(version, '1.32'):
                 if task_template['Resources'].get('GenericResources'):

--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -165,6 +165,8 @@ class ServiceCollection(Collection):
             env (list of str): Environment variables, in the form
                 ``KEY=val``.
             hostname (string): Hostname to set on the container.
+            init (boolean): Run an init inside the container that forwards
+                signals and reaps processes
             isolation (string): Isolation technology used by the service's
                 containers. Only used for Windows containers.
             labels (dict): Labels to apply to the service.
@@ -280,6 +282,7 @@ CONTAINER_SPEC_KWARGS = [
     'hostname',
     'hosts',
     'image',
+    'init',
     'isolation',
     'labels',
     'mounts',

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -110,13 +110,15 @@ class ContainerSpec(dict):
         privileges (Privileges): Security options for the service's containers.
         isolation (string): Isolation technology used by the service's
             containers. Only used for Windows containers.
+        init (boolean): Run an init inside the container that forwards signals
+            and reaps processes.
     """
     def __init__(self, image, command=None, args=None, hostname=None, env=None,
                  workdir=None, user=None, labels=None, mounts=None,
                  stop_grace_period=None, secrets=None, tty=None, groups=None,
                  open_stdin=None, read_only=None, stop_signal=None,
                  healthcheck=None, hosts=None, dns_config=None, configs=None,
-                 privileges=None, isolation=None):
+                 privileges=None, isolation=None, init=None):
         self['Image'] = image
 
         if isinstance(command, six.string_types):
@@ -182,6 +184,9 @@ class ContainerSpec(dict):
 
         if isolation is not None:
             self['Isolation'] = isolation
+
+        if init is not None:
+            self['Init'] = init
 
 
 class Mount(dict):

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -850,6 +850,20 @@ class ServiceTest(BaseAPIIntegrationTest):
         )
         assert privileges['SELinuxContext']['Disable'] is True
 
+    @requires_api_version('1.38')
+    def test_create_service_with_init(self):
+        container_spec = docker.types.ContainerSpec(
+            'busybox', ['sleep', '999'], init=True
+        )
+        task_tmpl = docker.types.TaskTemplate(container_spec)
+        name = self.get_service_name()
+        svc_id = self.client.create_service(task_tmpl, name=name)
+        svc_info = self.client.inspect_service(svc_id)
+        assert 'Init' in svc_info['Spec']['TaskTemplate']['ContainerSpec']
+        assert (
+            svc_info['Spec']['TaskTemplate']['ContainerSpec']['Init'] is True
+        )
+
     @requires_api_version('1.25')
     def test_update_service_with_defaults_name(self):
         container_spec = docker.types.ContainerSpec(


### PR DESCRIPTION
This PR adds support for setting the boolean `Init` in `ContainerSpec` when creating and updating services.

I'm not really sure about what API version this feature was actually introduced.

https://docs.docker.com/engine/reference/commandline/service_create/  states that `--init` is supported from 1.37. But when comparing the API spec it looks like it was supported in 1.38.

Check `TaskTemplate.ContainerSpec.Init`: 
https://docs.docker.com/engine/api/v1.38/#operation/ServiceCreate
vs
https://docs.docker.com/engine/api/v1.37/#operation/ServiceCreate

I've set the minimum version to 1.38.

Fixes #2293