### PR TITLE
Replace triple backtick in exec_run documentation which caused a rend…

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -179,7 +179,7 @@ class Container(Model):
             (ExecResult): A tuple of (exit_code, output)
                 exit_code: (int):
                     Exit code for the executed command or ``None`` if
-                    either ``stream```or ``socket`` is ``True``.
+                    either ``stream`` or ``socket`` is ``True``.
                 output: (generator, bytes, or tuple):
                     If ``stream=True``, a generator yielding response chunks.
                     If ``socket=True``, a socket object for the connection.


### PR DESCRIPTION

…ering error.

What it looks like at the moment:

<img width="496" alt="Screenshot 2019-04-27 at 09 14 39" src="https://user-images.githubusercontent.com/797801/56846918-e8cee100-68cc-11e9-8fd8-3148fcb919b4.png">
