### PR TITLE
Bump requests => 2.26.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ pycparser==2.17
 pyOpenSSL==18.0.0
 pyparsing==2.2.0
 pywin32==227; sys_platform == 'win32'
-requests==2.20.0
+requests==2.26.0
 urllib3==1.24.3
 websocket-client==0.56.0


### PR DESCRIPTION
This bump is to enable bumping `urllib` in https://github.com/docker/docker-py/pull/2850