### PR TITLE
raise an error for binding specific ports in 'host' mode of network

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -523,6 +523,10 @@ class ContainerApiMixin(object):
                 - ``container:<name|id>`` Reuse another container's network
                   stack.
                 - ``host`` Use the host network stack.
+                  This mode is incompatible with ``port_bindings``.
+                  If ``host`` is used as network_mode, all of listed up to
+                  ``port_bindings``` are ignored in running container.
+
             oom_kill_disable (bool): Whether to disable OOM killer.
             oom_score_adj (int): An integer value containing the score given
                 to the container in order to tune OOM killer preferences.
@@ -531,7 +535,8 @@ class ContainerApiMixin(object):
             pids_limit (int): Tune a container's pids limit. Set ``-1`` for
                 unlimited.
             port_bindings (dict): See :py:meth:`create_container`
-                    for more information.
+                for more information. The binding ports are ignored in
+                ``host`` as network mode.
             privileged (bool): Give extended privileges to this container.
             publish_all_ports (bool): Publish all ports to the host.
             read_only (bool): Mount the container's root filesystem as read

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -524,8 +524,6 @@ class ContainerApiMixin(object):
                   stack.
                 - ``host`` Use the host network stack.
                   This mode is incompatible with ``port_bindings``.
-                  If ``host`` is used as network_mode, all of listed up to
-                  ``port_bindings``` are ignored in running container.
 
             oom_kill_disable (bool): Whether to disable OOM killer.
             oom_score_adj (int): An integer value containing the score given
@@ -535,8 +533,8 @@ class ContainerApiMixin(object):
             pids_limit (int): Tune a container's pids limit. Set ``-1`` for
                 unlimited.
             port_bindings (dict): See :py:meth:`create_container`
-                for more information. The binding ports are ignored in
-                ``host`` as network mode.
+                for more information.
+                Imcompatible with ``host`` in ``network_mode``.
             privileged (bool): Give extended privileges to this container.
             publish_all_ports (bool): Publish all ports to the host.
             read_only (bool): Mount the container's root filesystem as read

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -649,6 +649,9 @@ class ContainerCollection(Collection):
                 - ``container:<name|id>`` Reuse another container's network
                   stack.
                 - ``host`` Use the host network stack.
+                  This mode is incompatible with ``ports``. If ``host`` is
+                  used as network_mode, all of listed up to ``ports``` are
+                  ignored in running container.
 
                 Incompatible with ``network``.
             oom_kill_disable (bool): Whether to disable OOM killer.
@@ -666,6 +669,8 @@ class ContainerCollection(Collection):
                 container, either as an integer or a string in the form
                 ``port/protocol``, where the protocol is either ``tcp``,
                 ``udp``, or ``sctp``.
+
+                Ports are ignored to bind with ``host`` as network mode.
 
                 The values of the dictionary are the corresponding ports to
                 open on the host, which can be either:

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -649,9 +649,7 @@ class ContainerCollection(Collection):
                 - ``container:<name|id>`` Reuse another container's network
                   stack.
                 - ``host`` Use the host network stack.
-                  This mode is incompatible with ``ports``. If ``host`` is
-                  used as network_mode, all of listed up to ``ports``` are
-                  ignored in running container.
+                  This mode is incompatible with ``ports``.
 
                 Incompatible with ``network``.
             oom_kill_disable (bool): Whether to disable OOM killer.
@@ -670,8 +668,6 @@ class ContainerCollection(Collection):
                 ``port/protocol``, where the protocol is either ``tcp``,
                 ``udp``, or ``sctp``.
 
-                Ports are ignored to bind with ``host`` as network mode.
-
                 The values of the dictionary are the corresponding ports to
                 open on the host, which can be either:
 
@@ -687,6 +683,7 @@ class ContainerCollection(Collection):
                   to a single container port. For example,
                   ``{'1111/tcp': [1234, 4567]}``.
 
+                Imcompatible with ``host`` in ``network_mode``.
             privileged (bool): Give extended privileges to this container.
             publish_all_ports (bool): Publish all ports to the host.
             read_only (bool): Mount the container's root filesystem as read

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -334,6 +334,11 @@ class HostConfig(dict):
         if dns_search:
             self['DnsSearch'] = dns_search
 
+        if network_mode is 'host' and port_bindings is not None:
+            raise host_config_incompatible_error(
+                'network_mode', 'host', 'port_bindings'
+            )
+
         if network_mode:
             self['NetworkMode'] = network_mode
         elif network_mode is None:
@@ -662,6 +667,13 @@ def host_config_version_error(param, version, less_than=True):
 def host_config_value_error(param, param_value):
     error_msg = 'Invalid value for {0} param: {1}'
     return ValueError(error_msg.format(param, param_value))
+
+
+def host_config_incompatible_error(param, param_value, incompatible_param):
+    error_msg = 'Incompatible {1} in {0} is not compatible with {2}'
+    return errors.InvalidArgument(
+        error_msg.format(param, param_value, incompatible_param)
+    )
 
 
 class ContainerConfig(dict):


### PR DESCRIPTION
The binding ports are ignored where the network mode is 'host'.
It could be a problem in case of using these options together on Mac or Windows OS. Because the [limitation](https://docs.docker.com/docker-for-mac/networking/)  that could not use the 'host' in network_mode on Mac and Windows. 
When 'host' mode is set on network_mode, the specific ports in 'ports' are ignored so the network is not able to be accessed through defined ports by developer.
