### PR TITLE
Update SSL Version link to point to non-deprecated item

### DIFF
--- a/docker/client.py
+++ b/docker/client.py
@@ -87,7 +87,7 @@ class DockerClient(object):
             >>> client = docker.from_env()
 
         .. _`SSL version`:
-            https://docs.python.org/3.5/library/ssl.html#ssl.PROTOCOL_TLSv1
+            https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
         """
         timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT_SECONDS)
         max_pool_size = kwargs.pop('max_pool_size', DEFAULT_MAX_POOL_SIZE)


### PR DESCRIPTION
- The docs were previously linking to an end-of-like version of Python (3.5)
- The docs were also linking to an attribute that was deprecated in Python 3.6

The new link points to the latest stable version of the Python docs as well as to the suggested constant to use.