### PR TITLE
fix docker build error when dockerfile contains unicode character.

### DIFF
--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -105,8 +105,9 @@ def create_archive(root, files=None, fileobj=None, gzip=False,
 
     for name, contents in extra_files:
         info = tarfile.TarInfo(name)
-        info.size = len(contents)
-        t.addfile(info, io.BytesIO(contents.encode('utf-8')))
+        contents_encoded = contents.encode('utf-8')
+        info.size = len(contents_encoded)
+        t.addfile(info, io.BytesIO(contents_encoded))
 
     t.close()
     fileobj.seek(0)


### PR DESCRIPTION
if dockerfile contains unicode character,len(contents) will return character length,this length will less than len(contents_encoded) length,so contants data will be truncated.