### PR TITLE
Jenkinsfile: update node selection labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def buildImage = { name, buildargs, pyTag ->
 }
 
 def buildImages = { ->
-  wrappedNode(label: "ubuntu && !zfs && amd64", cleanWorkspace: true) {
+  wrappedNode(label: "amd64 && ubuntu-1804 && overlay2", cleanWorkspace: true) {
     stage("build image") {
       checkout(scm)
 
@@ -32,7 +32,7 @@ def buildImages = { ->
 
 def getDockerVersions = { ->
   def dockerVersions = ["19.03.5"]
-  wrappedNode(label: "ubuntu && !zfs && amd64") {
+  wrappedNode(label: "amd64 && ubuntu-1804 && overlay2") {
     def result = sh(script: """docker run --rm \\
         --entrypoint=python \\
         ${imageNamePy3} \\
@@ -73,7 +73,7 @@ def runTests = { Map settings ->
   }
 
   { ->
-    wrappedNode(label: "ubuntu && !zfs && amd64", cleanWorkspace: true) {
+    wrappedNode(label: "amd64 && ubuntu-1804 && overlay2", cleanWorkspace: true) {
       stage("test python=${pythonVersion} / docker=${dockerVersion}") {
         checkout(scm)
         def dindContainerName = "dpy-dind-\$BUILD_NUMBER-\$EXECUTOR_NUMBER-${pythonVersion}-${dockerVersion}"


### PR DESCRIPTION
Make sure we use the LTS nodes, to prevent using machines that
we prepared with cgroups v2 (which is not yet supported by docker v19.03)


relates to https://github.com/docker/docker-py/pull/2584#discussion_r434402870