### PR TITLE
Fix CreateContainerTest.test_invalid_log_driver_raises_exception

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -279,7 +279,7 @@ class CreateContainerTest(BaseAPIIntegrationTest):
 
         expected_msgs = [
             "logger: no log driver named 'asdf' is registered",
-            "looking up logging plugin asdf: plugin \"asdf\" not found",
+            "error looking up logging plugin asdf: plugin \"asdf\" not found",
         ]
         with pytest.raises(docker.errors.APIError) as excinfo:
             # raises an internal server error 500


### PR DESCRIPTION
This test was updated in 7d92fbdee1b8621f54faa595ba53d7ef78ef1acc (https://github.com/docker/docker-py/pull/2549), but omitted the "error" prefix in the message, causing the test to fail;

    _________ CreateContainerTest.test_invalid_log_driver_raises_exception _________
    tests/integration/api_container_test.py:293: in test_invalid_log_driver_raises_exception
        assert excinfo.value.explanation in expected_msgs
    E   AssertionError: assert 'error looking up logging plugin asdf: plugin "asdf" not found' in ["logger: no log driver named 'asdf' is registered", 'looking up logging plugin asdf: plugin "asdf" not found']
    E    +  where 'error looking up logging plugin asdf: plugin "asdf" not found' = APIError(HTTPError('400 Client Error: Bad Request for url: http+docker://localhost/v1.39/containers/create')).explanation
    E    +    where APIError(HTTPError('400 Client Error: Bad Request for url: http+docker://localhost/v1.39/containers/create')) = <ExceptionInfo APIError tblen=6>.value

relates to https://github.com/moby/moby/pull/41221