### PR TITLE
Specify when to use `tls` on Context constructor

### DIFF
--- a/docker/context/config.py
+++ b/docker/context/config.py
@@ -73,8 +73,8 @@ def get_tls_dir(name=None, endpoint=""):
     return os.path.join(context_dir, "tls")
 
 
-def get_context_host(path=None):
-    host = utils.parse_host(path, IS_WINDOWS_PLATFORM)
+def get_context_host(path=None, tls=False):
+    host = utils.parse_host(path, IS_WINDOWS_PLATFORM, tls)
     if host == DEFAULT_UNIX_SOCKET:
         # remove http+ from default docker socket url
         return host.strip("http+")

--- a/docker/context/context.py
+++ b/docker/context/context.py
@@ -11,7 +11,8 @@ from docker.context.config import get_context_host
 
 class Context:
     """A context."""
-    def __init__(self, name, orchestrator="swarm", host=None, endpoints=None):
+    def __init__(self, name, orchestrator="swarm", host=None, endpoints=None,
+                 tls=False):
         if not name:
             raise Exception("Name not provided")
         self.name = name
@@ -22,8 +23,8 @@ class Context:
                 ) else orchestrator
             self.endpoints = {
                 default_endpoint: {
-                    "Host": get_context_host(host),
-                    "SkipTLSVerify": False
+                    "Host": get_context_host(host, tls),
+                    "SkipTLSVerify": not tls
                 }
             }
         else:
@@ -44,7 +45,7 @@ class Context:
             self, name="docker", host=None, tls_cfg=None,
             skip_tls_verify=False, def_namespace=None):
         self.endpoints[name] = {
-            "Host": get_context_host(host),
+            "Host": get_context_host(host, not skip_tls_verify),
             "SkipTLSVerify": skip_tls_verify
         }
         if def_namespace:

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -37,6 +37,10 @@ class BaseContextTest(unittest.TestCase):
     def test_get_current_context(self):
         assert ContextAPI.get_current_context().Name == "default"
 
+    def test_https_host(self):
+        c = Context("test", host="tcp://testdomain:8080", tls=True)
+        assert c.Host == "https://testdomain:8080"
+
     def test_context_inspect_without_params(self):
         ctx = ContextAPI.inspect_context()
         assert ctx["Name"] == "default"


### PR DESCRIPTION
This is a fix for https://github.com/docker/compose/issues/7348