### PR TITLE
put_archive: note the data may also be a stream

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -966,7 +966,7 @@ class ContainerApiMixin:
             container (str): The container where the file(s) will be extracted
             path (str): Path inside the container where the file(s) will be
                 extracted. Must exist.
-            data (bytes): tar data to be extracted
+            data (bytes or stream): tar data to be extracted
 
         Returns:
             (bool): True if the call succeeds.

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -324,7 +324,7 @@ class Container(Model):
         Args:
             path (str): Path inside the container where the file(s) will be
                 extracted. Must exist.
-            data (bytes): tar data to be extracted
+            data (bytes or stream): tar data to be extracted
 
         Returns:
             (bool): True if the call succeeds.


### PR DESCRIPTION
The docs imply the `data` parameter to `put_archive()` must be `bytes` (a bytestring), which is not the case; a stream is fine too [since it's passed directly to Requests](https://2.python-requests.org/en/master/user/advanced/#streaming-uploads).

In fact, the tests for the `put_archive()` feature always pass in a stream:

https://github.com/docker/docker-py/blob/a0b9c3d0b38abd4af1880ca3dde2845556dd2f70/tests/integration/api_container_test.py#L678-L679