### PR TITLE
reference swarm page correctly

### DIFF
--- a/docs/user_guides/swarm_services.md
+++ b/docs/user_guides/swarm_services.md
@@ -6,7 +6,7 @@
 
 Starting with Engine version 1.12 (API 1.24), it is possible to manage services
 using the Docker Engine API. Note that the engine needs to be part of a
-[Swarm cluster](../swarm.rst) before you can use the service-related methods.
+[Swarm cluster](../swarm.html) before you can use the service-related methods.
 
 ## Creating a service
 


### PR DESCRIPTION
Current version raises an HTTP404 when [trying](https://docker-py.readthedocs.io/en/stable/swarm.rst) to access swarm page.