### PR TITLE
Drop LD_LIBRARY_PATH env var for SSH shellout

### DIFF
--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -53,9 +53,15 @@ class SSHSocket(socket.socket):
                 signal.signal(signal.SIGINT, signal.SIG_IGN)
             preexec_func = f
 
+        env = dict(os.environ) 
+
+        # drop LD_LIBRARY_PATH and SSL_CERT_FILE
+        env.pop('LD_LIBRARY_PATH', None)
+        env.pop('SSL_CERT_FILE', None)
+
         self.proc = subprocess.Popen(
             ' '.join(args),
-            env=os.environ,
+            env=env,
             shell=True,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,


### PR DESCRIPTION
Issue https://github.com/docker/compose/issues/7686 reports an openssl mismatch error when shelling out to the ssh client in docker-compose. The root cause seems to be pyinstaller setting the LD_LIBRARY_PATH which is inherited on the shell out to ssh. 