### PR TITLE
Adjust `--platform` tests for changes in docker engine

### DIFF
--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -448,8 +448,10 @@ class BuildTest(BaseAPIIntegrationTest):
             for _ in stream:
                 pass
 
-        assert excinfo.value.status_code == 400
-        assert 'invalid platform' in excinfo.exconly()
+        # Some API versions incorrectly returns 500 status; assert 4xx or 5xx
+        assert excinfo.value.is_error()
+        assert 'unknown operating system' in excinfo.exconly() \
+               or 'invalid platform' in excinfo.exconly()
 
     def test_build_out_of_context_dockerfile(self):
         base_dir = tempfile.mkdtemp()

--- a/tests/integration/api_image_test.py
+++ b/tests/integration/api_image_test.py
@@ -69,8 +69,10 @@ class PullImageTest(BaseAPIIntegrationTest):
         with pytest.raises(docker.errors.APIError) as excinfo:
             self.client.pull('hello-world', platform='foobar')
 
-        assert excinfo.value.status_code == 500
-        assert 'invalid platform' in excinfo.exconly()
+        # Some API versions incorrectly returns 500 status; assert 4xx or 5xx
+        assert excinfo.value.is_error()
+        assert 'unknown operating system' in excinfo.exconly() \
+               or 'invalid platform' in excinfo.exconly()
 
 
 class CommitTest(BaseAPIIntegrationTest):


### PR DESCRIPTION
These tests started failing on recent versions of the engine because the error string changed,
and due to a regression, the status code for one endpoint changed from a 400 to a 500.

On Docker 18.03:

The `docker build` case properly returns a 400, and "invalid platform" as error string;

```bash
docker build --platform=foobar -<<EOF
FROM busybox
EOF

Sending build context to Docker daemon  2.048kB
Error response from daemon: invalid platform: invalid platform os "foobar"
```

```
DEBU[2019-07-15T12:17:22.745511870Z] Calling GET /_ping
DEBU[2019-07-15T12:17:22.748224796Z] Calling POST /session
DEBU[2019-07-15T12:17:22.748692282Z] Calling POST /v1.37/build?buildargs=%7B%7D&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&labels=%7B%7D&memory=0&memswap=0&networkmode=default&platform=foobar&rm=1&session=d7b6ceba9d8d0aed67a805528554feb5285781fe888a4bf4e0c15cb09bffd614&shmsize=0&target=&ulimits=null
```

The `docker pull --platform=foobar hello-world:latest` case incorrectly returns a 500

```
DEBU[2019-07-15T12:16:08.744827612Z] Calling POST /v1.37/images/create?fromImage=hello-world&platform=foobar&tag=latest
DEBU[2019-07-15T12:16:08.745594874Z] FIXME: Got an API for which error does not match any expected type!!!: invalid platform: invalid platform os "foobar"  error_type="*errors.errorString" module=api
ERRO[2019-07-15T12:16:08.745916686Z] Handler for POST /v1.37/images/create returned error: invalid platform: invalid platform os "foobar"
DEBU[2019-07-15T12:16:08.746191172Z] FIXME: Got an API for which error does not match any expected type!!!: invalid platform: invalid platform os "foobar"  error_type="*errors.errorString" module=api
```

On Docker 18.09;

```bash
docker build --platform=foobar -<<EOF
FROM busybox
EOF

Error response from daemon: "foobar": unknown operating system or architecture: invalid argument
```

Which incorrectly returns a 500 status;

