### PR TITLE
Add remove() method to Image

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -58,6 +58,20 @@ class Image(Model):
         """
         return self.client.api.history(self.id)
 
+    def remove(self, force=False, noprune=False):
+        """
+        Remove this image.
+
+        Args:
+            force (bool): Force removal of the image
+            noprune (bool): Do not delete untagged parents
+
+        Raises:
+            :py:class:`docker.errors.APIError`
+                If the server returns an error.
+        """
+        return self.client.api.remove_image(self.id, force=force, noprune=noprune)
+
     def save(self, chunk_size=DEFAULT_DATA_CHUNK_SIZE, named=False):
         """
         Get a tarball of an image. Similar to the ``docker save`` command.

--- a/tests/unit/models_images_test.py
+++ b/tests/unit/models_images_test.py
@@ -150,6 +150,12 @@ class ImageTest(unittest.TestCase):
         image.history()
         client.api.history.assert_called_with(FAKE_IMAGE_ID)
 
+    def test_remove(self):
+        client = make_fake_client()
+        image = client.images.get(FAKE_IMAGE_ID)
+        image.remove()
+        client.api.remove_image.assert_called_with(FAKE_IMAGE_ID, force=False, noprune=False)
+
     def test_save(self):
         client = make_fake_client()
         image = client.images.get(FAKE_IMAGE_ID)


### PR DESCRIPTION
Allow an Image to be deleted by calling the remove() method on it,
just like a Volume.

Signed-off-by: Ahmon Dancy <dancy@dancysoft.com>