### PR TITLE
Add optional parameters for pruning build cache.

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -275,9 +275,15 @@ class BuildApiMixin(object):
         return self._stream_helper(response, decode=decode)
 
     @utils.minimum_version('1.31')
-    def prune_builds(self):
+    def prune_builds(self, prune_all=False, keep_storage=None, filters=None):
         """
         Delete the builder cache
+
+        Args:
+            prune_all (bool): Remove all unused build cache, not just dangling
+                ones.
+            keep_storage (int): Amount of disk space to keep for cache.
+            filters (dict): Filters to process on the prune list.
 
         Returns:
             (dict): A dictionary containing information about the operation's
@@ -288,8 +294,13 @@ class BuildApiMixin(object):
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
         """
+        params = {'all': prune_all}
+        if keep_storage is not None:
+            params['keep-storage'] = keep_storage
+        if filters is not None:
+            params['filters'] = utils.convert_filters(filters)
         url = self._url("/build/prune")
-        return self._result(self._post(url), True)
+        return self._result(self._post(url, params=params), True)
 
     def _set_auth_headers(self, headers):
         log.debug('Looking for auth config')

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -593,3 +593,20 @@ class BuildTest(BaseAPIIntegrationTest):
         prune_result = self.client.prune_builds()
         assert 'SpaceReclaimed' in prune_result
         assert isinstance(prune_result['SpaceReclaimed'], int)
+
+    @requires_api_version('1.31')
+    @pytest.mark.xfail(
+        True,
+        reason='Currently fails on 18.09: '
+               'https://github.com/moby/moby/issues/37920'
+    )
+    def test_prune_builds_all(self):
+        prune_result = self.client.prune_builds(prune_all=True)
+        assert 'SpaceReclaimed' in prune_result
+        assert isinstance(prune_result['SpaceReclaimed'], int)
+
+    @requires_api_version('1.31')
+    def test_prune_builds_keep_storage(self):
+        prune_result = self.client.prune_builds(keep_storage=1)
+        assert 'SpaceReclaimed' in prune_result
+        assert isinstance(prune_result['SpaceReclaimed'], int)


### PR DESCRIPTION
The [API for cleaning the build cache](https://docs.docker.com/engine/api/v1.40/#operation/ImageBuild) supports optional parameters:
* `keep-storage`
* `all`
* `filters`

This PR exposes those arguments in docker-py

`make test` passed on my local development box, and I tried to add test coverage as best I could.
`make flake8` also passed.
Signed-off-by: Steve Swor <sworisbreathing@users.noreply.github.com>