### PR TITLE
Add response url to Server Error and Client Error messages

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -46,12 +46,14 @@ class APIError(requests.exceptions.HTTPError, DockerException):
         message = super(APIError, self).__str__()
 
         if self.is_client_error():
-            message = '{0} Client Error: {1}'.format(
-                self.response.status_code, self.response.reason)
+            message = '{0} Client Error for {1}: {2}'.format(
+                self.response.status_code, self.response.url,
+                self.response.reason)
 
         elif self.is_server_error():
-            message = '{0} Server Error: {1}'.format(
-                self.response.status_code, self.response.reason)
+            message = '{0} Server Error for {1}: {2}'.format(
+                self.response.status_code, self.response.url,
+                self.response.reason)
 
         if self.explanation:
             message = '{0} ("{1}")'.format(message, self.explanation)


### PR DESCRIPTION
Allowing better self-explanatory exceptions for server and client errors.

From 
```python
E   APIError: 500 Server Error: Internal Server Error ("cgroups: cgroup mountpoint does not exist: unknown")
```
To
```python
E   APIError: 500 Server Error for http://dpy-dind-py2:2375/v1.39/containers/beeee4d03ffa1a7ca8f44ea6b5c1e0373d33ca37370e8e792bf89d5d4d0ddc1e/start: Internal Server Error ("cgroups: cgroup mountpoint does not exist: unknown")
```

@ulyssessouza @thaJeztah