### PR TITLE
Fix tests to support both log plugin feedbacks

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -273,11 +273,14 @@ class CreateContainerTest(BaseAPIIntegrationTest):
 
     def test_invalid_log_driver_raises_exception(self):
         log_config = docker.types.LogConfig(
-            type='asdf-nope',
+            type='asdf',
             config={}
         )
 
-        expected_msg = "logger: no log driver named 'asdf-nope' is registered"
+        expected_msgs = [
+            "logger: no log driver named 'asdf' is registered",
+            "looking up logging plugin asdf: plugin \"asdf\" not found",
+        ]
         with pytest.raises(docker.errors.APIError) as excinfo:
             # raises an internal server error 500
             container = self.client.create_container(
@@ -287,7 +290,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
             )
             self.client.start(container)
 
-        assert excinfo.value.explanation == expected_msg
+        assert excinfo.value.explanation in expected_msgs
 
     def test_valid_no_log_driver_specified(self):
         log_config = docker.types.LogConfig(


### PR DESCRIPTION
I am improving the feedback when docker uses a log driver, could you see the change at: https://github.com/moby/moby/pull/40807.

After above change I broke one test that is inside this project, then, I am sending the fix.

Thanks.