### PR TITLE
Correct INDEX_URL logic in build.py _set_auth_headers

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -308,7 +308,8 @@ class BuildApiMixin(object):
             auth_data = self._auth_configs.get_all_credentials()
 
             # See https://github.com/docker/docker-py/issues/1683
-            if auth.INDEX_URL not in auth_data and auth.INDEX_URL in auth_data:
+            if (auth.INDEX_URL not in auth_data and
+                    auth.INDEX_NAME in auth_data):
                 auth_data[auth.INDEX_URL] = auth_data.get(auth.INDEX_NAME, {})
 
             log.debug(


### PR DESCRIPTION
A typo in conditional logic can prevent `auth.INDEX_URL` from being added to `auth_data` in cases where `auth.INDEX_URL` is missing but an `auth.INDEX_NAME` is available.

Signed-off-by: Matt Fluet <matt.fluet@appian.com>