### PR TITLE
Make context orchestrator field optional

### DIFF
--- a/docker/context/api.py
+++ b/docker/context/api.py
@@ -14,11 +14,11 @@ class ContextAPI(object):
     Contains methods for context management:
     create, list, remove, get, inspect.
     """
-    DEFAULT_CONTEXT = Context("default")
+    DEFAULT_CONTEXT = Context("default", "swarm")
 
     @classmethod
     def create_context(
-            cls, name, orchestrator="swarm", host=None, tls_cfg=None,
+            cls, name, orchestrator=None, host=None, tls_cfg=None,
             default_namespace=None, skip_tls_verify=False):
         """Creates a new context.
         Returns:
@@ -38,9 +38,7 @@ class ContextAPI(object):
         >>> print(ctx.Metadata)
         {
             "Name": "test",
-            "Metadata": {
-                "StackOrchestrator": "swarm"
-            },
+            "Metadata": {},
             "Endpoints": {
                 "docker": {
                     "Host": "unix:///var/run/docker.sock",
@@ -57,7 +55,9 @@ class ContextAPI(object):
         ctx = Context.load_context(name)
         if ctx:
             raise errors.ContextAlreadyExists(name)
-        endpoint = "docker" if orchestrator == "swarm" else orchestrator
+        endpoint = "docker"
+        if orchestrator and orchestrator != "swarm":
+            endpoint = orchestrator
         ctx = Context(name, orchestrator)
         ctx.set_endpoint(
             endpoint, host, tls_cfg,
@@ -79,9 +79,7 @@ class ContextAPI(object):
         >>> print(ctx.Metadata)
         {
             "Name": "test",
-            "Metadata": {
-                "StackOrchestrator": "swarm"
-            },
+            "Metadata": {},
             "Endpoints": {
                 "docker": {
                 "Host": "unix:///var/run/docker.sock",

--- a/tests/integration/context_api_test.py
+++ b/tests/integration/context_api_test.py
@@ -50,3 +50,10 @@ class ContextLifecycleTest(BaseAPIIntegrationTest):
         ContextAPI.remove_context("test")
         with pytest.raises(errors.ContextNotFound):
             ContextAPI.inspect_context("test")
+
+    def test_load_context_without_orchestrator(self):
+        ContextAPI.create_context("test")
+        ctx = ContextAPI.get_context("test")
+        assert ctx
+        assert ctx.Name == "test"
+        assert ctx.Orchestrator is None


### PR DESCRIPTION
Signed-off-by: aiordache <anca.iordache@docker.com>

When loading a context without the StackOrchestrator field set, we get an error. 
```
Traceback (most recent call last):
  File "main.py", line 64, in <module>
    test_get_docker_context()
  File "main.py", line 34, in test_get_docker_context
    ctx = ContextAPI.get_context("dev")
  File "/src/github.com/docker/docker-py/docker/context/api.py", line 97, in get_context
    return Context.load_context(name)
  File "/src/github.com/docker/docker-py/docker/context/context.py", line 62, in load_context
    name, orchestrator, endpoints = Context._load_meta(name)
  File "/src/github.com/docker/docker-py/docker/context/context.py", line 88, in _load_meta
    metadata["Name"], metadata["Metadata"]["StackOrchestrator"],
KeyError: 'StackOrchestrator'
```

Made this field optional so it won't raise error on load. 