### PR TITLE
Prevent pip cache in Docker image to save image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN mkdir /src
 WORKDIR /src
 
 COPY requirements.txt /src/requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY test-requirements.txt /src/test-requirements.txt
-RUN pip install -r test-requirements.txt
+RUN pip install --no-cache-dir -r test-requirements.txt
 
 COPY . /src
-RUN pip install .
+RUN pip install --no-cache-dir .

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -10,6 +10,6 @@ RUN addgroup --gid $gid sphinx \
 
 WORKDIR /src
 COPY requirements.txt docs-requirements.txt ./
-RUN pip install -r requirements.txt -r docs-requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt -r docs-requirements.txt
 
 USER sphinx


### PR DESCRIPTION
This will help save some disk space from the images, both of the images are nearly 1GB 😅 