### PR TITLE
Revert back to wrappedNode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ def buildImage = { name, buildargs, pyTag ->
 }
 
 def buildImages = { ->
-  node("amd64 && ubuntu-2004 && overlay2") {
+  wrappedNode(label: "amd64 && ubuntu-2004 && overlay2", cleanWorkspace: true) {
     stage("build image") {
       checkout(scm)
 
@@ -36,7 +36,7 @@ def buildImages = { ->
 
 def getDockerVersions = { ->
   def dockerVersions = ["19.03.12"]
-  node("amd64 && ubuntu-2004 && overlay2") {
+  wrappedNode(label: "amd64 && ubuntu-2004 && overlay2") {
     def result = sh(script: """docker run --rm \\
         --entrypoint=python \\
         ${imageNamePy3} \\
@@ -77,7 +77,7 @@ def runTests = { Map settings ->
   }
 
   { ->
-    node("amd64 && ubuntu-2004 && overlay2") {
+    wrappedNode(label: "amd64 && ubuntu-2004 && overlay2", cleanWorkspace: true) {
       stage("test python=${pythonVersion} / docker=${dockerVersion}") {
         checkout(scm)
         def dindContainerName = "dpy-dind-\$BUILD_NUMBER-\$EXECUTOR_NUMBER-${pythonVersion}-${dockerVersion}"


### PR DESCRIPTION
Revert #2761 to fix the `getDockerVersions` call in the pipeline. We saw the "is directory" error without it as well.

