### PR TITLE
tar entry size must be computed from utf-8 encoded content

### DIFF
--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -105,8 +105,9 @@ def create_archive(root, files=None, fileobj=None, gzip=False,
 
     for name, contents in extra_files:
         info = tarfile.TarInfo(name)
-        info.size = len(contents)
-        t.addfile(info, io.BytesIO(contents.encode('utf-8')))
+        encoded = contents.encode('utf-8')
+        info.size = len(encoded)
+        t.addfile(info, io.BytesIO(encoded))
 
     t.close()
     fileobj.seek(0)


### PR DESCRIPTION
See https://github.com/docker/compose/issues/7112

