### PR TITLE
Bump pytest to 4.3.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 coverage==4.5.2
 flake8==3.6.0
 mock==1.0.1
-pytest==4.2.1
+pytest==4.3.1
 pytest-cov==2.6.1
 pytest-timeout==1.3.3


### PR DESCRIPTION
Pytest 4.3.1 includes the fix from https://github.com/pytest-dev/pytest/pull/4795

which should fix the following failure:

> INFO: Building docker-sdk-python3:4.0.2...
> sha256:c7a40413c985b6e75df324fae39b1c30cb78a25df71b7892f1a4a15449537fb3
> INFO: Starting docker-py tests...
> Traceback (most recent call last):
>   File "/usr/local/bin/pytest", line 10, in <module>
>     sys.exit(main())
>   File "/usr/local/lib/python3.6/site-packages/_pytest/config/__init__.py", line 61, in main
>     config = _prepareconfig(args, plugins)
>   File "/usr/local/lib/python3.6/site-packages/_pytest/config/__init__.py", line 182, in _prepareconfig
>     config = get_config()
>   File "/usr/local/lib/python3.6/site-packages/_pytest/config/__init__.py", line 156, in get_config
>     pluginmanager.import_plugin(spec)
>   File "/usr/local/lib/python3.6/site-packages/_pytest/config/__init__.py", line 530, in import_plugin
>     __import__(importspec)
>   File "/usr/local/lib/python3.6/site-packages/_pytest/tmpdir.py", line 25, in <module>
>     class TempPathFactory(object):
>   File "/usr/local/lib/python3.6/site-packages/_pytest/tmpdir.py", line 35, in TempPathFactory
>     lambda p: Path(os.path.abspath(six.text_type(p)))
> TypeError: attrib() got an unexpected keyword argument 'convert'
> Sending interrupt signal to process
> Terminated
> script returned exit code 143

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>