### PR TITLE
Switch from pypiwin32 to pywin32

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -156,7 +156,7 @@ class APIClient(
                 )
             except NameError:
                 raise DockerException(
-                    'Install pypiwin32 package to enable npipe:// support'
+                    'Install pywin32 package to enable npipe:// support'
                 )
             self.mount('http+docker://', self._custom_adapter)
             self.base_url = 'http+docker://localnpipe'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,7 @@ paramiko==2.4.2
 pycparser==2.17
 pyOpenSSL==18.0.0
 pyparsing==2.2.0
-pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
-pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'
+pywin32==223; sys_platform == 'win32'
 requests==2.20.0
 six==1.10.0
 urllib3==1.24.3

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ extras_require = {
     ':python_version < "3.3"': 'ipaddress >= 1.0.16',
 
     # win32 APIs if on Windows (required for npipe support)
-    # Python 3.6 is only compatible with v220 ; Python < 3.5 is not supported
-    # on v220 ; ALL versions are broken for v222 (as of 2018-01-26)
-    ':sys_platform == "win32" and python_version < "3.6"': 'pypiwin32==219',
-    ':sys_platform == "win32" and python_version >= "3.6"': 'pypiwin32==223',
+    ':sys_platform == "win32"': 'pywin32>=223',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
Now that the supported versions of python are 2.7 and 3.5+, we can
switch to pywin32 (which as of 223 supports 2.7, 3.5, 3.6 and 3.7).

Arguably the lower bound is not required; it's merely included such that
for python 3+ the requirement remains the same as pypiwin32==223 was a
proxy for pywin32>=223.

Signed-off-by: Bill Collins <bill@bill.works>