### PR TITLE
relax PORT_SPEC regex so it accept and ignore square brackets

### DIFF
--- a/docker/utils/ports.py
+++ b/docker/utils/ports.py
@@ -3,7 +3,7 @@ import re
 PORT_SPEC = re.compile(
     "^"  # Match full string
     "("  # External part
-    r"((?P<host>[a-fA-F\d.:]+):)?"  # Address
+    r"(\[?(?P<host>[a-fA-F\d.:]+)\]?:)?"  # Address
     r"(?P<ext>[\d]*)(-(?P<ext_end>[\d]+))?:"  # External range
     ")?"
     r"(?P<int>[\d]+)(-(?P<int_end>[\d]+))?"  # Internal range

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -541,6 +541,12 @@ class PortsTest(unittest.TestCase):
         assert internal_port == ["2000"]
         assert external_port == [("2001:abcd:ef00::2", "1000")]
 
+    def test_split_port_with_ipv6_square_brackets_address(self):
+        internal_port, external_port = split_port(
+            "[2001:abcd:ef00::2]:1000:2000")
+        assert internal_port == ["2000"]
+        assert external_port == [("2001:abcd:ef00::2", "1000")]
+
     def test_split_port_invalid(self):
         with pytest.raises(ValueError):
             split_port("0.0.0.0:1000:2000:tcp")


### PR DESCRIPTION
this is the sibling for https://github.com/docker/go-connections/pull/78