### PR TITLE
 Update to python 3.7 (buster) and use build-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:2.7
+ARG PYTHON_VERSION=2.7
+
+FROM python:${PYTHON_VERSION}
 
 RUN mkdir /src
 WORKDIR /src

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -1,4 +1,6 @@
-FROM python:3.5
+ARG PYTHON_VERSION=3.7
+
+FROM python:${PYTHON_VERSION}
 
 ARG uid=1000
 ARG gid=1000

--- a/Dockerfile-py3
+++ b/Dockerfile-py3
@@ -1,4 +1,6 @@
-FROM python:3.6
+ARG PYTHON_VERSION=3.7
+
+FROM python:${PYTHON_VERSION}
 
 RUN mkdir /src
 WORKDIR /src

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,6 @@
-ARG PYTHON_VERSION=3.6
-FROM python:$PYTHON_VERSION-jessie
+ARG PYTHON_VERSION=3.7
+
+FROM python:${PYTHON_VERSION}
 RUN apt-get update && apt-get -y install \
     gnupg2 \
     pass \
@@ -8,7 +9,7 @@ RUN apt-get update && apt-get -y install \
 COPY ./tests/gpg-keys /gpg-keys
 RUN gpg2 --import gpg-keys/secret
 RUN gpg2 --import-ownertrust gpg-keys/ownertrust
-RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-keys | grep ^sec | cut -d/ -f2 | cut -d" " -f1)
+RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-key | awk '/^sec/{getline; $1=$1; print}')
 RUN gpg2 --check-trustdb
 ARG CREDSTORE_VERSION=v0.6.2
 RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \

--- a/tests/Dockerfile-dind-certs
+++ b/tests/Dockerfile-dind-certs
@@ -1,4 +1,6 @@
-FROM python:2.7
+ARG PYTHON_VERSION=2.7
+
+FROM python:${PYTHON_VERSION}
 RUN mkdir /tmp/certs
 VOLUME /certs
 


### PR DESCRIPTION
The build arg can be used to either test different versions, but also makes it easier to "grep" when upgrading versions.

The output format of `gpg2 --list-secret-keys` changed in the version installed on Buster, so `grep` was replaced with `awk` to address the new output format;

Debian Jessie:

    gpg2 --no-auto-check-trustdb --list-secret-keys
    /root/.gnupg/secring.gpg
    ------------------------
    sec   1024D/A7B21401 2018-04-25
    uid                  Sakuya Izayoi <sakuya@gensokyo.jp>
    ssb   1024g/C235E4CE 2018-04-25

Debian Buster:

    gpg2 --no-auto-check-trustdb --list-secret-keys
    /root/.gnupg/pubring.kbx
    ------------------------
    sec   dsa1024 2018-04-25 [SCA]
          9781B87DAB042E6FD51388A5464ED987A7B21401
    uid           [ultimate] Sakuya Izayoi <sakuya@gensokyo.jp>
    ssb   elg1024 2018-04-25 [E]


~Follow-up to https://github.com/docker/docker-py/pull/2377 and https://github.com/docker/docker-py/pull/2378 (first two commits are from those PR's)~