### PR TITLE
Fix image save example

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -86,7 +86,7 @@ class Image(Model):
 
             >>> image = cli.get_image("busybox:latest")
             >>> f = open('/tmp/busybox-latest.tar', 'wb')
-            >>> for chunk in image:
+            >>> for chunk in image.save():
             >>>   f.write(chunk)
             >>> f.close()
         """


### PR DESCRIPTION
### Description
This fixes the `Image.save()` example (see original listing in the appendix below) by actually calling the `save` method.
The example doesn't seem to work, otherwise, due to the image object not being iterable.

Reference version:
```python
>>> import docker
>>> docker.__version__
'4.3.0-dev'
```

### Appendix A: Original example listing
```python
        Example:
            >>> image = cli.get_image("busybox:latest")
            >>> f = open('/tmp/busybox-latest.tar', 'wb')
            >>> for chunk in image:
            >>>   f.write(chunk)
            >>> f.close()
```