### PR TITLE
limit upper bound of dependencies in setup.py and add six as explicit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,9 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
-    'websocket-client >= 0.32.0',
-    'requests >= 2.14.2, != 2.18.0',
+    'websocket-client >= 0.32.0, < 1',
+    'requests >= 2.14.2, != 2.18.0, < 3',
+    'six >= 1.16.0, < 2',
 ]
 
 extras_require = {


### PR DESCRIPTION
The dependency `websocket-client` recently released version 1.0.0 which removed `six` as a dependency. This breaks because `docker/auth.py` uses `six` without adding it as a dependency in `setup.py`. 

Version `1.16.0` of `six` is used because it was the only one I've tested it with but the lower bound could likely be lowered.

This addresses https://github.com/docker/docker-py/issues/2840