### PR TITLE
test_create_with_device_cgroup_rules: don't check devices.list

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -460,16 +460,13 @@ class CreateContainerTest(BaseAPIIntegrationTest):
     def test_create_with_device_cgroup_rules(self):
         rule = 'c 7:128 rwm'
         ctnr = self.client.create_container(
-            TEST_IMG, 'cat /sys/fs/cgroup/devices/devices.list',
-            host_config=self.client.create_host_config(
+            TEST_IMG, 'true', host_config=self.client.create_host_config(
                 device_cgroup_rules=[rule]
             )
         )
         self.tmp_containers.append(ctnr)
         config = self.client.inspect_container(ctnr)
         assert config['HostConfig']['DeviceCgroupRules'] == [rule]
-        self.client.start(ctnr)
-        assert rule in self.client.logs(ctnr).decode('utf-8')
 
     def test_create_with_uts_mode(self):
         container = self.client.create_container(


### PR DESCRIPTION
fixes https://github.com/docker/docker-py/issues/2939
relates to https://github.com/moby/moby/pull/42941#issuecomment-965515091

This test was verifying that the container has the right options set (through
`docker inspect`), but also checks if the cgroup-rules are set within the
container by reading `/sys/fs/cgroup/devices/devices.list`

Unlike cgroups v1, on cgroups v2, there is no file interface, and rules are
handled through ebpf, which means that the test will fail because this file
is not present.

From the Linux documentation for cgroups v2:
https://github.com/torvalds/linux/blob/v5.16/Documentation/admin-guide/cgroup-v2.rst#device-controller

> (...)
> Device controller manages access to device files. It includes both creation of
> new device files (using mknod), and access to the existing device files.
>
> Cgroup v2 device controller has no interface files and is implemented on top
> of cgroup BPF. To control access to device files, a user may create bpf programs
> of type BPF_PROG_TYPE_CGROUP_DEVICE and attach them to cgroups with
> BPF_CGROUP_DEVICE flag. (...)

Given that setting the right cgroups is not really a responsibility of this SDK,
it should be sufficient to verify that the right options were set in the container
configuration, so this patch is removing the part that checks the cgroup, to
allow this test to be run on a host with cgroups v2 enabled.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>