### PR TITLE
Add device requests

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -480,6 +480,9 @@ class ContainerApiMixin(object):
                 For example, ``/dev/sda:/dev/xvda:rwm`` allows the container
                 to have read-write access to the host's ``/dev/sda`` via a
                 node named ``/dev/xvda`` inside the container.
+            device_requests (:py:class:`list`): Expose host resources such as
+                GPUs to the container, as a list of
+                :py:class:`docker.types.DeviceRequest` instances.
             dns (:py:class:`list`): Set custom DNS servers.
             dns_opt (:py:class:`list`): Additional options to be added to the
                 container's ``resolv.conf`` file

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -579,6 +579,9 @@ class ContainerCollection(Collection):
                 For example, ``/dev/sda:/dev/xvda:rwm`` allows the container
                 to have read-write access to the host's ``/dev/sda`` via a
                 node named ``/dev/xvda`` inside the container.
+            device_requests (:py:class:`list`): Expose host resources such as
+                GPUs to the container, as a list of
+                :py:class:`docker.types.DeviceRequest` instances.
             dns (:py:class:`list`): Set custom DNS servers.
             dns_opt (:py:class:`list`): Additional options to be added to the
                 container's ``resolv.conf`` file.
@@ -998,6 +1001,7 @@ RUN_HOST_CONFIG_KWARGS = [
     'device_write_bps',
     'device_write_iops',
     'devices',
+    'device_requests',
     'dns_opt',
     'dns_search',
     'dns',

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
-from .containers import \
+from .containers import (
     ContainerConfig, HostConfig, LogConfig, Ulimit, DeviceRequest
+)
 from .daemon import CancellableStream
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
-from .containers import ContainerConfig, HostConfig, LogConfig, Ulimit
+from .containers import \
+    ContainerConfig, HostConfig, LogConfig, Ulimit, DeviceRequest
 from .daemon import CancellableStream
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -274,7 +274,7 @@ class HostConfig(dict):
                  volume_driver=None, cpu_count=None, cpu_percent=None,
                  nano_cpus=None, cpuset_mems=None, runtime=None, mounts=None,
                  cpu_rt_period=None, cpu_rt_runtime=None,
-                 device_cgroup_rules=None):
+                 device_cgroup_rules=None, device_requests=None):
 
         if mem_limit is not None:
             self['Memory'] = parse_bytes(mem_limit)
@@ -633,6 +633,19 @@ class HostConfig(dict):
                     'device_cgroup_rules', device_cgroup_rules, 'list'
                 )
             self['DeviceCgroupRules'] = device_cgroup_rules
+
+        if device_requests is not None:
+            if version_lt(version, '1.40'):
+                raise host_config_version_error('device_requests', '1.40')
+            if not isinstance(device_requests, list):
+                raise host_config_type_error(
+                    'device_requests', device_requests, 'list'
+                )
+            self['DeviceRequests'] = []
+            for req in device_requests:
+                if not isinstance(req, DeviceRequest):
+                    req = DeviceRequest(**req)
+                self['DeviceRequests'].append(req)
 
 
 def host_config_type_error(param, param_value, expected):

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -154,6 +154,104 @@ class Ulimit(DictType):
         self['Hard'] = value
 
 
