### PR TITLE
Fixed example code for save an image

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -84,9 +84,9 @@ class Image(Model):
 
         Example:
 
-            >>> image = cli.get_image("busybox:latest")
+            >>> image = client.images.get("busybox:latest")
             >>> f = open('/tmp/busybox-latest.tar', 'wb')
-            >>> for chunk in image:
+            >>> for chunk in image.save():
             >>>   f.write(chunk)
             >>> f.close()
         """


### PR DESCRIPTION
The example code provided in the docstring for saving images did not work. I adjusted the example to work.