### PR TITLE
 test/Dockerfile: Use multistage build for installing credential-helper

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,7 +10,7 @@ RUN gpg2 --import gpg-keys/secret
 RUN gpg2 --import-ownertrust gpg-keys/ownertrust
 RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-keys | grep ^sec | cut -d/ -f2 | cut -d" " -f1)
 RUN gpg2 --check-trustdb
-ARG CREDSTORE_VERSION=v0.6.0
+ARG CREDSTORE_VERSION=v0.6.2
 RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
     https://github.com/docker/docker-credential-helpers/releases/download/$CREDSTORE_VERSION/docker-credential-pass-$CREDSTORE_VERSION-amd64.tar.gz && \
     tar -xf /opt/docker-credential-pass.tar.gz -O > /usr/local/bin/docker-credential-pass && \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,21 +1,25 @@
 ARG PYTHON_VERSION=3.6
-FROM python:$PYTHON_VERSION-jessie
+FROM python:$PYTHON_VERSION-jessie AS base
+
+FROM base AS credhelpers
+ARG CREDSTORE_VERSION=v0.6.2
+ADD https://github.com/docker/docker-credential-helpers/releases/download/${CREDSTORE_VERSION}/docker-credential-pass-${CREDSTORE_VERSION}-amd64.tar.gz /tmp/
+
+RUN tar -xf /tmp/docker-credential-pass-${CREDSTORE_VERSION}-amd64.tar.gz -C /usr/local/bin/
+RUN docker-credential-pass version || echo "failed to run credentials helper"
+
+FROM base AS final
 RUN apt-get update && apt-get -y install \
     gnupg2 \
-    pass \
-    curl
+    pass
+
+COPY --from=credhelpers /usr/local/bin/docker-credential-pass /usr/local/bin/
 
 COPY ./tests/gpg-keys /gpg-keys
 RUN gpg2 --import gpg-keys/secret
 RUN gpg2 --import-ownertrust gpg-keys/ownertrust
 RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-keys | grep ^sec | cut -d/ -f2 | cut -d" " -f1)
 RUN gpg2 --check-trustdb
-ARG CREDSTORE_VERSION=v0.6.2
-RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
-    https://github.com/docker/docker-credential-helpers/releases/download/$CREDSTORE_VERSION/docker-credential-pass-$CREDSTORE_VERSION-amd64.tar.gz && \
-    tar -xf /opt/docker-credential-pass.tar.gz -O > /usr/local/bin/docker-credential-pass && \
-    rm -rf /opt/docker-credential-pass.tar.gz && \
-    chmod +x /usr/local/bin/docker-credential-pass
 
 WORKDIR /src
 COPY requirements.txt /src/requirements.txt
@@ -24,5 +28,5 @@ RUN pip install -r requirements.txt
 COPY test-requirements.txt /src/test-requirements.txt
 RUN pip install -r test-requirements.txt
 
-COPY . /src
+COPY . .
 RUN pip install .


### PR DESCRIPTION
follow-up to https://github.com/docker/docker-py/pull/2377 (first commit is from that PR)