### PR TITLE
fix(transport): remove disable_buffering option

### DIFF
--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -23,7 +23,6 @@ class UnixHTTPConnection(httplib.HTTPConnection):
         self.base_url = base_url
         self.unix_socket = unix_socket
         self.timeout = timeout
-        self.disable_buffering = False
 
     def connect(self):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -33,13 +32,8 @@ class UnixHTTPConnection(httplib.HTTPConnection):
 
     def putheader(self, header, *values):
         super().putheader(header, *values)
-        if header == 'Connection' and 'Upgrade' in values:
-            self.disable_buffering = True
 
     def response_class(self, sock, *args, **kwargs):
-        if self.disable_buffering:
-            kwargs['disable_buffering'] = True
-
         return httplib.HTTPResponse(sock, *args, **kwargs)
 
 


### PR DESCRIPTION
#2885 documents a breakage in 5.0.1 because `disable_buffering` is being passed to a `HTTPResponse` object (caused by commit https://github.com/docker/docker-py/commit/5fcc293ba268a89ea1535114d36fbdcb73ec3d88).

As mentioned in #1799, there is no way to disable buffering in Python3 on `HTTPResponse` for now. This removes the option, since the Python2 dependency was removed anyway.