### PR TITLE
Fix for Python 4

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -313,7 +313,7 @@ class APIClient(
             sock = response.raw._fp.fp.raw.sock
         elif self.base_url.startswith('http+docker://ssh'):
             sock = response.raw._fp.fp.channel
-        elif six.PY3:
+        elif not six.PY2:
             sock = response.raw._fp.fp.raw
             if self.base_url.startswith("https://"):
                 sock = sock._sock

--- a/docker/api/config.py
+++ b/docker/api/config.py
@@ -22,7 +22,7 @@ class ConfigApiMixin(object):
             data = data.encode('utf-8')
 
         data = base64.b64encode(data)
-        if six.PY3:
+        if not six.PY2:
             data = data.decode('ascii')
         body = {
             'Data': data,

--- a/docker/api/secret.py
+++ b/docker/api/secret.py
@@ -25,7 +25,7 @@ class SecretApiMixin(object):
             data = data.encode('utf-8')
 
         data = base64.b64encode(data)
-        if six.PY3:
+        if not six.PY2:
             data = data.decode('ascii')
         body = {
             'Data': data,

--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -75,20 +75,20 @@ class Store(object):
         output = None
         env = create_environment_dict(self.environment)
         try:
-            if six.PY3:
-                output = subprocess.check_output(
-                    [self.exe, subcmd], input=data_input, env=env,
-                )
-            else:
+            if six.PY2:
                 process = subprocess.Popen(
                     [self.exe, subcmd], stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE, env=env,
                 )
-                output, _ = process.communicate(data_input)
-                if process.returncode != 0:
-                    raise subprocess.CalledProcessError(
-                        returncode=process.returncode, cmd='', output=output
-                    )
+            output, _ = process.communicate(data_input)
+            if process.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    returncode=process.returncode, cmd='', output=output
+                )
+            else:
+                output = subprocess.check_output(
+                    [self.exe, subcmd], input=data_input, env=env,
+                )
         except subprocess.CalledProcessError as e:
             raise errors.process_store_error(e, self.program)
         except OSError as e:

--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -80,11 +80,11 @@ class Store(object):
                     [self.exe, subcmd], stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE, env=env,
                 )
-            output, _ = process.communicate(data_input)
-            if process.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    returncode=process.returncode, cmd='', output=output
-                )
+                output, _ = process.communicate(data_input)
+                if process.returncode != 0:
+                    raise subprocess.CalledProcessError(
+                        returncode=process.returncode, cmd='', output=output
+                    )
             else:
                 output = subprocess.check_output(
                     [self.exe, subcmd], input=data_input, env=env,

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -5,10 +5,10 @@ from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 from .npipesocket import NpipeSocket
 
-if six.PY3:
-    import http.client as httplib
-else:
+if six.PY2:
     import httplib
+else:
+    import http.client as httplib
 
 try:
     import requests.packages.urllib3 as urllib3

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -5,10 +5,10 @@ import six
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 
-if six.PY3:
-    import http.client as httplib
-else:
+if six.PY2:
     import httplib
+else:
+    import http.client as httplib
 
 try:
     import requests.packages.urllib3 as urllib3

--- a/docker/transport/ssladapter.py
+++ b/docker/transport/ssladapter.py
@@ -19,7 +19,7 @@ PoolManager = urllib3.poolmanager.PoolManager
 
 # Monkey-patching match_hostname with a version that supports
 # IP-address checking. Not necessary for Python 3.5 and above
-if sys.version_info[0] < 3 or sys.version_info[1] < 5:
+if sys.version_info < (3,):
     from backports.ssl_match_hostname import match_hostname
     urllib3.connection.match_hostname = match_hostname
 

--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -118,12 +118,12 @@ def mkbuildcontext(dockerfile):
     t = tarfile.open(mode='w', fileobj=f)
     if isinstance(dockerfile, io.StringIO):
         dfinfo = tarfile.TarInfo('Dockerfile')
-        if six.PY3:
-            raise TypeError('Please use io.BytesIO to create in-memory '
-                            'Dockerfiles with Python 3')
-        else:
+        if six.PY2:
             dfinfo.size = len(dockerfile.getvalue())
             dockerfile.seek(0)
+        else:
+            raise TypeError('Please use io.BytesIO to create in-memory '
+                            'Dockerfiles with Python 3')
     elif isinstance(dockerfile, io.BytesIO):
         dfinfo = tarfile.TarInfo('Dockerfile')
         dfinfo.size = len(dockerfile.getvalue())

--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -27,13 +27,13 @@ def read(socket, n=4096):
 
     recoverable_errors = (errno.EINTR, errno.EDEADLK, errno.EWOULDBLOCK)
 
-    if six.PY3 and not isinstance(socket, NpipeSocket):
+    if not six.PY2 and not isinstance(socket, NpipeSocket):
         select.select([socket], [], [])
 
     try:
         if hasattr(socket, 'recv'):
             return socket.recv(n)
-        if six.PY3 and isinstance(socket, getattr(pysocket, 'SocketIO')):
+        if not six.PY2 and isinstance(socket, getattr(pysocket, 'SocketIO')):
             return socket.read(n)
         return os.read(socket.fileno(), n)
     except EnvironmentError as e:

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -46,7 +46,7 @@ def create_ipam_config(*args, **kwargs):
 
 def decode_json_header(header):
     data = base64.b64decode(header)
-    if six.PY3:
+    if not six.PY2:
         data = data.decode('utf-8')
     return json.loads(data)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -109,7 +109,7 @@ def swarm_listen_addr():
 
 
 def assert_cat_socket_detached_with_keys(sock, inputs):
-    if six.PY3 and hasattr(sock, '_sock'):
+    if not six.PY2 and hasattr(sock, '_sock'):
         sock = sock._sock
 
     for i in inputs:

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -71,7 +71,7 @@ class BuildTest(BaseAPIIntegrationTest):
         assert len(logs) > 0
 
     def test_build_from_stringio(self):
-        if six.PY3:
+        if not six.PY2:
             return
         script = io.StringIO(six.text_type('\n').join([
             'FROM busybox',
@@ -83,7 +83,7 @@ class BuildTest(BaseAPIIntegrationTest):
         stream = self.client.build(fileobj=script)
         logs = ''
         for chunk in stream:
-            if six.PY3:
+            if not six.PY2:
                 chunk = chunk.decode('utf-8')
             logs += chunk
         assert logs != ''
@@ -135,7 +135,7 @@ class BuildTest(BaseAPIIntegrationTest):
         self.client.wait(c)
         logs = self.client.logs(c)
 
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
 
         assert sorted(list(filter(None, logs.split('\n')))) == sorted([
@@ -341,7 +341,7 @@ class BuildTest(BaseAPIIntegrationTest):
         ctnr = self.run_container(img_name, 'cat /hosts-file')
         self.tmp_containers.append(ctnr)
         logs = self.client.logs(ctnr)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert '127.0.0.1\textrahost.local.test' in logs
         assert '127.0.0.1\thello.world.test' in logs

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -105,7 +105,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         assert self.client.wait(container3_id)['StatusCode'] == 0
 
         logs = self.client.logs(container3_id)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert '{0}_NAME='.format(link_env_prefix1) in logs
         assert '{0}_ENV_FOO=1'.format(link_env_prefix1) in logs
@@ -228,7 +228,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         self.client.wait(container)
 
         logs = self.client.logs(container)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         groups = logs.strip().split(' ')
         assert '1000' in groups
@@ -245,7 +245,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         self.client.wait(container)
 
         logs = self.client.logs(container)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
 
         groups = logs.strip().split(' ')
@@ -514,7 +514,7 @@ class VolumeBindTest(BaseAPIIntegrationTest):
         )
         logs = self.client.logs(container)
 
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert self.filename in logs
         inspect_data = self.client.inspect_container(container)
@@ -533,7 +533,7 @@ class VolumeBindTest(BaseAPIIntegrationTest):
         )
         logs = self.client.logs(container)
 
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert self.filename in logs
 
@@ -552,7 +552,7 @@ class VolumeBindTest(BaseAPIIntegrationTest):
         )
         assert container
         logs = self.client.logs(container)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert self.filename in logs
         inspect_data = self.client.inspect_container(container)
@@ -571,7 +571,7 @@ class VolumeBindTest(BaseAPIIntegrationTest):
         )
         assert container
         logs = self.client.logs(container)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert self.filename in logs
         inspect_data = self.client.inspect_container(container)
@@ -643,7 +643,7 @@ class ArchiveTest(BaseAPIIntegrationTest):
                 destination.write(d)
             destination.seek(0)
             retrieved_data = helpers.untar_file(destination, 'data.txt')
-            if six.PY3:
+            if not six.PY2:
                 retrieved_data = retrieved_data.decode('utf-8')
             assert data == retrieved_data.strip()
 
@@ -680,7 +680,7 @@ class ArchiveTest(BaseAPIIntegrationTest):
         self.client.start(ctnr)
         self.client.wait(ctnr)
         logs = self.client.logs(ctnr)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
             data = data.decode('utf-8')
         assert logs.strip() == data
@@ -698,7 +698,7 @@ class ArchiveTest(BaseAPIIntegrationTest):
         self.client.start(ctnr)
         self.client.wait(ctnr)
         logs = self.client.logs(ctnr)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         results = logs.strip().split()
         assert 'a.py' in results

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -150,7 +150,7 @@ class ServiceTest(BaseAPIIntegrationTest):
             else:
                 break
 
-        if six.PY3:
+        if not six.PY2:
             log_line = log_line.decode('utf-8')
         assert 'hello\n' in log_line
 

--- a/tests/integration/regression_test.py
+++ b/tests/integration/regression_test.py
@@ -39,7 +39,7 @@ class TestRegressions(BaseAPIIntegrationTest):
         self.client.start(ctnr)
         self.client.wait(ctnr)
         logs = self.client.logs(ctnr)
-        if six.PY3:
+        if not six.PY2:
             logs = logs.decode('utf-8')
         assert logs == '1000\n'
 

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -327,7 +327,7 @@ class DockerApiTest(BaseAPIClientTest):
     def test_stream_helper_decoding(self):
         status_code, content = fake_api.fake_responses[url_prefix + 'events']()
         content_str = json.dumps(content)
-        if six.PY3:
+        if not six.PY2:
             content_str = content_str.encode('utf-8')
         body = io.BytesIO(content_str)
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -471,10 +471,10 @@ class UtilsTest(unittest.TestCase):
     def test_decode_json_header(self):
         obj = {'a': 'b', 'c': 1}
         data = None
-        if six.PY3:
-            data = base64.urlsafe_b64encode(bytes(json.dumps(obj), 'utf-8'))
-        else:
+        if six.PY2:
             data = base64.urlsafe_b64encode(json.dumps(obj))
+        else:
+            data = base64.urlsafe_b64encode(bytes(json.dumps(obj), 'utf-8'))
         decoded_data = decode_json_header(data)
         assert obj == decoded_data
 
@@ -483,7 +483,8 @@ class SplitCommandTest(unittest.TestCase):
     def test_split_command_with_unicode(self):
         assert split_command(u'echo μμ') == ['echo', 'μμ']
 
-    @pytest.mark.skipif(six.PY3, reason="shlex doesn't support bytes in py3")
+    @pytest.mark.skipif(not six.PY2,
+                        reason="shlex doesn't support bytes in py3")
     def test_split_command_with_bytes(self):
         assert split_command('echo μμ') == ['echo', 'μμ']
 


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print("Python 2 code")
```

Where in six:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code! Instead, use `six.PY2`.

---

This would also incorrectly monkeypatch 4.0 - 4.4:

```python
# Monkey-patching match_hostname with a version that supports
# IP-address checking. Not necessary for Python 3.5 and above
if sys.version_info[0] < 3 or sys.version_info[1] < 5:
    from backports.ssl_match_hostname import match_hostname
    urllib3.connection.match_hostname = match_hostname
```

Instead, as Python 3.5 is the minimum Python 3 supported, simplify to:

```python
if sys.version_info < (3,):
```

---

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./docker/transport/npipeconn.py:8:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/transport/sshconn.py:8:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/transport/ssladapter.py:22:31: YTT203 `sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to tuple
./docker/utils/build.py:121:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/utils/utils.py:49:8: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/utils/socket.py:30:8: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/utils/socket.py:36:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/api/config.py:25:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/api/client.py:316:14: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/api/secret.py:28:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./docker/credentials/store.py:78:16: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/helpers.py:112:8: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/unit/utils_test.py:474:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/unit/utils_test.py:486:25: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/unit/api_test.py:330:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_build_test.py:74:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_build_test.py:86:16: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_build_test.py:138:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_build_test.py:344:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/regression_test.py:42:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_service_test.py:153:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:108:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:231:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:248:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:517:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:536:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:555:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:574:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:646:16: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:683:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./tests/integration/api_container_test.py:701:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
```
