### PR TITLE
Upgrade cryptography library to version 3.4.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 asn1crypto==0.22.0
 backports.ssl-match-hostname==3.5.0.1
 cffi==1.14.4
-cryptography==3.2
+cryptography==3.4.7
 enum34==1.1.6
 idna==2.5
 ipaddress==1.0.18

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
     # https://github.com/pypa/pip/issues/4391).  Once that's fixed, instead of
     # installing the extra dependencies, install the following instead:
     # 'requests[security] >= 2.5.2, != 2.11.0, != 2.12.2'
-    'tls': ['pyOpenSSL>=17.5.0', 'cryptography>=1.3.4', 'idna>=2.0.0'],
+    'tls': ['pyOpenSSL>=17.5.0', 'cryptography>=3.4.7', 'idna>=2.0.0'],
 
     # Only required when connecting using the ssh:// protocol
     'ssh': ['paramiko>=2.4.2'],


### PR DESCRIPTION
Dependabot opened a pull request
93bcc0497d8302aa2d78bd7ef756fc2ff3fd0912 to upgrade cryptography from
2.3 to 3.2.

However, only `requirements.txt` was updated.
The extra requirements were kept outdated.

This commit was made to update the library to the last version.

Fix #2791