### PR TITLE
Add context manager to the client API

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -76,6 +76,14 @@ class APIClient(
          u'Os': u'linux',
          u'Version': u'17.10.0-ce'}
 
+    It's possible to use `DockerClient` as a context manager and make sure every
+    socket will be closed:
+
+        >>> import docker
+        >>> docker.DockerClient(base_url='unix://var/run/docker/sock') as cli:
+        ...     cli.info()
+        ...
+
     Args:
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
@@ -118,6 +126,7 @@ class APIClient(
         self.timeout = timeout
         self.headers['User-Agent'] = user_agent
 
+        self._sockets_ref = set()
         self._general_configs = config.load_general_config()
 
         proxy_config = self._general_configs.get('proxies', {})
@@ -208,6 +217,20 @@ class APIClient(
                 'API versions below {} are no longer supported by this '
                 'library.'.format(MINIMUM_DOCKER_API_VERSION)
             )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._close_sockets()
+
+    def _close_sockets(self, close_self=True):
+        for _socket in self._sockets_ref:
+            try:
+                _socket.close()
+            except ValueError:
+                pass
+
+        if close_self:
+            self.close()
 
     def _retrieve_server_version(self):
         try:
@@ -334,6 +357,8 @@ class APIClient(
             # fine because we won't be doing TLS over them
             pass
 
+        self._sockets_ref.add(sock)
+        self._sockets_ref.add(response)
         return sock
 
     def _stream_helper(self, response, decode=False):
@@ -503,3 +528,8 @@ class APIClient(
         self._auth_configs = auth.load_config(
             dockercfg_path, credstore_env=self.credstore_env
         )
+
+    def close(self):
+        super().close()
+        self._close_sockets(False)
+

--- a/docker/client.py
+++ b/docker/client.py
@@ -22,6 +22,14 @@ class DockerClient(object):
         >>> import docker
         >>> client = docker.DockerClient(base_url='unix://var/run/docker.sock')
 
+    It's possible to use `DockerClient` as a context manager and make sure every
+    socket will be closed:
+
+        >>> import docker
+        >>> docker.DockerClient(base_url='unix://var/run/docker/sock') as cli:
+        ...     cli.info()
+        ...
+
     Args:
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
@@ -43,6 +51,12 @@ class DockerClient(object):
     """
     def __init__(self, *args, **kwargs):
         self.api = APIClient(*args, **kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.api.__exit__(exc_type, exc_value, traceback)
 
     @classmethod
     def from_env(cls, **kwargs):

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -544,17 +544,17 @@ class TCPSocketStreamTest(unittest.TestCase):
 
     def request(self, stream=None, tty=None, demux=None):
         assert stream is not None and tty is not None and demux is not None
-        with APIClient(
+        client = APIClient(
                 base_url=self.address,
                 version=DEFAULT_DOCKER_API_VERSION
-                ) as client:
-            if tty:
-                url = client._url('/tty')
-            else:
-                url = client._url('/no-tty')
-            resp = client._post(url, stream=True)
-            return client._read_from_socket(
-                resp, stream=stream, tty=tty, demux=demux)
+                )
+        if tty:
+            url = client._url('/tty')
+        else:
+            url = client._url('/no-tty')
+        resp = client._post(url, stream=True)
+        return client._read_from_socket(
+            resp, stream=stream, tty=tty, demux=demux)
 
     def test_read_from_socket_tty(self):
         res = self.request(stream=True, tty=True, demux=False)


### PR DESCRIPTION
`ApiClient` inherence from `requests.session` that implements
`__enter__` and `__exit__` methods and the issue #2808 asks to add the
same behaviour to the `DockerClient`.

At the same time, issue #2766 reports a file descriptor leak when
`_get_raw_response_socket` is called.

To fix both requests, I added a `set` to the `ApiClient` instance to
track every socket open by `_get_raw_response_socket` and close when
the `close` method is called.

I added a test, and documentation now brings the context manager as an
example.

Signed-off-by: Felipe Ruhland <felipe.ruhland@gmail.com>