### PR TITLE
Fix images low-level documentation examples

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -31,7 +31,7 @@ class ImageApiMixin(object):
 
         Example:
 
-            >>> image = cli.get_image("busybox:latest")
+            >>> image = client.api.get_image("busybox:latest")
             >>> f = open('/tmp/busybox-latest.tar', 'wb')
             >>> for chunk in image:
             >>>   f.write(chunk)
@@ -379,7 +379,7 @@ class ImageApiMixin(object):
 
         Example:
 
-            >>> for line in cli.pull('busybox', stream=True, decode=True):
+            >>> for line in client.api.pull('busybox', stream=True, decode=True):
             ...     print(json.dumps(line, indent=4))
             {
                 "status": "Pulling image (latest) from busybox",
@@ -458,7 +458,7 @@ class ImageApiMixin(object):
                 If the server returns an error.
 
         Example:
-            >>> for line in cli.push('yourname/app', stream=True, decode=True):
+            >>> for line in client.api.push('yourname/app', stream=True, decode=True):
             ...   print(line)
             {'status': 'Pushing repository yourname/app (1 tags)'}
             {'status': 'Pushing','progressDetail': {}, 'id': '511136ea3c5a'}
@@ -549,7 +549,7 @@ class ImageApiMixin(object):
 
         Example:
 
-            >>> client.tag('ubuntu', 'localhost:5000/ubuntu', 'latest',
+            >>> client.api.tag('ubuntu', 'localhost:5000/ubuntu', 'latest',
                            force=True)
         """
         params = {


### PR DESCRIPTION
I realize that the documentation of low-level `images` was outdated when
answering issue #2798.

The issue can reproduce it with a simple test:

```py
In [1]: import docker
In [2]: client = docker.from_env()
In [3]: client.pull
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-d0931943ca5d> in <module>
----> 1 client.pull

~/docker-py/docker/client.py in __getattr__(self, name)
    219                      "object APIClient. See the low-level API section of the "
    220                      "documentation for more details.")
--> 221         raise AttributeError(' '.join(s))
    222
    223

AttributeError: 'DockerClient' object has no attribute 'pull' In Docker SDK for Python 2.0, this method is now on the object APIClient. See the low-level API section of the documentation for more details.

In [4]: client.push
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-f7d5b860a184> in <module>
----> 1 client.push

~/docker-py/docker/client.py in __getattr__(self, name)
    219                      "object APIClient. See the low-level API section of the "
    220                      "documentation for more details.")
--> 221         raise AttributeError(' '.join(s))
    222
    223

AttributeError: 'DockerClient' object has no attribute 'push' In Docker SDK for Python 2.0, this method is now on the object APIClient. See the low-level API section of the documentation for more details.

In [5]: client.tag
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-043bdfd088ca> in <module>
----> 1 client.tag

~/docker-py/docker/client.py in __getattr__(self, name)
    219                      "object APIClient. See the low-level API section of the "
    220                      "documentation for more details.")
--> 221         raise AttributeError(' '.join(s))
    222
    223

AttributeError: 'DockerClient' object has no attribute 'tag' In Docker SDK for Python 2.0, this method is now on the object APIClient. See the low-level API section of the documentation for more details.

In [6]: client.get_image
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-6-477c12713276> in <module>
----> 1 client.get_image

~/docker-py/docker/client.py in __getattr__(self, name)
    219                      "object APIClient. See the low-level API section of the "
    220                      "documentation for more details.")
--> 221         raise AttributeError(' '.join(s))
    222
    223

AttributeError: 'DockerClient' object has no attribute 'get_image' In Docker SDK for Python 2.0, this method is now on the object APIClient. See the low-level API section of the documentation for more details.

In [7]: client.api.get_image
Out[7]: <bound method ImageApiMixin.get_image of <docker.api.client.APIClient object at 0x7fad6a2037c0>>

In [8]: client.api.tag
Out[8]: <bound method ImageApiMixin.tag of <docker.api.client.APIClient object at 0x7fad6a2037c0>>

In [9]: client.api.pull
Out[9]: <bound method ImageApiMixin.pull of <docker.api.client.APIClient object at 0x7fad6a2037c0>>

In [10]: client.api.push
Out[10]: <bound method ImageApiMixin.push of <docker.api.client.APIClient object at 0x7fad6a2037c0>>
```

Signed-off-by: Felipe Ruhland <felipe.ruhland@gmail.com>