### PR TITLE
Proper handling of credentials not found for docker-credential-desktop

### DIFF
--- a/docker/credentials/errors.py
+++ b/docker/credentials/errors.py
@@ -12,7 +12,10 @@ class InitializationError(StoreError):
 
 def process_store_error(cpe, program):
     message = cpe.output.decode('utf-8')
-    if 'credentials not found in native keychain' in message:
+    if (
+        'credentials not found in native keychain' in message
+        or 'No stored credential for' in message
+    ):
         return CredentialsNotFound(
             'No matching credentials in {}'.format(
                 program


### PR DESCRIPTION
Can't pull any public image as this store returns a slightly different message than the one hardcoded, raising the wrong exception (StoreError instead of CredentialsNotFound)

```
echo 'https://index.docker.io/v1/' | docker-credential-desktop get
No stored credential for https://index.docker.io/v1/
```