### PR TITLE
Add support for swarm DataPathAddr

### DIFF
--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -35,7 +35,7 @@ class Swarm(Model):
 
     def init(self, advertise_addr=None, listen_addr='0.0.0.0:2377',
              force_new_cluster=False, default_addr_pool=None,
-             subnet_size=None, **kwargs):
+             subnet_size=None, data_path_addr=None, **kwargs):
         """
         Initialize a new swarm on this Engine.
 
@@ -63,6 +63,8 @@ class Swarm(Model):
                 Default: None
             subnet_size (int): SubnetSize specifies the subnet size of the
                 networks created from the default subnet pool. Default: None
+            data_path_addr (string): Address or interface to use for data path
+                traffic. For example, 192.168.1.1, or an interface, like eth0.
             task_history_retention_limit (int): Maximum number of tasks
                 history stored.
             snapshot_interval (int): Number of logs entries between snapshot.
@@ -117,7 +119,8 @@ class Swarm(Model):
             'listen_addr': listen_addr,
             'force_new_cluster': force_new_cluster,
             'default_addr_pool': default_addr_pool,
-            'subnet_size': subnet_size
+            'subnet_size': subnet_size,
+            'data_path_addr': data_path_addr,
         }
         init_kwargs['swarm_spec'] = self.client.api.create_swarm_spec(**kwargs)
         self.client.api.init_swarm(**init_kwargs)

--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -233,3 +233,7 @@ class SwarmTest(BaseAPIIntegrationTest):
             self.client.remove_node(node_id, True)
 
         assert e.value.response.status_code >= 400
+
+    @requires_api_version('1.30')
+    def test_init_swarm_data_path_addr(self):
+        assert self.init_swarm(data_path_addr='eth0')

--- a/tests/integration/models_swarm_test.py
+++ b/tests/integration/models_swarm_test.py
@@ -31,3 +31,15 @@ class SwarmTest(unittest.TestCase):
             cm.value.response.status_code == 406 or
             cm.value.response.status_code == 503
         )
+
+    def test_join_on_already_joined_swarm(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        client.swarm.init()
+        join_token = client.swarm.attrs['JoinTokens']['Manager']
+        with pytest.raises(docker.errors.APIError) as cm:
+            client.swarm.join(
+                remote_addrs=['127.0.0.1'],
+                join_token=join_token,
+            )
+        assert cm.value.response.status_code == 503
+        assert 'This node is already part of a swarm.' in cm.value.explanation


### PR DESCRIPTION
This PR adds support for setting the swarm `DataPathAddr` by the argument `data_path_addr` when initialising and joining a swarm. The reason why the integration tests do not check for `DataPathAddr` is because it isn't returned on inspect.  See https://github.com/moby/moby/issues/33938

I also added a test to get some coverage on `join_swarm` as I couldn't find any tests for this.

See: 
https://docs.docker.com/engine/api/v1.39/#operation/SwarmInit
https://docs.docker.com/engine/reference/commandline/swarm_init/