### PR TITLE
test/Dockerfile: allow using a mirror for the apt repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ clean:
 
 .PHONY: build
 build:
-	docker build -t docker-sdk-python -f tests/Dockerfile --build-arg PYTHON_VERSION=2.7 .
+	docker build -t docker-sdk-python -f tests/Dockerfile --build-arg PYTHON_VERSION=2.7 --build-arg APT_MIRROR .
 
 .PHONY: build-py3
 build-py3:
-	docker build -t docker-sdk-python3 -f tests/Dockerfile .
+	docker build -t docker-sdk-python3 -f tests/Dockerfile --build-arg APT_MIRROR .
 
 .PHONY: build-docs
 build-docs:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,11 @@
 ARG PYTHON_VERSION=3.7
 
 FROM python:${PYTHON_VERSION}
+
+ARG APT_MIRROR
+RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
+ && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install \
     gnupg2 \
     pass \


### PR DESCRIPTION
With this change applied, the default debian package repository can be replaced with a mirror;

```
make APT_MIRROR=cdn-fastly.deb.debian.org build-py3

...

Step 5/19 : RUN apt-get update && apt-get -y install     gnupg2     pass     curl
 ---> Running in 01c1101a0bd0
Get:1 http://cdn-fastly.deb.debian.org/debian buster InRelease [118 kB]
Get:2 http://cdn-fastly.deb.debian.org/debian-security buster/updates InRelease [39.1 kB]
Get:3 http://cdn-fastly.deb.debian.org/debian buster-updates InRelease [46.8 kB]
Get:4 http://cdn-fastly.deb.debian.org/debian buster/main amd64 Packages [7897 kB]
Get:5 http://cdn-fastly.deb.debian.org/debian-security buster/updates/main amd64 Packages [22.8 kB]
```
