### PR TITLE
fix build error when .dockerfile contains non-ascii character

### DIFF
--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -105,8 +105,9 @@ def create_archive(root, files=None, fileobj=None, gzip=False,
 
     for name, contents in extra_files:
         info = tarfile.TarInfo(name)
-        info.size = len(contents)
-        t.addfile(info, io.BytesIO(contents.encode('utf-8')))
+        contents_encode = contents.encode('utf-8')
+        info.size = len(contents_encode)
+        t.addfile(info, io.BytesIO(contents_encode))
 
     t.close()
     fileobj.seek(0)

--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -105,9 +105,9 @@ def create_archive(root, files=None, fileobj=None, gzip=False,
 
     for name, contents in extra_files:
         info = tarfile.TarInfo(name)
-        contents_encode = contents.encode('utf-8')
-        info.size = len(contents_encode)
-        t.addfile(info, io.BytesIO(contents_encode))
+        contents_encoded = contents.encode('utf-8')
+        info.size = len(contents_encoded)
+        t.addfile(info, io.BytesIO(contents_encoded))
 
     t.close()
     fileobj.seek(0)


### PR DESCRIPTION
docker-compose up will failed when the dockerfile be built contains non-ascii character, the reason is that the len(contents) returns unicode character number,not bytes number.