### PR TITLE
End Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from __future__ import print_function
 import codecs
 import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
@@ -71,7 +72,7 @@ setup(
     install_requires=requirements,
     tests_require=test_requirements,
     extras_require=extras_require,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     zip_safe=False,
     test_suite='tests',
     classifiers=[
@@ -83,7 +84,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 coverage==4.5.2
-flake8==3.6.0; python_version != '3.3'
-flake8==3.4.1; python_version == '3.3'
+flake8==3.6.0
 mock==1.0.1
 pytest==4.1.0
 pytest-cov==2.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, flake8
+envlist = py27, py35, py36, py37, flake8
 skipsdist=True
 
 [testenv]

--- a/win32-requirements.txt
+++ b/win32-requirements.txt
@@ -1,1 +1,0 @@
--r requirements.txt


### PR DESCRIPTION
According to [PEP 429](https://www.python.org/dev/peps/pep-0429/), Python 3.4 has reached end of life. To avoid creating the unnecessary burden of backward support for the upcoming 4.0.0 release, we are removing it from the list of supported versions.