### PR TITLE
Fix docs typo and `port_bindings` check

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -683,7 +683,7 @@ class ContainerCollection(Collection):
                   to a single container port. For example,
                   ``{'1111/tcp': [1234, 4567]}``.
 
-                Imcompatible with ``host`` in ``network_mode``.
+                Incompatible with ``host`` network mode.
             privileged (bool): Give extended privileges to this container.
             publish_all_ports (bool): Publish all ports to the host.
             read_only (bool): Mount the container's root filesystem as read

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -334,7 +334,7 @@ class HostConfig(dict):
         if dns_search:
             self['DnsSearch'] = dns_search
 
-        if network_mode is 'host' and port_bindings is not None:
+        if network_mode is 'host' and port_bindings:
             raise host_config_incompatible_error(
                 'network_mode', 'host', 'port_bindings'
             )
@@ -670,7 +670,7 @@ def host_config_value_error(param, param_value):
 
 
 def host_config_incompatible_error(param, param_value, incompatible_param):
-    error_msg = 'Incompatible {1} in {0} is not compatible with {2}'
+    error_msg = '\"{1}\" {0} is incompatible with {2}'
     return errors.InvalidArgument(
         error_msg.format(param, param_value, incompatible_param)
     )


### PR DESCRIPTION
We should not raise an error for `port_bindings={}` in `host` network mode (use case in docker-compose).