### PR TITLE
Avoid deprecated splitnport function.

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -14,7 +14,7 @@ from ..constants import DEFAULT_UNIX_SOCKET
 from ..constants import DEFAULT_NPIPE
 from ..constants import BYTE_UNITS
 
-from urllib.parse import splitnport, urlparse
+from urllib.parse import urlparse
 
 
 def create_ipam_pool(*args, **kwargs):
@@ -265,8 +265,8 @@ def parse_host(addr, is_win32=False, tls=False):
 
     if proto in ('tcp', 'ssh'):
         # parsed_url.hostname strips brackets from IPv6 addresses,
-        # which can be problematic hence our use of splitnport() instead.
-        host, port = splitnport(parsed_url.netloc)
+        # which can be problematic.
+        port = parsed_url.port
         if port is None or port < 0:
             if proto != 'ssh':
                 raise errors.DockerException(
@@ -274,6 +274,9 @@ def parse_host(addr, is_win32=False, tls=False):
                     ' {}'.format(addr)
                 )
             port = 22
+            host = parsed_url.netloc
+        else:
+            host, *_ = parsed_url.netloc.rpartition(':')
 
         if not host:
             host = DEFAULT_HTTP_HOST


### PR DESCRIPTION
I saw three ways forward to avoid the use of the deprecated `splitnport` function.

* Just use the parsed results' hostname. I couldn't track down the actual reason why the stripping of brackets is **actually** problematic. So I figured that would be harder to get merged.
* Inline the use of `splitnport`. I see https://github.com/docker/docker-py/pull/2567, but also that it's been unchanged since 2020.
* Do something else. the behavior you're getting from `splitnport` is essentially just chopping off the port part to find the hostname. But the rest of the logic seems unnecessary because you've already run `parse` and have `parsed_url.port` handy. So I opted to just directly perform the behavior of chopping off the port instead.

I have no opinion on which of the three options are chosen, I'm just aiming to stop this warning on my own code. But figured that if copying the whole of `splitnport` was the reason for no action, that this might be preferable; or else might cause https://github.com/docker/docker-py/pull/2567 to be merged