### PR TITLE
Add repr to Container class

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -21,6 +21,12 @@ class Container(Model):
         query the Docker daemon for the current properties, causing
         :py:attr:`attrs` to be refreshed.
     """
+
+    def __repr__(self):
+        return "<%s: '%s', '%s'" % (self.__class__.__name__,
+                                    self.image,
+                                    self.name)
+
     @property
     def name(self):
         """


### PR DESCRIPTION
While debugging, I noticed Container objects did not have helpful `__repr__`.

This `__repr__` better represents containers by showing which image the container
is using and the name of the container.

One integration test was failing, even before this commit:

```
tests/integration/api_service_test.py:630: in test_create_service_with_secret
    assert container is not None
E   AssertionError: assert None is not None
```