### PR TITLE
Fix doc formatting

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -497,7 +497,7 @@ class APIClient(
         Args:
             dockercfg_path (str): Use a custom path for the Docker config file
                 (default ``$HOME/.docker/config.json`` if present,
-                otherwise``$HOME/.dockercfg``)
+                otherwise ``$HOME/.dockercfg``)
 
         Returns:
             None

--- a/docker/api/daemon.py
+++ b/docker/api/daemon.py
@@ -109,7 +109,7 @@ class DaemonApiMixin(object):
                 the Docker server.
             dockercfg_path (str): Use a custom path for the Docker config file
                 (default ``$HOME/.docker/config.json`` if present,
-                otherwise``$HOME/.dockercfg``)
+                otherwise ``$HOME/.dockercfg``)
 
         Returns:
             (dict): The response from the login request


### PR DESCRIPTION
A space is required before `` for it to be recognised.