### PR TITLE
Upgrade Windows dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,7 @@ paramiko==2.4.2
 pycparser==2.17
 pyOpenSSL==18.0.0
 pyparsing==2.2.0
-pypiwin32==219; sys_platform == 'win32' and python_version < '3.6'
-pypiwin32==223; sys_platform == 'win32' and python_version >= '3.6'
+pywin32==227; sys_platform == 'win32'
 requests==2.20.0
 six==1.10.0
 urllib3==1.24.3

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ extras_require = {
     ':python_version < "3.3"': 'ipaddress >= 1.0.16',
 
     # win32 APIs if on Windows (required for npipe support)
-    # Python 3.6 is only compatible with v220 ; Python < 3.5 is not supported
-    # on v220 ; ALL versions are broken for v222 (as of 2018-01-26)
-    ':sys_platform == "win32" and python_version < "3.6"': 'pypiwin32==219',
-    ':sys_platform == "win32" and python_version >= "3.6"': 'pypiwin32==223',
+    ':sys_platform == "win32"': 'pywin32==227',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
Another attempt at https://github.com/docker/docker-py/pull/2047

`pypiwin32` is completely deprecated as `pywin32` moved to GitHub and now ships binary wheels itself. Also, it seems the bug introduced in `222` has been fixed.

https://github.com/mhammond/pywin32
https://pypi.org/project/pywin32/#files
https://github.com/mhammond/pywin32/pull/1153