### PR TITLE
Add six to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ pyOpenSSL==18.0.0
 pyparsing==2.2.0
 pywin32==227; sys_platform == 'win32'
 requests==2.20.0
+six==1.16.0
 urllib3==1.24.3
 websocket-client==0.56.0

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ SOURCE_DIR = os.path.join(ROOT_DIR)
 requirements = [
     'websocket-client >= 0.32.0',
     'requests >= 2.14.2, != 2.18.0',
+    'six >= 1.4.0'
 ]
 
 extras_require = {


### PR DESCRIPTION
fixes [#2807](https://github.com/docker/docker-py/issues/2807)
fixes [#2842](https://github.com/docker/docker-py/issues/2842)


Made sure all imports contained in the package would have a corresponding requirement:
- grep'ed for 'import' or from, under docker/ dir 
- Filtered out local imports (starting with dot), and 'docker.' imports
- Print only imported module (awk)
- Sort, unique
$ grep -rh -e "^import\b" -e "^from\b"  docker/ | grep -v " \." | grep -v docker |  awk '{print $2}' |sort -u

Imported all listed output in a clean python:3.8-slim docker and caught ImportError exceptions - printing the missing packages
Made sure every* error'ed package is included in the requirements.txt, installed updated requirement.txt and ran import script again - No errors.

* Only exception is the windows-related modules which are imported only for windows.

** Unclear why 'six' was removed on March 2021 (commit: c8fba210)