### PR TITLE
xfail test_init_swarm_data_path_addr

### DIFF
--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -250,5 +250,6 @@ class SwarmTest(BaseAPIIntegrationTest):
         assert key_1['UnlockKey'] != key_2['UnlockKey']
 
     @requires_api_version('1.30')
+    @pytest.mark.xfail(reason='Can fail if eth0 has multiple IP addresses')
     def test_init_swarm_data_path_addr(self):
         assert self.init_swarm(data_path_addr='eth0')


### PR DESCRIPTION
Relates to https://github.com/moby/moby/pull/39068#issuecomment-510943803

This test can fail if `eth0` has multiple IP addresses;

    E   docker.errors.APIError: 400 Client Error: Bad Request ("interface eth0 has more than one IPv6 address (2001:db8:1::242:ac11:2 and fe80::42:acff:fe11:2)")

Which is not a failiure, but depends on the environment that
the test is run in.