### PR TITLE
feat: add py.typed file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [metadata]
 description_file = README.rst
 license = Apache License 2.0
+
+[options.package_data]
+* = py.typed


### PR DESCRIPTION
According to PEP 561, we just need to add this file to mark the lib as typed.

I don't know if all the lib is typed, maybe we also need to do that before merging.