### PR TITLE
Avoid setting unsupported parameter for subprocess.Popen on Windows

### DIFF
--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -42,12 +42,17 @@ class SSHSocket(socket.socket):
             port,
             'docker system dial-stdio'
         ]
+
+        preexec_func = None
+        if not constants.IS_WINDOWS_PLATFORM:
+            preexec_func = lambda: signal.signal(signal.SIGINT, signal.SIG_IGN))
+
         self.proc = subprocess.Popen(
             ' '.join(args),
             shell=True,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
-            preexec_fn=lambda: signal.signal(signal.SIGINT, signal.SIG_IGN))
+            preexec_fn=preexec_func)
 
     def _write(self, data):
         if not self.proc or self.proc.stdin.closed:


### PR DESCRIPTION

Fixes https://github.com/docker/docker-py/issues/2723

Signed-off-by: aiordache <anca.iordache@docker.com>