### PR TITLE
Use DOCKER_CONFIG to have creds in dind environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ def runTests = { Map settings ->
               -e 'DOCKER_TEST_API_VERSION=${apiVersion}' \\
               --network ${testNetwork} \\
               --volumes-from ${dindContainerName} \\
-              -v ~/.docker/config.json:/root/.docker/config.json \\
+              -v $DOCKER_CONFIG/config.json:/root/.docker/config.json \\
               ${testImage} \\
               py.test -v -rxs --cov=docker --ignore=tests/ssh tests/
             """
@@ -111,7 +111,7 @@ def runTests = { Map settings ->
               -e 'DOCKER_TEST_API_VERSION=${apiVersion}' \\
               --network ${testNetwork} \\
               --volumes-from ${dindContainerName} \\
-              -v ~/.docker/config.json:/root/.docker/config.json \\
+              -v $DOCKER_CONFIG/config.json:/root/.docker/config.json \\
               ${testImage} \\
               py.test -v -rxs --cov=docker tests/ssh
             """


### PR DESCRIPTION
We tried to mount the docker creds into the dind environment, but Jenkins doesn't put it in `~/.docker/config.json` on the host, but in `$DOCKER_CONFIG` environment variable. So use the variable instead to keep the machines in a sane state.
We otherwise accidentally created a folder `~/.docker/config.json/` which then breaks any `wrappedNode` and `withDockerRegistry` steps.

