### PR TITLE
4.0.1 release

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: 3.5
+  install:
+    - requirements: docs-requirements.txt
+    - requirements: requirements.txt

--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -1,5 +1,5 @@
+import errno
 import json
-import os
 import subprocess
 
 import six
@@ -84,7 +84,7 @@ class Store(object):
                     [self.exe, subcmd], stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE, env=env,
                 )
-                output, err = process.communicate(data_input)
+                output, _ = process.communicate(data_input)
                 if process.returncode != 0:
                     raise subprocess.CalledProcessError(
                         returncode=process.returncode, cmd='', output=output
@@ -92,7 +92,7 @@ class Store(object):
         except subprocess.CalledProcessError as e:
             raise errors.process_store_error(e, self.program)
         except OSError as e:
-            if e.errno == os.errno.ENOENT:
+            if e.errno == errno.ENOENT:
                 raise errors.StoreError(
                     '{} not installed or not available in PATH'.format(
                         self.program

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "4.1.0-dev"
+version = "4.0.1"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "4.0.0"
+version = "4.1.0-dev"
 version_info = tuple([int(d) for d in version.split("-")[0].split(".")])

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,20 @@
 Change log
 ==========
 
+4.0.1
+-----
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/60?closed=1)
+
+### Bugfixes
+
+- Fixed an obsolete import in the `credentials` subpackage that caused import errors in
+  Python 3.7
+
+### Miscellaneous
+
+- Docs building has been repaired
+
 4.0.0
 -----
 

--- a/docs/user_guides/swarm_services.md
+++ b/docs/user_guides/swarm_services.md
@@ -6,7 +6,7 @@
 
 Starting with Engine version 1.12 (API 1.24), it is possible to manage services
 using the Docker Engine API. Note that the engine needs to be part of a
-[Swarm cluster](../swarm.rst) before you can use the service-related methods.
+[Swarm cluster](../swarm.html) before you can use the service-related methods.
 
 ## Creating a service
 


### PR DESCRIPTION
[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/60?closed=1)

### Bugfixes

- Fixed an obsolete import in the `credentials` subpackage that caused import errors in
  Python 3.7

### Miscellaneous

- Docs building has been repaired