### PR TITLE
Don't pin to pywin32 227

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
-    ':sys_platform == "win32"': 'pywin32==227',
+    ':sys_platform == "win32"': 'pywin32>=227',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
The hard pin to 227 is keeping us from using docker with other projects that depend on a newer version of pywin32.