### PR TITLE
Fix documentation for inspect_secret referring to removal.

### DIFF
--- a/docker/api/secret.py
+++ b/docker/api/secret.py
@@ -53,7 +53,7 @@ class SecretApiMixin(object):
             Retrieve secret metadata
 
             Args:
-                id (string): Full ID of the secret to remove
+                id (string): Full ID of the secret to inspect
 
             Returns (dict): A dictionary of metadata
 


### PR DESCRIPTION
The documentation for `inspect_secret` takes a secret ID, but documents this as the "full ID of the secret to remove". Since `inspect_secret` inspects a secret as opposed to removing it, it would be more appropriate to document this as "full ID of the secret to inspect".