### PR TITLE
Allows to use other types than lists as label filter values

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -174,8 +174,8 @@ class ContainerApiMixin(object):
                 - `exited` (int): Only containers with specified exit code
                 - `status` (str): One of ``restarting``, ``running``,
                     ``paused``, ``exited``
-                - `label` (str|list): format either ``"key"``, ``"key=value"``
-                    or a list of such.
+                - `label` (str|iterable): format either ``"key"``,
+                  ``"key=value"`` or an iterable of such.
                 - `id` (str): The id of the container.
                 - `name` (str): The name of the container.
                 - `ancestor` (str): Filter by container ancestor. Format of

--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -69,9 +69,9 @@ class ImageApiMixin(object):
                 filtered out.
             filters (dict): Filters to be processed on the image list.
                 Available filters:
-                - ``dangling`` (bool)
-                - `label` (str|list): format either ``"key"``, ``"key=value"``
-                    or a list of such.
+                - `dangling` (bool)
+                - `label` (str|iterable): format either ``"key"``,
+                  ``"key=value"`` or an iterable of such.
 
         Returns:
             (dict or list): A list if ``quiet=True``, otherwise a dict.

--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -14,10 +14,10 @@ class NetworkApiMixin(object):
             ids (:py:class:`list`): List of ids to filter by
             filters (dict): Filters to be processed on the network list.
                 Available filters:
-                - ``driver=[<driver-name>]`` Matches a network's driver.
-                - ``label=[<key>]``, ``label=[<key>=<value>]`` or a list of
-                    such.
-                - ``type=["custom"|"builtin"]`` Filters networks by type.
+                - `driver` (str): The network driver name.
+                - `label` (str|iterable): format either ``"key"``,
+                  ``"key=value"`` or an iterable of such.
+                - `type` (str): One of ``builtin`` or ``custom``.
 
         Returns:
             (dict): List of network objects.

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -900,8 +900,8 @@ class ContainerCollection(Collection):
                 - `exited` (int): Only containers with specified exit code
                 - `status` (str): One of ``restarting``, ``running``,
                     ``paused``, ``exited``
-                - `label` (str|list): format either ``"key"``, ``"key=value"``
-                    or a list of such.
+                - `label` (str|iterable): format either ``"key"``,
+                  ``"key=value"`` or an iterable of such.
                 - `id` (str): The id of the container.
                 - `name` (str): The name of the container.
                 - `ancestor` (str): Filter by container ancestor. Format of

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -349,9 +349,9 @@ class ImageCollection(Collection):
                 filtered out.
             filters (dict): Filters to be processed on the image list.
                 Available filters:
-                - ``dangling`` (bool)
-                - `label` (str|list): format either ``"key"``, ``"key=value"``
-                    or a list of such.
+                - `dangling` (bool)
+                - `label` (str|iterable): format either ``"key"``,
+                  ``"key=value"`` or an iterable of such.
 
         Returns:
             (list of :py:class:`Image`): The images.

--- a/docker/models/networks.py
+++ b/docker/models/networks.py
@@ -189,10 +189,10 @@ class NetworkCollection(Collection):
             ids (:py:class:`list`): List of ids to filter by.
             filters (dict): Filters to be processed on the network list.
                 Available filters:
-                - ``driver=[<driver-name>]`` Matches a network's driver.
-                - `label` (str|list): format either ``"key"``, ``"key=value"``
-                    or a list of such.
-                - ``type=["custom"|"builtin"]`` Filters networks by type.
+                - `driver` (str): The network driver name.
+                - `label` (str|iterable): format either ``"key"``,
+                  ``"key=value"`` or an iterable of such.
+                - `type` (str): One of ``builtin`` or ``custom``.
             greedy (bool): Fetch more details for each network individually.
                 You might want this to get the containers attached to them.
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -13,9 +13,11 @@ from .. import errors
 from .. import tls
 
 if six.PY2:
+    from collections import Iterable
     from urllib import splitnport
     from urlparse import urlparse
 else:
+    from collections.abc import Iterable
     from urllib.parse import splitnport, urlparse
 
 DEFAULT_HTTP_HOST = "127.0.0.1"
@@ -380,14 +382,14 @@ def kwargs_from_env(ssl_version=None, assert_hostname=None, environment=None):
 def convert_filters(filters):
     result = {}
     for k, v in six.iteritems(filters):
-        if isinstance(v, bool):
-            v = 'true' if v else 'false'
-        if not isinstance(v, list):
-            v = [v, ]
-        result[k] = [
-            str(item) if not isinstance(item, six.string_types) else item
-            for item in v
-        ]
+        if isinstance(v, six.string_types):
+            result[k] = (v,)
+        elif isinstance(v, bool):
+            result[k] = ('true',) if v else ('false',)
+        elif isinstance(v, Iterable):
+            result[k] = tuple(str(x) for x in v)
+        else:
+            result[k] = (str(v),)
     return json.dumps(result)
 
 

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -463,6 +463,9 @@ class UtilsTest(unittest.TestCase):
             ({'dangling': "true"}, '{"dangling": ["true"]}'),
             ({'exited': 0}, '{"exited": ["0"]}'),
             ({'exited': [0, 1]}, '{"exited": ["0", "1"]}'),
+            ({'label': ('foo=a', 'bar=b')}, '{"label": ["foo=a", "bar=b"]}'),
+            ({'label': (x for x in ('foo=a', 'bar=b'))},
+             '{"label": ["foo=a", "bar=b"]}'),
         ]
 
         for filters, expected in tests:


### PR DESCRIPTION
my use-case is an app where label filters are stored as tuples, but need to be casted to a list before passing them to an api method in order to work.