### PR TITLE
fix: Missing comma in `api_build_test.py`

### DIFF
--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -253,7 +253,7 @@ class BuildTest(BaseAPIIntegrationTest):
             'RUN mkdir -p /tmp/test',
             'RUN touch /tmp/silence.tar.gz',
             'FROM alpine:latest',
-            'WORKDIR /root/'
+            'WORKDIR /root/',
             'COPY --from=first /tmp/silence.tar.gz .',
             'ONBUILD RUN echo "This should not be in the final image"'
         ]).encode('ascii'))

--- a/tests/ssh/api_build_test.py
+++ b/tests/ssh/api_build_test.py
@@ -253,7 +253,7 @@ class BuildTest(BaseAPIIntegrationTest):
             'RUN mkdir -p /tmp/test',
             'RUN touch /tmp/silence.tar.gz',
             'FROM alpine:latest',
-            'WORKDIR /root/'
+            'WORKDIR /root/',
             'COPY --from=first /tmp/silence.tar.gz .',
             'ONBUILD RUN echo "This should not be in the final image"'
         ]).encode('ascii'))


### PR DESCRIPTION
* The comma has been most probably left out unintentionally, leading to string concatenation between the two consecutive lines. It has been found automatically using a regular expression.