### PR TITLE
Add max_pool_size parameter

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -9,9 +9,9 @@ import websocket
 
 from .. import auth
 from ..constants import (DEFAULT_NUM_POOLS, DEFAULT_NUM_POOLS_SSH,
-                         DEFAULT_TIMEOUT_SECONDS, DEFAULT_USER_AGENT,
-                         IS_WINDOWS_PLATFORM, MINIMUM_DOCKER_API_VERSION,
-                         STREAM_HEADER_SIZE_BYTES)
+                         DEFAULT_MAX_POOL_SIZE, DEFAULT_TIMEOUT_SECONDS,
+                         DEFAULT_USER_AGENT, IS_WINDOWS_PLATFORM,
+                         MINIMUM_DOCKER_API_VERSION, STREAM_HEADER_SIZE_BYTES)
 from ..errors import (DockerException, InvalidVersion, TLSParameterError,
                       create_api_error_from_http_exception)
 from ..tls import TLSConfig
@@ -103,7 +103,8 @@ class APIClient(
     def __init__(self, base_url=None, version=None,
                  timeout=DEFAULT_TIMEOUT_SECONDS, tls=False,
                  user_agent=DEFAULT_USER_AGENT, num_pools=None,
-                 credstore_env=None, use_ssh_client=False):
+                 max_pool_size=DEFAULT_MAX_POOL_SIZE, credstore_env=None,
+                 use_ssh_client=False):
         super(APIClient, self).__init__()
 
         if tls and not base_url:
