### PR TITLE
Set default version to 'auto'

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -7,6 +7,19 @@ import requests.exceptions
 import six
 import websocket
 
+from .. import auth
+from ..constants import (DEFAULT_DOCKER_API_VERSION, DEFAULT_NUM_POOLS,
+                         DEFAULT_NUM_POOLS_SSH, DEFAULT_TIMEOUT_SECONDS,
+                         DEFAULT_USER_AGENT, IS_WINDOWS_PLATFORM,
+                         MINIMUM_DOCKER_API_VERSION, STREAM_HEADER_SIZE_BYTES)
+from ..errors import (DockerException, InvalidVersion, TLSParameterError,
+                      create_api_error_from_http_exception)
+from ..tls import TLSConfig
+from ..transport import SSLHTTPAdapter, UnixHTTPAdapter
+from ..utils import check_resource, config, update_headers, utils
+from ..utils.json_stream import json_stream
+from ..utils.proxy import ProxyConfig
+from ..utils.socket import consume_socket_output, demux_adaptor, frames_iter
 from .build import BuildApiMixin
 from .config import ConfigApiMixin
 from .container import ContainerApiMixin
@@ -19,22 +32,7 @@ from .secret import SecretApiMixin
 from .service import ServiceApiMixin
 from .swarm import SwarmApiMixin
 from .volume import VolumeApiMixin
-from .. import auth
-from ..constants import (
-    DEFAULT_TIMEOUT_SECONDS, DEFAULT_USER_AGENT, IS_WINDOWS_PLATFORM,
-    DEFAULT_DOCKER_API_VERSION, MINIMUM_DOCKER_API_VERSION,
-    STREAM_HEADER_SIZE_BYTES, DEFAULT_NUM_POOLS_SSH, DEFAULT_NUM_POOLS
-)
-from ..errors import (
-    DockerException, InvalidVersion, TLSParameterError,
-    create_api_error_from_http_exception
-)
-from ..tls import TLSConfig
-from ..transport import SSLHTTPAdapter, UnixHTTPAdapter
-from ..utils import utils, check_resource, update_headers, config
-from ..utils.socket import frames_iter, consume_socket_output, demux_adaptor
-from ..utils.json_stream import json_stream
-from ..utils.proxy import ProxyConfig
+
 try:
     from ..transport import NpipeHTTPAdapter
 except ImportError:
