### PR TITLE
Add support for DriverOpts in EndpointConfig

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -636,6 +636,8 @@ class ContainerApiMixin(object):
                 network, using the IPv6 protocol. Defaults to ``None``.
             link_local_ips (:py:class:`list`): A list of link-local (IPv4/IPv6)
                 addresses.
+            driver_opt (dict): A dictionary of options to provide to the
+                network driver. Defaults to ``None``.
 
         Returns:
             (dict) An endpoint config.

--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -216,7 +216,7 @@ class NetworkApiMixin(object):
     def connect_container_to_network(self, container, net_id,
                                      ipv4_address=None, ipv6_address=None,
                                      aliases=None, links=None,
-                                     link_local_ips=None):
+                                     link_local_ips=None, driver_opt=None):
         """
         Connect a container to a network.
 
@@ -240,7 +240,8 @@ class NetworkApiMixin(object):
             "Container": container,
             "EndpointConfig": self.create_endpoint_config(
                 aliases=aliases, links=links, ipv4_address=ipv4_address,
-                ipv6_address=ipv6_address, link_local_ips=link_local_ips
+                ipv6_address=ipv6_address, link_local_ips=link_local_ips,
+                driver_opt=driver_opt
             ),
         }
 

--- a/docker/models/networks.py
+++ b/docker/models/networks.py
@@ -46,6 +46,8 @@ class Network(Model):
                 network, using the IPv6 protocol. Defaults to ``None``.
             link_local_ips (:py:class:`list`): A list of link-local (IPv4/IPv6)
                 addresses.
+            driver_opt (dict): A dictionary of options to provide to the
+                network driver. Defaults to ``None``.
 
         Raises:
             :py:class:`docker.errors.APIError`

--- a/docker/types/networks.py
+++ b/docker/types/networks.py
@@ -4,7 +4,7 @@ from ..utils import normalize_links, version_lt
 
 class EndpointConfig(dict):
     def __init__(self, version, aliases=None, links=None, ipv4_address=None,
-                 ipv6_address=None, link_local_ips=None):
+                 ipv6_address=None, link_local_ips=None, driver_opt=None):
         if version_lt(version, '1.22'):
             raise errors.InvalidVersion(
                 'Endpoint config is not supported for API version < 1.22'
@@ -32,6 +32,15 @@ class EndpointConfig(dict):
 
         if ipam_config:
             self['IPAMConfig'] = ipam_config
+
+        if driver_opt:
+            if version_lt(version, '1.32'):
+                raise errors.InvalidVersion(
+                    'DriverOpts is not supported for API version < 1.32'
+                )
+            if not isinstance(driver_opt, dict):
+                raise TypeError('driver_opt must be a dictionary')
+            self['DriverOpts'] = driver_opt
 
 
 class NetworkingConfig(dict):

--- a/tests/unit/api_network_test.py
+++ b/tests/unit/api_network_test.py
@@ -136,7 +136,8 @@ class NetworkTest(BaseAPIClientTest):
                 container={'Id': container_id},
                 net_id=network_id,
                 aliases=['foo', 'bar'],
-                links=[('baz', 'quux')]
+                links=[('baz', 'quux')],
+                driver_opt={'com.docker-py.setting': 'yes'},
             )
 
         assert post.call_args[0][0] == (
@@ -148,6 +149,7 @@ class NetworkTest(BaseAPIClientTest):
             'EndpointConfig': {
                 'Aliases': ['foo', 'bar'],
                 'Links': ['baz:quux'],
+                'DriverOpts': {'com.docker-py.setting': 'yes'},
             },
         }
 


### PR DESCRIPTION
Docker API 1.32 added support for providing options to a network driver
via EndpointConfig when connecting a container to a network.

Fixes #2550

Signed-off-by: Mike Haboustak <haboustak@gmail.com>