### PR TITLE
Fix exception semantics in _raise_for_status

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -267,7 +267,7 @@ class APIClient(
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            raise create_api_error_from_http_exception(e)
+            raise create_api_error_from_http_exception(e) from e
 
     def _result(self, response, json=False, binary=False):
         assert not (json and binary)


### PR DESCRIPTION
We want "The above exception was the direct cause of the following exception:" instead of "During handling of the above exception, another exception occurred:"