### PR TITLE
docker/api/image: replace use of deprecated "filter" argument

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -81,10 +81,18 @@ class ImageApiMixin(object):
                 If the server returns an error.
         """
         params = {
-            'filter': name,
             'only_ids': 1 if quiet else 0,
             'all': 1 if all else 0,
         }
+        if name:
+            if utils.version_lt(self._version, '1.25'):
+                # only use "filter" on API 1.24 and under, as it is deprecated
+                params['filter'] = name
+            else:
+                if filters:
+                    filters['reference'] = name
+                else:
+                    filters = {'reference': name}
         if filters:
             params['filters'] = utils.convert_filters(filters)
         res = self._result(self._get(self._url("/images/json"), params=params),

--- a/tests/unit/api_image_test.py
+++ b/tests/unit/api_image_test.py
@@ -26,7 +26,18 @@ class ImageTest(BaseAPIClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'images/json',
-            params={'filter': None, 'only_ids': 0, 'all': 1},
+            params={'only_ids': 0, 'all': 1},
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
+    def test_images_name(self):
+        self.client.images('foo:bar')
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'images/json',
+            params={'only_ids': 0, 'all': 0,
+                    'filters': '{"reference": ["foo:bar"]}'},
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
@@ -36,7 +47,7 @@ class ImageTest(BaseAPIClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'images/json',
-            params={'filter': None, 'only_ids': 1, 'all': 1},
+            params={'only_ids': 1, 'all': 1},
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
@@ -46,7 +57,7 @@ class ImageTest(BaseAPIClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'images/json',
-            params={'filter': None, 'only_ids': 1, 'all': 0},
+            params={'only_ids': 1, 'all': 0},
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
@@ -56,7 +67,7 @@ class ImageTest(BaseAPIClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'images/json',
-            params={'filter': None, 'only_ids': 0, 'all': 0,
+            params={'only_ids': 0, 'all': 0,
                     'filters': '{"dangling": ["true"]}'},
             timeout=DEFAULT_TIMEOUT_SECONDS
         )


### PR DESCRIPTION
relates to the failures seen in https://github.com/moby/moby/pull/41709#issuecomment-732789163

The "filter" argument was deprecated in docker 1.13 (API version 1.25), and removed from API v1.41 and up. See https://github.com/docker/cli/blob/v20.10.0-rc1/docs/deprecated.md#filter-param-for-imagesjson-endpoint

This patch applies the name as "reference" filter, instead of "filter" for API 1.25 and up.
