### PR TITLE
Remove init_path from create

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -487,7 +487,6 @@ class ContainerApiMixin(object):
                 IDs that the container process will run as.
             init (bool): Run an init inside the container that forwards
                 signals and reaps processes
-            init_path (str): Path to the docker-init binary
             ipc_mode (str): Set the IPC mode for the container.
             isolation (str): Isolation technology to use. Default: ``None``.
             links (dict): Mapping of links using the

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -448,19 +448,6 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         config = self.client.inspect_container(ctnr)
         assert config['HostConfig']['Init'] is True
 
-    @pytest.mark.xfail(True, reason='init-path removed in 17.05.0')
-    @requires_api_version('1.25')
-    def test_create_with_init_path(self):
-        ctnr = self.client.create_container(
-            BUSYBOX, 'true',
-            host_config=self.client.create_host_config(
-                init_path="/usr/libexec/docker-init"
-            )
-        )
-        self.tmp_containers.append(ctnr['Id'])
-        config = self.client.inspect_container(ctnr)
-        assert config['HostConfig']['InitPath'] == "/usr/libexec/docker-init"
-
     @requires_api_version('1.24')
     @pytest.mark.xfail(not os.path.exists('/sys/fs/cgroup/cpu.rt_runtime_us'),
                        reason='CONFIG_RT_GROUP_SCHED isn\'t enabled')


### PR DESCRIPTION
This option was never functional, and was not intended to be added to the "container create" API, so let's remove it, because it has been removed in Docker 17.05, and was broken in versions before that; see

- https://github.com/moby/moby/issues/32355 --init-path does not seem to work
- https://github.com/moby/moby/pull/32470 remove --init-path from client
