### PR TITLE
Merge 4.0.2-release to master

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,20 @@
 Change log
 ==========
 
+4.0.2
+-----
+
+[List of PRs / issues for this release](https://github.com/docker/docker-py/milestone/62?closed=1)
+
+### Bugfixes
+
+- Unified the way `HealthCheck` is created/configured
+
+### Miscellaneous
+
+- Bumped version of websocket-client
+
+
 4.0.1
 -----
 

--- a/scripts/versions.py
+++ b/scripts/versions.py
@@ -72,5 +72,6 @@ def main():
         results.add(str(latest))
     print(' '.join(results))
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I noticed the changelog  on master wasn't yet updated with the 4.0.2 release