### PR TITLE
Fix condition to avoid syntax warning

### DIFF
--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -334,15 +334,11 @@ class HostConfig(dict):
         if dns_search:
             self['DnsSearch'] = dns_search
 
-        if network_mode is 'host' and port_bindings:
+        if network_mode == 'host' and port_bindings:
             raise host_config_incompatible_error(
                 'network_mode', 'host', 'port_bindings'
             )
-
-        if network_mode:
-            self['NetworkMode'] = network_mode
-        elif network_mode is None:
-            self['NetworkMode'] = 'default'
+        self['NetworkMode'] = network_mode or 'default'
 
         if restart_policy:
             if not isinstance(restart_policy, dict):


### PR DESCRIPTION
Small fix for
```
docker-py/docker/types/containers.py:337: SyntaxWarning: "is" with a literal. Did you mean "=="?
```