### PR TITLE
Update some test dependencies / default values with newer versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ integration-test-py3: build-py3
 	docker run -t --rm -v /var/run/docker.sock:/var/run/docker.sock docker-sdk-python3 py.test tests/integration/${file}
 
 TEST_API_VERSION ?= 1.35
-TEST_ENGINE_VERSION ?= 17.12.0-ce
+TEST_ENGINE_VERSION ?= 18.09.5
 
 .PHONY: setup-network
 setup-network:

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -5,21 +5,20 @@ import tempfile
 import threading
 from datetime import datetime
 
-import docker
-from docker.constants import IS_WINDOWS_PLATFORM
-from docker.utils.socket import next_frame_header
-from docker.utils.socket import read_exactly
-
 import pytest
-
 import requests
 import six
 
-from .base import BUSYBOX, BaseAPIIntegrationTest
+import docker
 from .. import helpers
-from ..helpers import (
-    assert_cat_socket_detached_with_keys, ctrl_with, requires_api_version,
-)
+from ..helpers import assert_cat_socket_detached_with_keys
+from ..helpers import ctrl_with
+from ..helpers import requires_api_version
+from .base import BaseAPIIntegrationTest
+from .base import BUSYBOX
+from docker.constants import IS_WINDOWS_PLATFORM
+from docker.utils.socket import next_frame_header
+from docker.utils.socket import read_exactly
 
 
 class ListContainersTest(BaseAPIIntegrationTest):
@@ -38,7 +37,7 @@ class ListContainersTest(BaseAPIIntegrationTest):
         assert 'Command' in retrieved
         assert retrieved['Command'] == six.text_type('true')
         assert 'Image' in retrieved
-        assert re.search(r'busybox:.*', retrieved['Image'])
+        assert re.search(r'alpine:.*', retrieved['Image'])
         assert 'Status' in retrieved
 
 
@@ -368,10 +367,9 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         )
         self.tmp_containers.append(container['Id'])
         config = self.client.inspect_container(container['Id'])
-        assert (
-            sorted(config['Config']['Env']) ==
-            sorted(['Foo', 'Other=one', 'Blank='])
-        )
+        assert 'Foo' in config['Config']['Env']
+        assert 'Other=one' in config['Config']['Env']
+        assert 'Blank=' in config['Config']['Env']
 
     @requires_api_version('1.22')
     def test_create_with_tmpfs(self):

--- a/tests/integration/api_exec_test.py
+++ b/tests/integration/api_exec_test.py
@@ -1,11 +1,11 @@
+from ..helpers import assert_cat_socket_detached_with_keys
+from ..helpers import ctrl_with
+from ..helpers import requires_api_version
+from .base import BaseAPIIntegrationTest
+from .base import BUSYBOX
 from docker.utils.proxy import ProxyConfig
 from docker.utils.socket import next_frame_header
 from docker.utils.socket import read_exactly
-
-from .base import BUSYBOX, BaseAPIIntegrationTest
-from ..helpers import (
-    assert_cat_socket_detached_with_keys, ctrl_with, requires_api_version,
-)
 
 
 class ExecTest(BaseAPIIntegrationTest):
@@ -81,11 +81,11 @@ class ExecTest(BaseAPIIntegrationTest):
         self.client.start(id)
         self.tmp_containers.append(id)
 
-        res = self.client.exec_create(id, 'whoami', user='default')
+        res = self.client.exec_create(id, 'whoami', user='postgres')
         assert 'Id' in res
 
         exec_log = self.client.exec_start(res)
-        assert exec_log == b'default\n'
+        assert exec_log == b'postgres\n'
 
     def test_exec_command_as_root(self):
         container = self.client.create_container(BUSYBOX, 'cat',
@@ -188,9 +188,9 @@ class ExecTest(BaseAPIIntegrationTest):
         self.tmp_containers.append(container)
         self.client.start(container)
 
-        res = self.client.exec_create(container, 'pwd', workdir='/var/www')
+        res = self.client.exec_create(container, 'pwd', workdir='/var/opt')
         exec_log = self.client.exec_start(res)
-        assert exec_log == b'/var/www\n'
+        assert exec_log == b'/var/opt\n'
 
     def test_detach_with_default(self):
         container = self.client.create_container(
@@ -252,7 +252,7 @@ class ExecDemuxTest(BaseAPIIntegrationTest):
         'echo hello out',
         # Busybox's sleep does not handle sub-second times.
         # This loops takes ~0.3 second to execute on my machine.
-        'for i in $(seq 1 50000); do echo $i>/dev/null; done',
+        'sleep 0.5',
         # Write something on stderr
         'echo hello err >&2'])
     )

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -3,11 +3,10 @@ import shutil
 import unittest
 
 import docker
+from .. import helpers
 from docker.utils import kwargs_from_env
 
-from .. import helpers
-
-BUSYBOX = 'busybox:buildroot-2014.02'
+BUSYBOX = 'alpine:3.9.3'  # FIXME: this should probably be renamed
 TEST_API_VERSION = os.environ.get('DOCKER_TEST_API_VERSION')
 
 


### PR DESCRIPTION
- Default `TEST_ENGINE_VERSION` in Makefile bumped to latest stable
- Default image for integration tests is now `alpine:3.9.3` instead of old `busybox`.