### PR TITLE
Example of how to connect with Docker through the portainer API

### DIFF
--- a/docs/user_guides/portainer.md
+++ b/docs/user_guides/portainer.md
@@ -1,0 +1,31 @@
+# Portainer
+
+To connect with Docker through the portainer API we need a custom http header.
+This can be done by adding the header to the config.json `HttpHeaders` entry.
+The APIClient searches for the config.json file in your home directory or in the
+directory you specify in the DOCKER_CONFIG environment variable.
+
+For sake of clarity we create the config file in this example inline:
+
+```python
+
+with TemporaryDirectory() as temp_path:
+    docker_config = temp_path / Path("config.json")
+
+    docker_config.write_text(
+        json.dumps(
+            {
+                "HttpHeaders": {
+                    "Authorization": "Bearer " + os.environ("PORTAINER_JWT"),
+                }
+            }
+        )
+    )
+
+    os.environ["DOCKER_CONFIG"] = temp_path
+
+    client = DockerClient(
+        base_url="http://localhost:9000/api/endpoints/1/docker/")
+
+    print(client.containers.list())
+```


### PR DESCRIPTION
Took me some time to figure out how to use the SDK in combination with Portainer but it is actually quite easy. 

This pull request adds a small user guide to get things up and running with Portainer as your endpoint. 

Closes #2568