### PR TITLE
Upgrade pywin32 version constraint in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
-    ':sys_platform == "win32"': 'pywin32==227',
+    ':sys_platform == "win32"': 'pywin32==301',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
Updated the `pywin32` version constraint to match the newer version specified in the project `requirements.txt` which was updated in [this commit](https://github.com/docker/docker-py/commit/e0d186d754693feb7d27c2352e455c5febb4a5cd). This fixes issues where `pywin32` would continue to resolve to the older version specified in the `setup.py` which has a security vulnerability.
