### PR TITLE
Avoid race condition on test

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1267,19 +1267,16 @@ class AttachContainerTest(BaseAPIIntegrationTest):
     @pytest.mark.timeout(5)
     @pytest.mark.skipif(os.environ.get('DOCKER_HOST', '').startswith('ssh://'),
                         reason='No cancellable streams over SSH')
-    @pytest.mark.xfail(condition=os.environ.get('DOCKER_TLS_VERIFY') or
-                       os.environ.get('DOCKER_CERT_PATH'),
-                       reason='Flaky test on TLS')
     def test_attach_stream_and_cancel(self):
         container = self.client.create_container(
-            BUSYBOX, 'sh -c "echo hello && sleep 60"',
+            BUSYBOX, 'sh -c "sleep 2 && echo hello && sleep 60"',
             tty=True
         )
         self.tmp_containers.append(container)
         self.client.start(container)
         output = self.client.attach(container, stream=True, logs=True)
 
-        threading.Timer(1, output.close).start()
+        threading.Timer(3, output.close).start()
 
         lines = []
         for line in output:


### PR DESCRIPTION
This test makes https://github.com/docker/docker-py/pull/2300 fail too often with a timeout, which is not related to the change in the PR.