### PR TITLE
fix(dockerignore): trim trailing whitespace

### DIFF
--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -231,6 +231,9 @@ class Pattern(object):
     @classmethod
     def normalize(cls, p):
 
+        # Remove trailing spaces
+        p = p.strip()
+
         # Leading and trailing slashes are not relevant. Yes,
         # "foo.py/" must exclude the "foo.py" regular file. "."
         # components are not relevant either, even if the whole

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -103,7 +103,9 @@ class BuildTest(BaseAPIIntegrationTest):
                 'ignored',
                 'Dockerfile',
                 '.dockerignore',
+                ' ignored-with-spaces ',  # check that spaces are trimmed
                 '!ignored/subdir/excepted-file',
+                '! ignored/subdir/excepted-with-spaces '
                 '',  # empty line,
                 '#*',  # comment line
             ]))
@@ -114,12 +116,18 @@ class BuildTest(BaseAPIIntegrationTest):
         with open(os.path.join(base_dir, '#file.txt'), 'w') as f:
             f.write('this file should not be ignored')
 
+        with open(os.path.join(base_dir, 'ignored-with-spaces'), 'w') as f:
+            f.write("this file should be ignored")
+
         subdir = os.path.join(base_dir, 'ignored', 'subdir')
         os.makedirs(subdir)
         with open(os.path.join(subdir, 'file'), 'w') as f:
             f.write("this file should be ignored")
 
         with open(os.path.join(subdir, 'excepted-file'), 'w') as f:
+            f.write("this file should not be ignored")
+
+        with open(os.path.join(subdir, 'excepted-with-spaces'), 'w') as f:
             f.write("this file should not be ignored")
 
         tag = 'docker-py-test-build-with-dockerignore'
@@ -140,6 +148,7 @@ class BuildTest(BaseAPIIntegrationTest):
 
         assert sorted(list(filter(None, logs.split('\n')))) == sorted([
             '/test/#file.txt',
+            '/test/ignored/subdir/excepted-with-spaces',
             '/test/ignored/subdir/excepted-file',
             '/test/not-ignored'
         ])

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -105,7 +105,7 @@ class BuildTest(BaseAPIIntegrationTest):
                 '.dockerignore',
                 ' ignored-with-spaces ',  # check that spaces are trimmed
                 '!ignored/subdir/excepted-file',
-                '! ignored/subdir/excepted-with-spaces '
+                '! ignored/subdir/excepted-with-spaces  '
                 '',  # empty line,
                 '#*',  # comment line
             ]))


### PR DESCRIPTION
Remove the trailing whitespaces in dockerignore files, allowing the following structure to be conform to the official `docker` build.
```
*
! files
! src
```

fixes https://github.com/docker/docker-py/issues/2732