### PR TITLE
Change os.errno to errno for compatibility with Python 3.7

### DIFF
--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -1,6 +1,5 @@
 import errno
 import json
-import os
 import subprocess
 
 import six

--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import subprocess
@@ -92,7 +93,7 @@ class Store(object):
         except subprocess.CalledProcessError as e:
             raise errors.process_store_error(e, self.program)
         except OSError as e:
-            if e.errno == os.errno.ENOENT:
+            if e.errno == errno.ENOENT:
                 raise errors.StoreError(
                     '{} not installed or not available in PATH'.format(
                         self.program


### PR DESCRIPTION
`os.errno` has been removed in Python 3.7