```
DEBU[2019-07-15T11:59:20.687268380Z] Calling POST /v1.39/build?buildargs=%7B%7D&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&labels=%7B%7D&memory=0&memswap=0&networkmode=default&platform=foobar&rm=1&session=jko7kejjvs93judyfnq7shoda&shmsize=0&target=&ulimits=null&version=1
DEBU[2019-07-15T11:59:20.687282279Z] Calling POST /session
INFO[2019-07-15T11:59:20.687761392Z] parsed scheme: ""                             module=grpc
INFO[2019-07-15T11:59:20.687833668Z] scheme "" not registered, fallback to default scheme  module=grpc
INFO[2019-07-15T11:59:20.688017578Z] ccResolverWrapper: sending new addresses to cc: [{ 0  <nil>}]  module=grpc
INFO[2019-07-15T11:59:20.688270160Z] ClientConn switching balancer to "pick_first"  module=grpc
INFO[2019-07-15T11:59:20.688353083Z] pickfirstBalancer: HandleSubConnStateChange: 0xc4209b0630, CONNECTING  module=grpc
INFO[2019-07-15T11:59:20.688985698Z] pickfirstBalancer: HandleSubConnStateChange: 0xc4209b0630, READY  module=grpc
DEBU[2019-07-15T11:59:20.812700550Z] client is session enabled
DEBU[2019-07-15T11:59:20.813139288Z] FIXME: Got an API for which error does not match any expected type!!!: invalid argument
github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs.init
	/go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs/errors.go:40
github.com/docker/docker/vendor/github.com/containerd/containerd/content.init
	<autogenerated>:1
github.com/docker/docker/builder/builder-next.init
	<autogenerated>:1
github.com/docker/docker/api/server/backend/build.init
	<autogenerated>:1
main.init
	<autogenerated>:1
runtime.main
	/usr/local/go/src/runtime/proc.go:186
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2361  error_type="*errors.fundamental" module=api
ERRO[2019-07-15T11:59:20.813210677Z] Handler for POST /v1.39/build returned error: "foobar": unknown operating system or architecture: invalid argument
DEBU[2019-07-15T11:59:20.813276737Z] FIXME: Got an API for which error does not match any expected type!!!: invalid argument
github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs.init
	/go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs/errors.go:40
github.com/docker/docker/vendor/github.com/containerd/containerd/content.init
	<autogenerated>:1
github.com/docker/docker/builder/builder-next.init
	<autogenerated>:1
github.com/docker/docker/api/server/backend/build.init
	<autogenerated>:1
main.init
	<autogenerated>:1
runtime.main
	/usr/local/go/src/runtime/proc.go:186
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2361  error_type="*errors.fundamental" module=api
```

Same for the `docker pull --platform=foobar hello-world:latest` case:

```bash
docker pull --platform=foobar hello-world:latest
Error response from daemon: "foobar": unknown operating system or architecture: invalid argument
```

```
DEBU[2019-07-15T12:00:18.812995330Z] Calling POST /v1.39/images/create?fromImage=hello-world&platform=foobar&tag=latest
DEBU[2019-07-15T12:00:18.813229172Z] FIXME: Got an API for which error does not match any expected type!!!: invalid argument
github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs.init
	/go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs/errors.go:40
github.com/docker/docker/vendor/github.com/containerd/containerd/content.init
	<autogenerated>:1
github.com/docker/docker/builder/builder-next.init
	<autogenerated>:1
github.com/docker/docker/api/server/backend/build.init
	<autogenerated>:1
main.init
	<autogenerated>:1
runtime.main
	/usr/local/go/src/runtime/proc.go:186
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2361  error_type="*errors.fundamental" module=api
ERRO[2019-07-15T12:00:18.813365546Z] Handler for POST /v1.39/images/create returned error: "foobar": unknown operating system or architecture: invalid argument
DEBU[2019-07-15T12:00:18.813461428Z] FIXME: Got an API for which error does not match any expected type!!!: invalid argument
github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs.init
	/go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/errdefs/errors.go:40
github.com/docker/docker/vendor/github.com/containerd/containerd/content.init
	<autogenerated>:1
github.com/docker/docker/builder/builder-next.init
	<autogenerated>:1
github.com/docker/docker/api/server/backend/build.init
	<autogenerated>:1
main.init
	<autogenerated>:1
runtime.main
	/usr/local/go/src/runtime/proc.go:186
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:2361  error_type="*errors.fundamental" module=api
```
