### PR TITLE
Update credentials-helpers to v0.6.2

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,7 +10,7 @@ RUN gpg2 --import gpg-keys/secret
 RUN gpg2 --import-ownertrust gpg-keys/ownertrust
 RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-keys | grep ^sec | cut -d/ -f2 | cut -d" " -f1)
 RUN gpg2 --check-trustdb
-ARG CREDSTORE_VERSION=v0.6.0
+ARG CREDSTORE_VERSION=v0.6.2
 RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
     https://github.com/docker/docker-credential-helpers/releases/download/$CREDSTORE_VERSION/docker-credential-pass-$CREDSTORE_VERSION-amd64.tar.gz && \
     tar -xf /opt/docker-credential-pass.tar.gz -O > /usr/local/bin/docker-credential-pass && \


### PR DESCRIPTION
Full diff: https://github.com/docker/docker-credential-helpers/compare/v0.6.0...v0.6.2