### PR TITLE
Fix broken test due to BUSYBOX -> TEST_IMG rename

### DIFF
--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -376,7 +376,7 @@ class ServiceTest(BaseAPIIntegrationTest):
             'dockerpytest_1', driver='overlay', ipam={'Driver': 'default'}
         )
         self.tmp_networks.append(network['Id'])
-        container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
+        container_spec = docker.types.ContainerSpec(TEST_IMG, ['true'])
         network_config = docker.types.NetworkAttachmentConfig(
             target='dockerpytest_1',
             aliases=['dockerpytest_1_alias'],


### PR DESCRIPTION
The BUSYBOX variable was renamed to TEST_IMG in 54b48a9b7ab59b4dcf49acf49ddf52035ba3ea08 (https://github.com/docker/docker-py/pull/2407), however 0ddf428b6ce7accdac3506b45047df2cb72941ec (https://github.com/docker/docker-py/pull/2333) got merged after that change, but was out of date, and therefore caused the tests to fail:

```
=================================== FAILURES ===================================
________ ServiceTest.test_create_service_with_network_attachment_config ________
tests/integration/api_service_test.py:379: in test_create_service_with_network_attachment_config
    container_spec = docker.types.ContainerSpec(BUSYBOX, ['true'])
E   NameError: global name 'BUSYBOX' is not defined
```

Fix the test by using the correct variable name.
