### PR TITLE
Create Python3 only wheel.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 description_file = README.rst
 license = Apache License 2.0


### PR DESCRIPTION
bdist_wheel universal should only be use if the project does not have any C extensions and supports Python 2 and 3.
The current project only supports py3.6 and above.