### PR TITLE
ContainerCollection.run sets tag to "latest" if not set.

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -9,7 +9,7 @@ from ..errors import (
     NotFound, create_unexpected_kwargs_error
 )
 from ..types import HostConfig
-from ..utils import version_gte
+from ..utils import parse_repository_tag, version_gte
 from .images import Image
 from .resource import Collection, Model
 
@@ -541,7 +541,8 @@ class ContainerCollection(Collection):
             'Reticulating spline 1...\\nReticulating spline 2...\\n'
 
         Args:
-            image (str): The image to run.
+            image (str): The image to run. If the tag is not specified, it will
+                be set to "latest".
             command (str or list): The command to run in the container.
             auto_remove (bool): enable auto-removal of the container on daemon
                 side when the container's process exits.
@@ -788,6 +789,11 @@ class ContainerCollection(Collection):
         """
         if isinstance(image, Image):
             image = image.id
+        else:
+            _, tag = parse_repository_tag(image)
+            if tag is None:
+                image += ":latest"
+
         stream = kwargs.pop('stream', False)
         detach = kwargs.pop('detach', False)
         platform = kwargs.pop('platform', None)

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -23,7 +23,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
-        assert container.attrs['Config']['Image'] == "alpine"
+        assert container.attrs['Config']['Image'] == "alpine:latest"
         assert container.attrs['Config']['Cmd'] == ['sleep', '300']
 
     def test_run_with_error(self):
@@ -187,7 +187,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         assert client.containers.get(container.id).attrs[
-            'Config']['Image'] == "alpine"
+            'Config']['Image'] == "alpine:latest"
 
     def test_list(self):
         client = docker.from_env(version=TEST_API_VERSION)
@@ -199,7 +199,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert len(containers) == 1
 
         container = containers[0]
-        assert container.attrs['Config']['Image'] == 'alpine'
+        assert container.attrs['Config']['Image'] == 'alpine:latest'
         assert container.status == 'running'
         assert container.image == client.images.get('alpine')
 
@@ -217,7 +217,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert len(containers) == 1
 
         container = containers[0]
-        assert container.attrs['Image'] == 'alpine'
+        assert container.attrs['Image'] == 'alpine:latest'
         assert container.status == 'running'
         assert container.image == client.images.get('alpine')
         with pytest.raises(docker.errors.DockerException):


### PR DESCRIPTION
This fixes issue https://github.com/docker/docker-py/issues/2545.

The issue is when you call `client.containers.run("some-image")` and `some-image:latest` doesn't exist locally. `run` will call `ImageCollection.pull` without passing a tag:
https://github.com/docker/docker-py/blob/2b1c7eb72406bcdb4b6eb3567333a27e0eb6e1ed/docker/models/containers.py#L808-L814

Since the tag doesn't exist, `pull` will pull all tags from the repository:
https://github.com/docker/docker-py/blob/2b1c7eb72406bcdb4b6eb3567333a27e0eb6e1ed/docker/models/images.py#L398-L403

This behavior of `run` seems unintuitive since it will only run the `latest` image and the rest are not needed.

This patch only modifies `run`. I felt like it might be preferable for `pull` to mimic `docker pull`, and only pull all tags if the user explicitly asks for that with a keyword arg like `all=True`. However, the current behavior of `pull` is documented, so that would be a major breaking change.

I also considered whether `ContainerCollection.create` should append the `latest` tag if there was none, but its current behavior is also documented. Hence, only updating `run` seems like the safest approach.