### PR TITLE
Fixes #2024 by adding navigation scrollbar

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,3 @@
 recommonmark==0.4.0
 Sphinx==1.4.6
+alabaster==0.7.12

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,17 @@
 dl.hide-signature > dt {
   display: none;
 }
+
+/* navigation scroller */
+@media screen and (min-width: 876px) {
+    div.sphinxsidebar {
+        height: 100%;
+    }
+    div.sphinxsidebarwrapper {
+        height: 100%;
+    }
+    div.sphinxsidebar ul {
+        height: calc(100% - 325px);
+        overflow-y: auto;
+    }
+}

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,0 +1,13 @@
+$(document).ready(function() {
+    var nav = document.querySelector('div.sphinxsidebar ul');
+    nav.style.height = 'auto'; // to get actual height
+    var height = $(nav).height() + 'px';
+    var updateHeight = function() {
+        nav.style.height = ''; // to get scroll height
+        if (nav.offsetHeight >= nav.scrollHeight) {
+            nav.style.height = height;  // no scrollbar, use actual height
+        }
+    };
+    updateHeight();
+    $(window).resize(updateHeight);
+});

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,2 +1,3 @@
 {% extends "!page.html" %}
 {% set css_files = css_files + ["_static/custom.css"] %}
+{% set script_files = script_files + ["_static/custom.js"] %}


### PR DESCRIPTION
CSS rules are added to introduce scrollbar to the navigation menu when it overflow the screen.

However, the Quick Search section would then always stick to the bottom left, even when the navigation list is short. Thus the Javascript is added to restore actual navigation height. I cannot think of a way to work around without Javascript. Suggestion is welcomed.

To prevent having any future change in alabaster theme that is incompatible with this customisation, the version of the theme is frozen. Theme updates will need to be done manually by changing the requirements file.