### PR TITLE
Fix "Error connecting: 'SSHHTTPAdapter' object has no attribute 'ssh_conf'"

### DIFF
--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -204,7 +204,7 @@ class SSHHTTPAdapter(BaseHTTPAdapter):
             host_config = conf.lookup(base_url.hostname)
             if 'proxycommand' in host_config:
                 self.ssh_params["sock"] = paramiko.ProxyCommand(
-                    self.ssh_conf['proxycommand']
+                    host_config['proxycommand']
                 )
             if 'hostname' in host_config:
                 self.ssh_params['hostname'] = host_config['hostname']


### PR DESCRIPTION
Ansible docker_compose module fails when using `docker_host: ssh://hostname`.

```
The full traceback is:                                                                                                                                                          
  File "/tmp/ansible_docker_compose_payload_twrqyrsg/ansible_docker_compose_payload.zip/ansible_collections/community/docker/plugins/module_utils/common.py", line 310, in __init__
    super(AnsibleDockerClientBase, self).__init__(**self._connect_params)                                              
  File "/home/masakura/tmp/hoge/venv/lib/python3.8/site-packages/docker/api/client.py", line 171, in __init__                           
    self._custom_adapter = SSHHTTPAdapter(                                                                             
  File "/home/masakura/tmp/hoge/venv/lib/python3.8/site-packages/docker/transport/sshconn.py", line 176, in __init__                    
    self._create_paramiko_client(base_url)                                                                             
  File "/home/masakura/tmp/hoge/venv/lib/python3.8/site-packages/docker/transport/sshconn.py", line 207, in _create_paramiko_client
    self.ssh_conf['proxycommand']                                                                        
```