### PR TITLE
Change use_config_proxy default value to True to match CLI behavior

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -20,7 +20,7 @@ class BuildApiMixin(object):
               decode=False, buildargs=None, gzip=False, shmsize=None,
               labels=None, cache_from=None, target=None, network_mode=None,
               squash=None, extra_hosts=None, platform=None, isolation=None,
-              use_config_proxy=False):
+              use_config_proxy=True):
         """
         Similar to the ``docker build`` command. Either ``path`` or ``fileobj``
         needs to be set. ``path`` can be a local path (to a directory

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1,13 +1,15 @@
-import six
 from datetime import datetime
+
+import six
 
 from .. import errors
 from .. import utils
 from ..constants import DEFAULT_DATA_CHUNK_SIZE
-from ..types import (
-    CancellableStream, ContainerConfig, EndpointConfig, HostConfig,
-    NetworkingConfig
-)
+from ..types import CancellableStream
+from ..types import ContainerConfig
+from ..types import EndpointConfig
+from ..types import HostConfig
+from ..types import NetworkingConfig
 
 
 class ContainerApiMixin(object):
@@ -222,7 +224,7 @@ class ContainerApiMixin(object):
                          mac_address=None, labels=None, stop_signal=None,
                          networking_config=None, healthcheck=None,
                          stop_timeout=None, runtime=None,
-                         use_config_proxy=False):
+                         use_config_proxy=True):
         """
         Creates a container. Parameters are similar to those for the ``docker
         run`` command except it doesn't support the attach options (``-a``).

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -416,7 +416,7 @@ class ContainerApiMixin(object):
         if use_config_proxy:
             environment = self._proxy_configs.inject_proxy_environment(
                 environment
-            )
+            ) or None
 
         config = self.create_container_config(
             image, command, hostname, user, detach, stdin_open, tty,

--- a/tests/integration/api_exec_test.py
+++ b/tests/integration/api_exec_test.py
@@ -17,7 +17,6 @@ class ExecTest(BaseAPIIntegrationTest):
 
         container = self.client.create_container(
             BUSYBOX, 'cat', detach=True, stdin_open=True,
-            use_config_proxy=True,
         )
         self.client.start(container)
         self.tmp_containers.append(container)

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -2,10 +2,13 @@ import os
 import tempfile
 import threading
 
-import docker
 import pytest
-from .base import BaseIntegrationTest, TEST_API_VERSION
-from ..helpers import random_name, requires_api_version
+
+import docker
+from ..helpers import random_name
+from ..helpers import requires_api_version
+from .base import BaseIntegrationTest
+from .base import TEST_API_VERSION
 
 
 class ContainerCollectionTest(BaseIntegrationTest):
@@ -174,9 +177,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
             ftp='sakuya.jp:4967'
         )
 
-        out = client.containers.run(
-            'alpine', 'sh -c "env"', use_config_proxy=True
-        )
+        out = client.containers.run('alpine', 'sh -c "env"')
 
         assert b'FTP_PROXY=sakuya.jp:4967\n' in out
         assert b'ftp_proxy=sakuya.jp:4967\n' in out


### PR DESCRIPTION
As announced in the [3.7.0 changelog](https://github.com/docker/docker-py/blame/master/docs/change-log.md#L28-L29)