### PR TITLE
Fix plugin model upgrade

### DIFF
--- a/docker/models/plugins.py
+++ b/docker/models/plugins.py
@@ -119,7 +119,7 @@ class Plugin(Model):
         privileges = self.client.api.plugin_privileges(remote)
         for d in self.client.api.upgrade_plugin(self.name, remote, privileges):
             yield d
-        self._reload()
+        self.reload()
 
 
 class PluginCollection(Collection):


### PR DESCRIPTION
When upgrading a plugin via the model interface, it would yield the
following error:

    AttributeError: 'Plugin' object has no attribute '_reload'

It appears that the proper method is `self.reload()`. This is what is
used by all other methods in the class and base. I'm not finding any
references to `_reload` apart from this instance in the project either.

I've verified that this patch fixes the issue on my machine and all
tests pass.

Signed-off-by: Ian Fijolek <ian@iamthefij.com>

Fixes #2685