### PR TITLE
Tweak pywin32 vers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ requirements = [
 
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
-    ':sys_platform == "win32"': 'pywin32==227',
+    ':sys_platform == "win32" and python_version<"3.0"': 'pywin32>=228',
+    ':sys_platform == "win32" and python_version>="3.0"': 'pywin32>=300',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
     ':sys_platform == "win32" and python_version<"3.0"': 'pywin32>=228',
-    ':sys_platform == "win32" and python_version>="3.0"': 'pywin32>=300',
+    ':sys_platform == "win32" and python_version>="3.0"': 'pywin32>=303',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
The library `pywin32` is being flagged by GitHub Dependabot with an integer overflow vulnerability which can be used by an attacker to crash the process in question. `docker-py` has a conditional dependency on the fixed version `227` of this library. This PR upgrades that to 228 for python2 users and upgrades to 301 (which fixes the security issue) for python3 users.