### PR TITLE
Update default API version to 1.39 in docs

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -82,7 +82,7 @@ class APIClient(
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
         version (str): The version of the API to use. Set to ``auto`` to
-            automatically detect the server's version. Default: ``1.35``
+            automatically detect the server's version. Default: ``1.39``
         timeout (int): Default timeout for API calls, in seconds.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a

--- a/docker/client.py
+++ b/docker/client.py
@@ -26,7 +26,7 @@ class DockerClient(object):
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
         version (str): The version of the API to use. Set to ``auto`` to
-            automatically detect the server's version. Default: ``1.35``
+            automatically detect the server's version. Default: ``1.39``
         timeout (int): Default timeout for API calls, in seconds.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a
@@ -62,7 +62,7 @@ class DockerClient(object):
 
         Args:
             version (str): The version of the API to use. Set to ``auto`` to
-                automatically detect the server's version. Default: ``1.35``
+                automatically detect the server's version. Default: ``1.39``
             timeout (int): Default timeout for API calls, in seconds.
             ssl_version (int): A valid `SSL version`_.
             assert_hostname (bool): Verify the hostname of the server.

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -742,7 +742,7 @@ class ContainerCollection(Collection):
             uts_mode (str): Sets the UTS namespace mode for the container.
                 Supported values are: ``host``
             version (str): The version of the API to use. Set to ``auto`` to
-                automatically detect the server's version. Default: ``1.35``
+                automatically detect the server's version. Default: ``1.39``
             volume_driver (str): The name of a volume driver/plugin.
             volumes (dict or list): A dictionary to configure volumes mounted
                 inside the container. The key is either the host path or a


### PR DESCRIPTION
@thaJeztah #2512 b4beaaac8cafcec9fe9eb3d6903addd5d9bac4f2

BTW, [Travis CI](https://travis-ci.com/)'s pre-installed Docker server version 18.06.0-ce does not support API v1.39 but 1.38.
So I suggest changing the default to `1.38` or `auto`.
```
Build system information
docker version
Client:
 Version:           18.06.0-ce
 API version:       1.38
 Go version:        go1.10.3
 Git commit:        0ffa825
 Built:             Wed Jul 18 19:11:02 2018
 OS/Arch:           linux/amd64
 Experimental:      false
Server:
 Engine:
  Version:          18.06.0-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.3
  Git commit:       0ffa825
  Built:            Wed Jul 18 19:09:05 2018
  OS/Arch:          linux/amd64
  Experimental:     false
```