### PR TITLE
Fix versions.py to include release stage

### DIFF
--- a/scripts/versions.py
+++ b/scripts/versions.py
@@ -26,8 +26,8 @@ class Version(namedtuple('_Version', 'major minor patch stage edition')):
                 edition = stage
                 stage = None
             elif '-' in stage:
-                edition, stage = stage.split('-')
-        major, minor, patch = version.split('.', 3)
+                edition, stage = stage.split('-', 1)
+        major, minor, patch = version.split('.', 2)
         return cls(major, minor, patch, stage, edition)
 
     @property
@@ -63,7 +63,7 @@ def main():
         res = requests.get(url)
         content = res.text
         versions = [Version.parse(v) for v in re.findall(
-                r'"docker-([0-9]+\.[0-9]+\.[0-9]+)-?.*tgz"', content
+            r'"docker-([0-9]+\.[0-9]+\.[0-9]+-?.*)\.tgz"', content
         )]
         sorted_versions = sorted(
             versions, reverse=True, key=operator.attrgetter('order')


### PR DESCRIPTION
This was causing CI to fail when trying to use the yet-to-be-released 19.03.0 stable instead of the beta.