### PR TITLE
Update: allow "force" parameter in plugin.disable()

### DIFF
--- a/docker/api/plugin.py
+++ b/docker/api/plugin.py
@@ -53,19 +53,20 @@ class PluginApiMixin(object):
         return True
 
     @utils.minimum_version('1.25')
-    def disable_plugin(self, name):
+    def disable_plugin(self, name, force=False):
         """
             Disable an installed plugin.
 
             Args:
                 name (string): The name of the plugin. The ``:latest`` tag is
                     optional, and is the default if omitted.
+                force (bool): To enable the force query parameter.
 
             Returns:
                 ``True`` if successful
         """
         url = self._url('/plugins/{0}/disable', name)
-        res = self._post(url)
+        res = self._post(url, params={'force': force})
         self._raise_for_status(res)
         return True
 

--- a/docker/models/plugins.py
+++ b/docker/models/plugins.py
@@ -44,16 +44,19 @@ class Plugin(Model):
         self.client.api.configure_plugin(self.name, options)
         self.reload()
 
-    def disable(self):
+    def disable(self, force=False):
         """
             Disable the plugin.
+
+            Args:
+                force (bool): Force disable. Default: False
 
             Raises:
                 :py:class:`docker.errors.APIError`
                     If the server returns an error.
         """
 
-        self.client.api.disable_plugin(self.name)
+        self.client.api.disable_plugin(self.name, force)
         self.reload()
 
     def enable(self, timeout=0):

--- a/tests/integration/api_plugin_test.py
+++ b/tests/integration/api_plugin_test.py
@@ -22,13 +22,13 @@ class PluginTest(BaseAPIIntegrationTest):
     def teardown_method(self, method):
         client = self.get_client_instance()
         try:
-            client.disable_plugin(SSHFS)
+            client.disable_plugin(SSHFS, True)
         except docker.errors.APIError:
             pass
 
         for p in self.tmp_plugins:
             try:
-                client.remove_plugin(p, force=True)
+                client.remove_plugin(p)
             except docker.errors.APIError:
                 pass
 


### PR DESCRIPTION
FYI, I used the docker/cli for inspiration:
https://github.com/docker/cli/blob/86e1f04b5f115fb0b4bbd51e0e4a68233072d24b/vendor/github.com/docker/docker/client/plugin_disable.go#L11-L19