### PR TITLE
Fix ImageCollectionTest.test_pull_multiple flakiness

### DIFF
--- a/tests/integration/models_images_test.py
+++ b/tests/integration/models_images_test.py
@@ -87,8 +87,10 @@ class ImageCollectionTest(BaseIntegrationTest):
     def test_pull_multiple(self):
         client = docker.from_env(version=TEST_API_VERSION)
         images = client.images.pull('hello-world')
-        assert len(images) == 1
-        assert 'hello-world:latest' in images[0].attrs['RepoTags']
+        assert len(images) >= 1
+        assert any([
+            'hello-world:latest' in img.attrs['RepoTags'] for img in images
+        ])
 
     def test_load_error(self):
         client = docker.from_env(version=TEST_API_VERSION)


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/40340 (https://github.com/moby/moby/pull/40340#issuecomment-570578753)
relates to https://github.com/moby/moby/pull/40343
introduced in https://github.com/docker/docker-py/pull/1883

The ImageCollectionTest.test_pull_multiple test performs a `docker pull` without
a `:tag` specified) to pull all tags of the given repository (image).

After pulling the image, the image(s) pulled are checked to verify if the list
of images contains the `:latest` tag.

However, the test assumes that all tags of the image are tags for the same
version of the image (same digest), and thus a *single* image is returned, which
is not always the case.

Currently, the `hello-world:latest` and `hello-world:linux` tags point to a
different digest, therefore the `client.images.pull()` returns multiple images:
one image for digest, making the test fail:

```
    =================================== FAILURES ===================================
    ____________________ ImageCollectionTest.test_pull_multiple ____________________
    tests/integration/models_images_test.py:90: in test_pull_multiple
        assert len(images) == 1
    E   AssertionError: assert 2 == 1
    E    +  where 2 = len([<Image: 'hello-world:linux'>, <Image: 'hello-world:latest'>])
```

This patch updates the test to not assume a single image is returned, and instead
loop through the list of images and check if any of the images contains the
`:latest` tag.
