### PR TITLE
docs/css: remove hyphens in literals

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,6 @@
 dl.hide-signature > dt {
   display: none;
 }
+code.literal{
+  hyphens: none;
+}


### PR DESCRIPTION
Edited the sphinx css theme to prevent hyphens being inserted into the `requirements.txt` name and other literals.

right now:
![image](https://user-images.githubusercontent.com/178803/67668070-9a66d180-f945-11e9-82e3-8c700e1eaf23.png)
with fix:
![image](https://user-images.githubusercontent.com/178803/67668118-afdbfb80-f945-11e9-8884-b271d591a333.png)
