### PR TITLE
Correct example in Image save methods docstr

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -86,7 +86,7 @@ class Image(Model):
 
             >>> image = cli.get_image("busybox:latest")
             >>> f = open('/tmp/busybox-latest.tar', 'wb')
-            >>> for chunk in image:
+            >>> for chunk in image.save():
             >>>   f.write(chunk)
             >>> f.close()
         """


### PR DESCRIPTION
The example incorrectly tries to iterate over the
image object. This commit fixes it so that it calls
the save method and iterates over the generator.