@@ -139,7 +140,8 @@ class APIClient(
 
         if base_url.startswith('http+unix://'):
             self._custom_adapter = UnixHTTPAdapter(
-                base_url, timeout, pool_connections=num_pools
+                base_url, timeout, pool_connections=num_pools,
+                max_pool_size=max_pool_size
             )
             self.mount('http+docker://', self._custom_adapter)
             self._unmount('http://', 'https://')
@@ -153,7 +155,8 @@ class APIClient(
                 )
             try:
                 self._custom_adapter = NpipeHTTPAdapter(
-                    base_url, timeout, pool_connections=num_pools
+                    base_url, timeout, pool_connections=num_pools,
+                    max_pool_size=max_pool_size
                 )
             except NameError:
                 raise DockerException(
@@ -165,7 +168,7 @@ class APIClient(
             try:
                 self._custom_adapter = SSHHTTPAdapter(
                     base_url, timeout, pool_connections=num_pools,
-                    shell_out=use_ssh_client
+                    max_pool_size=max_pool_size, shell_out=use_ssh_client
                 )
             except NameError:
                 raise DockerException(

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -92,6 +92,8 @@ class APIClient(
         use_ssh_client (bool): If set to `True`, an ssh connection is made
             via shelling out to the ssh client. Ensure the ssh client is
             installed and configured on the host.
+        max_pool_size (int): The maximum number of connections
+            to save in the pool.
     """
 
     __attrs__ = requests.Session.__attrs__ + ['_auth_configs',
@@ -103,8 +105,8 @@ class APIClient(
     def __init__(self, base_url=None, version=None,
                  timeout=DEFAULT_TIMEOUT_SECONDS, tls=False,
                  user_agent=DEFAULT_USER_AGENT, num_pools=None,
-                 max_pool_size=DEFAULT_MAX_POOL_SIZE, credstore_env=None,
-                 use_ssh_client=False):
+                 credstore_env=None, use_ssh_client=False,
+                 max_pool_size=DEFAULT_MAX_POOL_SIZE):
         super(APIClient, self).__init__()
 
         if tls and not base_url:

--- a/docker/client.py
+++ b/docker/client.py
@@ -1,5 +1,5 @@
 from .api.client import APIClient
-from .constants import DEFAULT_TIMEOUT_SECONDS
+from .constants import (DEFAULT_TIMEOUT_SECONDS, DEFAULT_MAX_POOL_SIZE)
 from .models.configs import ConfigCollection
 from .models.containers import ContainerCollection
 from .models.images import ImageCollection
@@ -28,6 +28,8 @@ class DockerClient(object):
         version (str): The version of the API to use. Set to ``auto`` to
             automatically detect the server's version. Default: ``1.35``
         timeout (int): Default timeout for API calls, in seconds.
+        max_pool_size (int): The maximum number of connections
+            to save in the pool.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a
             :py:class:`~docker.tls.TLSConfig` object to use custom
@@ -67,6 +69,8 @@ class DockerClient(object):
             version (str): The version of the API to use. Set to ``auto`` to
                 automatically detect the server's version. Default: ``auto``
             timeout (int): Default timeout for API calls, in seconds.
+            max_pool_size (int): The maximum number of connections
+                to save in the pool.
             ssl_version (int): A valid `SSL version`_.
             assert_hostname (bool): Verify the hostname of the server.
             environment (dict): The environment to read environment variables
@@ -86,10 +90,12 @@ class DockerClient(object):
             https://docs.python.org/3.5/library/ssl.html#ssl.PROTOCOL_TLSv1
         """
         timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT_SECONDS)
+        max_pool_size = kwargs.pop('max_pool_size', DEFAULT_MAX_POOL_SIZE)
         version = kwargs.pop('version', None)
         use_ssh_client = kwargs.pop('use_ssh_client', False)
         return cls(
             timeout=timeout,
+            max_pool_size=max_pool_size,
             version=version,
             use_ssh_client=use_ssh_client,
             **kwargs_from_env(**kwargs)

--- a/docker/client.py
+++ b/docker/client.py
@@ -28,8 +28,6 @@ class DockerClient(object):
         version (str): The version of the API to use. Set to ``auto`` to
             automatically detect the server's version. Default: ``1.35``
         timeout (int): Default timeout for API calls, in seconds.
-        max_pool_size (int): The maximum number of connections
-            to save in the pool.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a
             :py:class:`~docker.tls.TLSConfig` object to use custom
@@ -40,6 +38,8 @@ class DockerClient(object):
         use_ssh_client (bool): If set to `True`, an ssh connection is made
             via shelling out to the ssh client. Ensure the ssh client is
             installed and configured on the host.
+        max_pool_size (int): The maximum number of connections
+            to save in the pool.
     """
     def __init__(self, *args, **kwargs):
         self.api = APIClient(*args, **kwargs)

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -36,6 +36,8 @@ DEFAULT_NUM_POOLS = 25
 # For more details see: https://github.com/docker/docker-py/issues/2246
 DEFAULT_NUM_POOLS_SSH = 9
 
+DEFAULT_MAX_POOL_SIZE = 10
+
 DEFAULT_DATA_CHUNK_SIZE = 1024 * 2048
 
 DEFAULT_SWARM_ADDR_POOL = ['10.0.0.0/8']

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -73,12 +73,15 @@ class NpipeHTTPAdapter(BaseHTTPAdapter):
 
     __attrs__ = requests.adapters.HTTPAdapter.__attrs__ + ['npipe_path',
                                                            'pools',
-                                                           'timeout']
+                                                           'timeout',
+                                                           'max_pool_size']
 
     def __init__(self, base_url, timeout=60,
-                 pool_connections=constants.DEFAULT_NUM_POOLS):
+                 pool_connections=constants.DEFAULT_NUM_POOLS,
+                 max_pool_size=constants.DEFAULT_MAX_POOL_SIZE):
         self.npipe_path = base_url.replace('npipe://', '')
         self.timeout = timeout
+        self.max_pool_size = max_pool_size
         self.pools = RecentlyUsedContainer(
             pool_connections, dispose_func=lambda p: p.close()
         )
@@ -91,7 +94,8 @@ class NpipeHTTPAdapter(BaseHTTPAdapter):
                 return pool
 
             pool = NpipeHTTPConnectionPool(
-                self.npipe_path, self.timeout
+                self.npipe_path, self.timeout,
+                maxsize=self.max_pool_size
             )
             self.pools[url] = pool
 

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -184,11 +184,12 @@ class SSHConnectionPool(urllib3.connectionpool.HTTPConnectionPool):
 class SSHHTTPAdapter(BaseHTTPAdapter):
 
     __attrs__ = requests.adapters.HTTPAdapter.__attrs__ + [
-        'pools', 'timeout', 'ssh_client', 'ssh_params'
+        'pools', 'timeout', 'ssh_client', 'ssh_params', 'max_pool_size'
     ]
 
     def __init__(self, base_url, timeout=60,
                  pool_connections=constants.DEFAULT_NUM_POOLS,
+                 max_pool_size=constants.DEFAULT_MAX_POOL_SIZE,
                  shell_out=True):
         self.ssh_client = None
         if not shell_out:
@@ -197,6 +198,7 @@ class SSHHTTPAdapter(BaseHTTPAdapter):
         base_url = base_url.lstrip('ssh://')
         self.host = base_url
         self.timeout = timeout
+        self.max_pool_size = max_pool_size
         self.pools = RecentlyUsedContainer(
             pool_connections, dispose_func=lambda p: p.close()
         )
@@ -219,6 +221,7 @@ class SSHHTTPAdapter(BaseHTTPAdapter):
             pool = SSHConnectionPool(
                 ssh_client=self.ssh_client,
                 timeout=self.timeout,
+                maxsize=self.max_pool_size,
                 host=self.host
             )
             self.pools[url] = pool

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -74,15 +74,18 @@ class UnixHTTPAdapter(BaseHTTPAdapter):
 
     __attrs__ = requests.adapters.HTTPAdapter.__attrs__ + ['pools',
                                                            'socket_path',
-                                                           'timeout']
+                                                           'timeout',
+                                                           'max_pool_size']
 
     def __init__(self, socket_url, timeout=60,
-                 pool_connections=constants.DEFAULT_NUM_POOLS):
+                 pool_connections=constants.DEFAULT_NUM_POOLS,
+                 max_pool_size=constants.DEFAULT_MAX_POOL_SIZE):
         socket_path = socket_url.replace('http+unix://', '')
         if not socket_path.startswith('/'):
             socket_path = '/' + socket_path
         self.socket_path = socket_path
         self.timeout = timeout
+        self.max_pool_size = max_pool_size
         self.pools = RecentlyUsedContainer(
             pool_connections, dispose_func=lambda p: p.close()
         )
@@ -95,7 +98,8 @@ class UnixHTTPAdapter(BaseHTTPAdapter):
                 return pool
 
             pool = UnixHTTPConnectionPool(
-                url, self.socket_path, self.timeout
+                url, self.socket_path, self.timeout,
+                maxsize=self.max_pool_size
             )
             self.pools[url] = pool
 

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -83,7 +83,9 @@ class ClientTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
     def test_default_pool_size_unix(self, mock_obj):
-        client = docker.DockerClient()
+        client = docker.DockerClient(
+            version=DEFAULT_DOCKER_API_VERSION
+        )
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -103,7 +105,9 @@ class ClientTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
     def test_default_pool_size_win(self, mock_obj):
-        client = docker.DockerClient()
+        client = docker.DockerClient(
+            version=DEFAULT_DOCKER_API_VERSION
+        )
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -117,7 +121,10 @@ class ClientTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
     def test_pool_size_unix(self, mock_obj):
-        client = docker.DockerClient(max_pool_size=POOL_SIZE)
+        client = docker.DockerClient(
+            version=DEFAULT_DOCKER_API_VERSION,
+            max_pool_size=POOL_SIZE
+        )
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -137,7 +144,10 @@ class ClientTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
     def test_pool_size_win(self, mock_obj):
-        client = docker.DockerClient(max_pool_size=POOL_SIZE)
+        client = docker.DockerClient(
+            version=DEFAULT_DOCKER_API_VERSION,
+            max_pool_size=POOL_SIZE
+        )
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -188,7 +198,7 @@ class FromEnvTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
     def test_default_pool_size_from_env_unix(self, mock_obj):
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -208,7 +218,7 @@ class FromEnvTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
     def test_default_pool_size_from_env_win(self, mock_obj):
-        client = docker.from_env()
+        client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -222,7 +232,10 @@ class FromEnvTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
     def test_pool_size_from_env_unix(self, mock_obj):
-        client = docker.from_env(max_pool_size=POOL_SIZE)
+        client = docker.from_env(
+            version=DEFAULT_DOCKER_API_VERSION,
+            max_pool_size=POOL_SIZE
+        )
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 
@@ -242,7 +255,10 @@ class FromEnvTest(unittest.TestCase):
     )
     @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
     def test_pool_size_from_env_win(self, mock_obj):
-        client = docker.from_env(max_pool_size=POOL_SIZE)
+        client = docker.from_env(
+            version=DEFAULT_DOCKER_API_VERSION,
+            max_pool_size=POOL_SIZE
+        )
         mock_obj.return_value.urlopen.return_value.status = 200
         client.ping()
 

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -5,7 +5,9 @@ import unittest
 import docker
 import pytest
 from docker.constants import (
-        DEFAULT_DOCKER_API_VERSION, DEFAULT_TIMEOUT_SECONDS)
+    DEFAULT_DOCKER_API_VERSION, DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_MAX_POOL_SIZE, IS_WINDOWS_PLATFORM
+)
 from docker.utils import kwargs_from_env
 
 from . import fake_api
@@ -15,8 +17,8 @@ try:
 except ImportError:
     import mock
 
-
 TEST_CERT_DIR = os.path.join(os.path.dirname(__file__), 'testdata/certs')
+POOL_SIZE = 20
 
 
 class ClientTest(unittest.TestCase):
@@ -76,6 +78,74 @@ class ClientTest(unittest.TestCase):
         assert "'ContainerCollection' object is not callable" in s
         assert "docker.APIClient" in s
 
+    @pytest.mark.skipif(
+        IS_WINDOWS_PLATFORM, reason='Unix Connection Pool only on Linux'
+    )
+    @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
+    def test_default_pool_size_unix(self, mock_obj):
+        client = docker.DockerClient()
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        base_url = "{base_url}/v{version}/_ping".format(
+            base_url=client.api.base_url,
+            version=client.api._version
+        )
+
+        mock_obj.assert_called_once_with(base_url,
+                                         "/var/run/docker.sock",
+                                         60,
+                                         maxsize=DEFAULT_MAX_POOL_SIZE
+                                         )
+
+    @pytest.mark.skipif(
+        not IS_WINDOWS_PLATFORM, reason='Npipe Connection Pool only on Windows'
+    )
+    @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
+    def test_default_pool_size_win(self, mock_obj):
+        client = docker.DockerClient()
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        mock_obj.assert_called_once_with("//./pipe/docker_engine",
+                                         60,
+                                         maxsize=DEFAULT_MAX_POOL_SIZE
+                                         )
+
+    @pytest.mark.skipif(
+        IS_WINDOWS_PLATFORM, reason='Unix Connection Pool only on Linux'
+    )
+    @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
+    def test_pool_size_unix(self, mock_obj):
+        client = docker.DockerClient(max_pool_size=POOL_SIZE)
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        base_url = "{base_url}/v{version}/_ping".format(
+            base_url=client.api.base_url,
+            version=client.api._version
+        )
+
+        mock_obj.assert_called_once_with(base_url,
+                                         "/var/run/docker.sock",
+                                         60,
+                                         maxsize=POOL_SIZE
+                                         )
+
+    @pytest.mark.skipif(
+        not IS_WINDOWS_PLATFORM, reason='Npipe Connection Pool only on Windows'
+    )
+    @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
+    def test_pool_size_win(self, mock_obj):
+        client = docker.DockerClient(max_pool_size=POOL_SIZE)
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        mock_obj.assert_called_once_with("//./pipe/docker_engine",
+                                         60,
+                                         maxsize=POOL_SIZE
+                                         )
+
 
 class FromEnvTest(unittest.TestCase):
 
@@ -112,3 +182,71 @@ class FromEnvTest(unittest.TestCase):
         client = docker.from_env(version=DEFAULT_DOCKER_API_VERSION)
 
         assert client.api.timeout == DEFAULT_TIMEOUT_SECONDS
+
+    @pytest.mark.skipif(
+        IS_WINDOWS_PLATFORM, reason='Unix Connection Pool only on Linux'
+    )
+    @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
+    def test_default_pool_size_from_env_unix(self, mock_obj):
+        client = docker.from_env()
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        base_url = "{base_url}/v{version}/_ping".format(
+            base_url=client.api.base_url,
+            version=client.api._version
+        )
+
+        mock_obj.assert_called_once_with(base_url,
+                                         "/var/run/docker.sock",
+                                         60,
+                                         maxsize=DEFAULT_MAX_POOL_SIZE
+                                         )
+
+    @pytest.mark.skipif(
+        not IS_WINDOWS_PLATFORM, reason='Npipe Connection Pool only on Windows'
+    )
+    @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
+    def test_default_pool_size_from_env_win(self, mock_obj):
+        client = docker.from_env()
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        mock_obj.assert_called_once_with("//./pipe/docker_engine",
+                                         60,
+                                         maxsize=DEFAULT_MAX_POOL_SIZE
+                                         )
+
+    @pytest.mark.skipif(
+        IS_WINDOWS_PLATFORM, reason='Unix Connection Pool only on Linux'
+    )
+    @mock.patch("docker.transport.unixconn.UnixHTTPConnectionPool")
+    def test_pool_size_from_env_unix(self, mock_obj):
+        client = docker.from_env(max_pool_size=POOL_SIZE)
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        base_url = "{base_url}/v{version}/_ping".format(
+            base_url=client.api.base_url,
+            version=client.api._version
+        )
+
+        mock_obj.assert_called_once_with(base_url,
+                                         "/var/run/docker.sock",
+                                         60,
+                                         maxsize=POOL_SIZE
+                                         )
+
+    @pytest.mark.skipif(
+        not IS_WINDOWS_PLATFORM, reason='Npipe Connection Pool only on Windows'
+    )
+    @mock.patch("docker.transport.npipeconn.NpipeHTTPConnectionPool")
+    def test_pool_size_from_env_win(self, mock_obj):
+        client = docker.from_env(max_pool_size=POOL_SIZE)
+        mock_obj.return_value.urlopen.return_value.status = 200
+        client.ping()
+
+        mock_obj.assert_called_once_with("//./pipe/docker_engine",
+                                         60,
+                                         maxsize=POOL_SIZE
+                                         )


### PR DESCRIPTION
All the connection pools (UNIX socket/NPipe and SSH) are limited to a pool of 10 threads. This value is hardcoded in the Python code, so it can't be changed.

This pull request adds a `max_pool_size` parameter in the Client that makes able to tweak the number of thread for each connection pool used by the library. Of couse, by default this value is set to 10.

This feature was requested in #2477. We already opened a PR 1 year ago but we had some problems with the commits signatures.