### PR TITLE
Add `gzip` documentation to `BuildApiMixin`

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -76,6 +76,7 @@ class BuildApiMixin:
             forcerm (bool): Always remove intermediate containers, even after
                 unsuccessful builds
             dockerfile (str): path within the build context to the Dockerfile
+            gzip (bool): If set to ``True``, gzip compression/encoding is used
             buildargs (dict): A dictionary of build arguments
             container_limits (dict): A dictionary of limits applied to each
                 container created by the build process. Valid keys:


### PR DESCRIPTION
Fixes #2318 by adding docstrings for the `gzip` option in `BuildApiMixin`