### PR TITLE
Use `packaging` instead of `distutils` for `Version`

### DIFF
--- a/docker/transport/ssladapter.py
+++ b/docker/transport/ssladapter.py
@@ -4,7 +4,7 @@
 """
 import sys
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 from requests.adapters import HTTPAdapter
 
 from docker.transport.basehttpadapter import BaseHTTPAdapter
@@ -70,4 +70,4 @@ class SSLHTTPAdapter(BaseHTTPAdapter):
             return False
         if urllib_ver == 'dev':
             return True
-        return StrictVersion(urllib_ver) > StrictVersion('1.5')
+        return Version(urllib_ver) > Version('1.5')

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -5,7 +5,7 @@ import os.path
 import shlex
 import string
 from datetime import datetime
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 from .. import errors
 from .. import tls
@@ -49,8 +49,8 @@ def compare_version(v1, v2):
     >>> compare_version(v2, v2)
     0
     """
-    s1 = StrictVersion(v1)
-    s2 = StrictVersion(v2)
+    s1 = Version(v1)
+    s2 = Version(v2)
     if s1 == s2:
         return 0
     elif s1 > s2:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cryptography==3.4.7
 enum34==1.1.6
 idna==2.5
 ipaddress==1.0.18
-packaging==16.8
+packaging==21.3
 paramiko==2.8.0
 pycparser==2.17
 pyOpenSSL==18.0.0

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
 requirements = [
+    'packaging',
     'websocket-client >= 0.32.0',
     'requests >= 2.14.2, != 2.18.0',
 ]


### PR DESCRIPTION
Fixes #2928.

## Context

`setuptools` has deprecated the usage of `distutils` `Version` classes since version `60.3.0`. See https://github.com/pypa/setuptools/commit/1701579e0827317d8888c2254a17b5786b6b5246 for details.

As a consequence, a `warning` is raised any time we try, e.g., to do `from docker import from_env`. Notice that this `warning` can be fatal if the user has set a warning filter to `error` mode, which is not too uncommon when running unit tests in CI.

## Proposed solution

1. Replace occurrences of `distutils.Version` (and its subclasses) with `packaging.Version`.
2. Add `packaging` to the `install_requires`.