### PR TITLE
docs: fix simple typo, containe -> container

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -421,7 +421,7 @@ class UpdateConfig(dict):
 
 class RollbackConfig(UpdateConfig):
     """
-    Used to specify the way containe rollbacks should be performed by a service
+    Used to specify the way container rollbacks should be performed by a service
 
     Args:
         parallelism (int): Maximum number of tasks to be rolled back in one


### PR DESCRIPTION
There is a small typo in docker/types/services.py.

Should read `container` rather than `containe`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md