### PR TITLE
Disable compression by default when using container:get_archive method

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -694,7 +694,8 @@ class ContainerApiMixin(object):
         return self._stream_raw_result(res, chunk_size, False)
 
     @utils.check_resource('container')
-    def get_archive(self, container, path, chunk_size=DEFAULT_DATA_CHUNK_SIZE):
+    def get_archive(self, container, path, chunk_size=DEFAULT_DATA_CHUNK_SIZE,
+                    encode_stream=False):
         """
         Retrieve a file or folder from a container in the form of a tar
         archive.
@@ -705,6 +706,8 @@ class ContainerApiMixin(object):
             chunk_size (int): The number of bytes returned by each iteration
                 of the generator. If ``None``, data will be streamed as it is
                 received. Default: 2 MB
+            encode_stream (bool): Determines if data should be encoded
+                (gzip-compressed) during transmission. Default: False
 
         Returns:
             (tuple): First element is a raw tar data stream. Second element is
@@ -729,8 +732,13 @@ class ContainerApiMixin(object):
         params = {
             'path': path
         }
+        headers = {
+            "Accept-Encoding": "gzip, deflate"
+        } if encode_stream else {
+            "Accept-Encoding": "identity"
+        }
         url = self._url('/containers/{0}/archive', container)
-        res = self._get(url, params=params, stream=True)
+        res = self._get(url, params=params, stream=True, headers=headers)
         self._raise_for_status(res)
         encoded_stat = res.headers.get('x-docker-container-path-stat')
         return (

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -225,7 +225,8 @@ class Container(Model):
         """
         return self.client.api.export(self.id, chunk_size)
 
-    def get_archive(self, path, chunk_size=DEFAULT_DATA_CHUNK_SIZE):
+    def get_archive(self, path, chunk_size=DEFAULT_DATA_CHUNK_SIZE,
+                    encode_stream=False):
         """
         Retrieve a file or folder from the container in the form of a tar
         archive.
@@ -235,6 +236,8 @@ class Container(Model):
             chunk_size (int): The number of bytes returned by each iteration
                 of the generator. If ``None``, data will be streamed as it is
                 received. Default: 2 MB
+            encode_stream (bool): Determines if data should be encoded
+                (gzip-compressed) during transmission. Default: False
 
         Returns:
             (tuple): First element is a raw tar data stream. Second element is
@@ -255,7 +258,8 @@ class Container(Model):
             ...    f.write(chunk)
             >>> f.close()
         """
-        return self.client.api.get_archive(self.id, path, chunk_size)
+        return self.client.api.get_archive(self.id, path,
+                                           chunk_size, encode_stream)
 
     def kill(self, signal=None):
         """

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -450,7 +450,7 @@ class ContainerTest(unittest.TestCase):
         container = client.containers.get(FAKE_CONTAINER_ID)
         container.get_archive('foo')
         client.api.get_archive.assert_called_with(
-            FAKE_CONTAINER_ID, 'foo', DEFAULT_DATA_CHUNK_SIZE
+            FAKE_CONTAINER_ID, 'foo', DEFAULT_DATA_CHUNK_SIZE, False
         )
 
     def test_image(self):


### PR DESCRIPTION
Some pre-discussion can be found from here: https://github.com/moby/moby/issues/40577

This PR attempts to disable compression by default and parametrize the encoding of data stream, when using container's get_archive method. This should bring similar performance than command `docker cp` has when copying files from container as tar file into host system.

Current implementation is not giving any headers for this GET request, and this causes the use of default headers of `requests` library: [`Accept-Encoding: gzip, deflate`](https://github.com/psf/requests/blob/ca6f9af5dba09591007b15a7368bc0f006b7cc50/requests/utils.py#L807). 

This makes Docker engine to encode response stream as gzip-compressed format, and this slows download speed a lot.

I'm not sure if giving possibility for parameter is that useful, but maybe there are some use cases where network bandwidth is bottleneck, and compression could be helpful.