+class DeviceRequest(DictType):
+    """
+    Create a device request to be used with
+    :py:meth:`~docker.api.container.ContainerApiMixin.create_host_config`.
+
+    Args:
+
+        driver (str): Which driver to use for this device. Optional.
+        count (int): Number or devices to request. Optional.
+            Set to -1 to request all available devices.
+        device_ids (list): List of strings for device IDs. Optional.
+            Set either ``count`` or ``device_ids``.
+        capabilities (list): List of lists of strings to request
+            capabilities. Optional. The global list acts like an OR,
+            and the sub-lists are AND. The driver will try to satisfy
+            one of the sub-lists.
+            Available capabilities for the ``nvidia`` driver can be found
+            `here <https://github.com/NVIDIA/nvidia-container-runtime>`_.
+        options (dict): Driver-specific options. Optional.
+    """
+
+    def __init__(self, **kwargs):
+        driver = kwargs.get('driver', kwargs.get('Driver'))
+        count = kwargs.get('count', kwargs.get('Count'))
+        device_ids = kwargs.get('device_ids', kwargs.get('DeviceIDs'))
+        capabilities = kwargs.get('capabilities', kwargs.get('Capabilities'))
+        options = kwargs.get('options', kwargs.get('Options'))
+
+        if driver is None:
+            driver = ''
+        elif not isinstance(driver, six.string_types):
+            raise ValueError('DeviceRequest.driver must be a string')
+        if count is None:
+            count = 0
+        elif not isinstance(count, int):
+            raise ValueError('DeviceRequest.count must be an integer')
+        if device_ids is None:
+            device_ids = []
+        elif not isinstance(device_ids, list):
+            raise ValueError('DeviceRequest.device_ids must be a list')
+        if capabilities is None:
+            capabilities = []
+        elif not isinstance(capabilities, list):
+            raise ValueError('DeviceRequest.capabilities must be a list')
+        if options is None:
+            options = {}
+        elif not isinstance(options, dict):
+            raise ValueError('DeviceRequest.options must be a dict')
+
+        super(DeviceRequest, self).__init__({
+            'Driver': driver,
+            'Count': count,
+            'DeviceIDs': device_ids,
+            'Capabilities': capabilities,
+            'Options': options
+        })
+
+    @property
+    def driver(self):
+        return self['Driver']
+
+    @driver.setter
+    def driver(self, value):
+        self['Driver'] = value
+
+    @property
+    def count(self):
+        return self['Count']
+
+    @count.setter
+    def count(self, value):
+        self['Count'] = value
+
+    @property
+    def device_ids(self):
+        return self['DeviceIDs']
+
+    @device_ids.setter
+    def device_ids(self, value):
+        self['DeviceIDs'] = value
+
+    @property
+    def capabilities(self):
+        return self['Capabilities']
+
+    @capabilities.setter
+    def capabilities(self, value):
+        self['Capabilities'] = value
+
+    @property
+    def options(self):
+        return self['Options']
+
+    @options.setter
+    def options(self, value):
+        self['Options'] = value
+
+
 class HostConfig(dict):
     def __init__(self, version, binds=None, port_bindings=None,
                  lxc_conf=None, publish_all_ports=False, links=None,

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -767,7 +767,7 @@ class CreateContainerTest(BaseAPIClientTest):
         assert args[1]['headers'] == {'Content-Type': 'application/json'}
         assert args[1]['timeout'] == DEFAULT_TIMEOUT_SECONDS
 
-    # @requires_api_version('1.40')
+    @requires_api_version('1.40')
     def test_create_container_with_device_requests(self):
         self.client.create_container(
             'busybox', 'true', host_config=self.client.create_host_config(

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -767,6 +767,62 @@ class CreateContainerTest(BaseAPIClientTest):
         assert args[1]['headers'] == {'Content-Type': 'application/json'}
         assert args[1]['timeout'] == DEFAULT_TIMEOUT_SECONDS
 
+    # @requires_api_version('1.40')
+    def test_create_container_with_device_requests(self):
+        self.client.create_container(
+            'busybox', 'true', host_config=self.client.create_host_config(
+                device_requests=[
+                    {
+                        'device_ids': [
+                            '0',
+                            'GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a'
+                        ]
+                    },
+                    {
+                        'driver': 'nvidia',
+                        'Count': -1,
+                        'capabilities': [
+                            ['gpu', 'utility']
+                        ],
+                        'options': {
+                            'key': 'value'
+                        }
+                    }
+                ]
+            )
+        )
+
+        args = fake_request.call_args
+        assert args[0][1] == url_prefix + 'containers/create'
+        expected_payload = self.base_create_payload()
+        expected_payload['HostConfig'] = self.client.create_host_config()
+        expected_payload['HostConfig']['DeviceRequests'] = [
+            {
+                'Driver': '',
+                'Count': 0,
+                'DeviceIDs': [
+                    '0',
+                    'GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a'
+                ],
+                'Capabilities': [],
+                'Options': {}
+            },
+            {
+                'Driver': 'nvidia',
+                'Count': -1,
+                'DeviceIDs': [],
+                'Capabilities': [
+                    ['gpu', 'utility']
+                ],
+                'Options': {
+                    'key': 'value'
+                }
+            }
+        ]
+        assert json.loads(args[1]['data']) == expected_payload
+        assert args[1]['headers'] == {'Content-Type': 'application/json'}
+        assert args[1]['timeout'] == DEFAULT_TIMEOUT_SECONDS
+
     def test_create_container_with_labels_dict(self):
         labels_dict = {
             six.text_type('foo'): six.text_type('1'),


### PR DESCRIPTION
Another take on #2395: while the Docker CLI adds a `--gpus` parameter, it is in fact syntatic sugar for the `DeviceRequests` argument in a container's host config. This PR adds support for any kind of device request, as it seems the API was designed to handle more in the future than just GPUs.

It would still be possible to support another `gpus=...` argument in a way similar to #2465, that could handle the previous `nvidia` runtime and set the environment variables itself or use the new device requests.

For example, with NVIDIA's test image, the equivalent of `--gpus all` would be:

``` python
client.containers.run(
    'nvidia/cuda:9.0-base',
    'nvidia-smi',
    device_requests=[
        docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])
    ]
)
```

The equivalent of `--gpus 2` would be `DeviceRequest(count=2, capabilities=[['gpu']])`.

And for something like `--gpus device=GPU-c6e298ba-aa33-4083-8ae3-db4e27037475,driver=nvidia,capabilities="utility,display"`:

``` python
client.containers.run(
    'nvidia/cuda:9.0-base',
    'nvidia-smi',
    device_requests=[
        docker.types.DeviceRequest(
            driver='nvidia',
            device_ids=['GPU-c6e298ba-aa33-4083-8ae3-db4e27037475'],
            capabilities=[
                ['gpu', 'utility', 'display']
            ]
        )
    ]
)
```