@@ -183,14 +181,14 @@ class APIClient(
             self.base_url = base_url
 
         # version detection needs to be after unix adapter mounting
-        if version is None:
-            self._version = DEFAULT_DOCKER_API_VERSION
-        elif isinstance(version, six.string_types):
-            if version.lower() == 'auto':
-                self._version = self._retrieve_server_version()
-            else:
-                self._version = version
+        if version is None or (
+            isinstance(version, six.string_types) and 
+            version.lower()) == 'auto':
+            self._version = self._retrieve_server_version()
         else:
+            self._version = version
+        
+        if not isinstance(self._version, six.string_types):
             raise DockerException(
                 'Version parameter must be a string or None. Found {0}'.format(
                     type(version).__name__

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -8,10 +8,10 @@ import six
 import websocket
 
 from .. import auth
-from ..constants import (DEFAULT_DOCKER_API_VERSION, DEFAULT_NUM_POOLS,
-                         DEFAULT_NUM_POOLS_SSH, DEFAULT_TIMEOUT_SECONDS,
-                         DEFAULT_USER_AGENT, IS_WINDOWS_PLATFORM,
-                         MINIMUM_DOCKER_API_VERSION, STREAM_HEADER_SIZE_BYTES)
+from ..constants import (DEFAULT_NUM_POOLS, DEFAULT_NUM_POOLS_SSH,
+                         DEFAULT_TIMEOUT_SECONDS, DEFAULT_USER_AGENT,
+                         IS_WINDOWS_PLATFORM, MINIMUM_DOCKER_API_VERSION,
+                         STREAM_HEADER_SIZE_BYTES)
 from ..errors import (DockerException, InvalidVersion, TLSParameterError,
                       create_api_error_from_http_exception)
 from ..tls import TLSConfig
@@ -181,13 +181,13 @@ class APIClient(
             self.base_url = base_url
 
         # version detection needs to be after unix adapter mounting
-        if version is None or (
-            isinstance(version, six.string_types) and 
-            version.lower()) == 'auto':
+        if version is None or (isinstance(
+                                version,
+                                six.string_types
+                                ) and version.lower() == 'auto'):
             self._version = self._retrieve_server_version()
         else:
             self._version = version
-        
         if not isinstance(self._version, six.string_types):
             raise DockerException(
                 'Version parameter must be a string or None. Found {0}'.format(

--- a/docker/client.py
+++ b/docker/client.py
@@ -62,7 +62,7 @@ class DockerClient(object):
 
         Args:
             version (str): The version of the API to use. Set to ``auto`` to
-                automatically detect the server's version. Default: ``1.35``
+                automatically detect the server's version. Default: ``auto``
             timeout (int): Default timeout for API calls, in seconds.
             ssl_version (int): A valid `SSL version`_.
             assert_hostname (bool): Verify the hostname of the server.

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1,14 +1,14 @@
 import datetime
-import docker
-from docker.utils import kwargs_from_env
-from docker.constants import (
-    DEFAULT_DOCKER_API_VERSION, DEFAULT_TIMEOUT_SECONDS
-)
 import os
 import unittest
 
-from . import fake_api
+import docker
 import pytest
+from docker.constants import (
+        DEFAULT_DOCKER_API_VERSION, DEFAULT_TIMEOUT_SECONDS)
+from docker.utils import kwargs_from_env
+
+from . import fake_api
 
 try:
     from unittest import mock
@@ -25,33 +25,33 @@ class ClientTest(unittest.TestCase):
     def test_events(self, mock_func):
         since = datetime.datetime(2016, 1, 1, 0, 0)
         mock_func.return_value = fake_api.get_fake_events()[1]
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         assert client.events(since=since) == mock_func.return_value
         mock_func.assert_called_with(since=since)
 
     @mock.patch('docker.api.APIClient.info')
     def test_info(self, mock_func):
         mock_func.return_value = fake_api.get_fake_info()[1]
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         assert client.info() == mock_func.return_value
         mock_func.assert_called_with()
 
     @mock.patch('docker.api.APIClient.ping')
     def test_ping(self, mock_func):
         mock_func.return_value = True
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         assert client.ping() is True
         mock_func.assert_called_with()
 
     @mock.patch('docker.api.APIClient.version')
     def test_version(self, mock_func):
         mock_func.return_value = fake_api.get_fake_version()[1]
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         assert client.version() == mock_func.return_value
         mock_func.assert_called_with()
 
     def test_call_api_client_method(self):
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         with pytest.raises(AttributeError) as cm:
             client.create_container()
         s = cm.exconly()
@@ -65,7 +65,9 @@ class ClientTest(unittest.TestCase):
         assert "this method is now on the object APIClient" not in s
 
     def test_call_containers(self):
-        client = docker.DockerClient(**kwargs_from_env())
+        client = docker.DockerClient(
+            version=DEFAULT_DOCKER_API_VERSION,
+            **kwargs_from_env())
 
         with pytest.raises(TypeError) as cm:
             client.containers()
@@ -90,7 +92,7 @@ class FromEnvTest(unittest.TestCase):
         os.environ.update(DOCKER_HOST='tcp://192.168.59.103:2376',
                           DOCKER_CERT_PATH=TEST_CERT_DIR,
                           DOCKER_TLS_VERIFY='1')
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         assert client.api.base_url == "https://192.168.59.103:2376"
 
     def test_from_env_with_version(self):
@@ -102,11 +104,11 @@ class FromEnvTest(unittest.TestCase):
         assert client.api._version == '2.32'
 
     def test_from_env_without_version_uses_default(self):
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
 
         assert client.api._version == DEFAULT_DOCKER_API_VERSION
 
     def test_from_env_without_timeout_uses_default(self):
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
 
         assert client.api.timeout == DEFAULT_TIMEOUT_SECONDS

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -1,5 +1,6 @@
-from . import fake_stat
 from docker import constants
+
+from . import fake_stat
 
 CURRENT_VERSION = 'v{0}'.format(constants.DEFAULT_DOCKER_API_VERSION)
 

--- a/tests/unit/fake_api_client.py
+++ b/tests/unit/fake_api_client.py
@@ -1,6 +1,7 @@
 import copy
-import docker
 
+import docker
+from docker.constants import DEFAULT_DOCKER_API_VERSION
 from . import fake_api
 
 try:
@@ -30,7 +31,7 @@ def make_fake_api_client(overrides=None):
 
     if overrides is None:
         overrides = {}
-    api_client = docker.APIClient()
+    api_client = docker.APIClient(version=DEFAULT_DOCKER_API_VERSION)
     mock_attrs = {
         'build.return_value': fake_api.FAKE_IMAGE_ID,
         'commit.return_value': fake_api.post_fake_commit()[1],
@@ -50,6 +51,7 @@ def make_fake_api_client(overrides=None):
         'networks.return_value': fake_api.get_fake_network_list()[1],
         'start.return_value': None,
         'wait.return_value': {'StatusCode': 0},
+        'version.return_value': fake_api.get_fake_version()
     }
     mock_attrs.update(overrides)
     mock_client = CopyReturnMagicMock(**mock_attrs)
@@ -62,6 +64,6 @@ def make_fake_client(overrides=None):
     """
     Returns a Client with a fake APIClient.
     """
-    client = docker.DockerClient()
+    client = docker.DockerClient(version=DEFAULT_DOCKER_API_VERSION)
     client.api = make_fake_api_client(overrides)
     return client

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -11,7 +11,7 @@ import unittest
 import pytest
 import six
 from docker.api.client import APIClient
-from docker.constants import IS_WINDOWS_PLATFORM
+from docker.constants import IS_WINDOWS_PLATFORM, DEFAULT_DOCKER_API_VERSION
 from docker.errors import DockerException
 from docker.utils import (convert_filters, convert_volume_binds,
                           decode_json_header, kwargs_from_env, parse_bytes,
@@ -35,7 +35,7 @@ class DecoratorsTest(unittest.TestCase):
         def f(self, headers=None):
             return headers
 
-        client = APIClient()
+        client = APIClient(version=DEFAULT_DOCKER_API_VERSION)
         client._general_configs = {}
 
         g = update_headers(f)
@@ -86,6 +86,7 @@ class KwargsFromEnvTest(unittest.TestCase):
         assert kwargs['tls'].verify
 
         parsed_host = parse_host(kwargs['base_url'], IS_WINDOWS_PLATFORM, True)
+        kwargs['version'] = DEFAULT_DOCKER_API_VERSION
         try:
             client = APIClient(**kwargs)
             assert parsed_host == client.base_url
@@ -106,6 +107,7 @@ class KwargsFromEnvTest(unittest.TestCase):
         assert kwargs['tls'].assert_hostname is True
         assert kwargs['tls'].verify is False
         parsed_host = parse_host(kwargs['base_url'], IS_WINDOWS_PLATFORM, True)
+        kwargs['version'] = DEFAULT_DOCKER_API_VERSION
         try:
             client = APIClient(**kwargs)
             assert parsed_host == client.base_url


### PR DESCRIPTION
Set version to 'auto'  to avoid breaking on old engines not implementing v1.39.

Relates to https://github.com/docker/docker-py/issues/2639