### PR TITLE
Add swarm support for DataPathPort

### DIFF
--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -85,7 +85,7 @@ class SwarmApiMixin:
     def init_swarm(self, advertise_addr=None, listen_addr='0.0.0.0:2377',
                    force_new_cluster=False, swarm_spec=None,
                    default_addr_pool=None, subnet_size=None,
-                   data_path_addr=None):
+                   data_path_addr=None, data_path_port=None):
         """
         Initialize a new Swarm using the current connected engine as the first
         node.
@@ -118,6 +118,9 @@ class SwarmApiMixin:
                 networks created from the default subnet pool. Default: None
             data_path_addr (string): Address or interface to use for data path
                 traffic. For example, 192.168.1.1, or an interface, like eth0.
+            data_path_port (int): Port number to use for data path traffic.
+                Acceptable port range is 1024 to 49151. If set to ``None`` or
+                0, the default port 4789 will be used. Default: None
 
         Returns:
             (str): The ID of the created node.
@@ -165,6 +168,14 @@ class SwarmApiMixin:
                     'API version >= 1.30'
                 )
             data['DataPathAddr'] = data_path_addr
+
+        if data_path_port is not None:
+            if utils.version_lt(self._version, '1.40'):
+                raise errors.InvalidVersion(
+                    'Data path port is only available for '
+                    'API version >= 1.40'
+                )
+            data['DataPathPort'] = data_path_port
 
         response = self._post_json(url, data=data)
         return self._result(response, json=True)

--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -35,7 +35,8 @@ class Swarm(Model):
 
     def init(self, advertise_addr=None, listen_addr='0.0.0.0:2377',
              force_new_cluster=False, default_addr_pool=None,
-             subnet_size=None, data_path_addr=None, **kwargs):
+             subnet_size=None, data_path_addr=None, data_path_port=None,
+             **kwargs):
         """
         Initialize a new swarm on this Engine.
 
@@ -65,6 +66,9 @@ class Swarm(Model):
                 networks created from the default subnet pool. Default: None
             data_path_addr (string): Address or interface to use for data path
                 traffic. For example, 192.168.1.1, or an interface, like eth0.
+            data_path_port (int): Port number to use for data path traffic.
+                Acceptable port range is 1024 to 49151. If set to ``None`` or
+                0, the default port 4789 will be used. Default: None
             task_history_retention_limit (int): Maximum number of tasks
                 history stored.
             snapshot_interval (int): Number of logs entries between snapshot.
@@ -121,6 +125,7 @@ class Swarm(Model):
             'default_addr_pool': default_addr_pool,
             'subnet_size': subnet_size,
             'data_path_addr': data_path_addr,
+            'data_path_port': data_path_port,
         }
         init_kwargs['swarm_spec'] = self.client.api.create_swarm_spec(**kwargs)
         node_id = self.client.api.init_swarm(**init_kwargs)

--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -253,3 +253,8 @@ class SwarmTest(BaseAPIIntegrationTest):
     @pytest.mark.xfail(reason='Can fail if eth0 has multiple IP addresses')
     def test_init_swarm_data_path_addr(self):
         assert self.init_swarm(data_path_addr='eth0')
+
+    @requires_api_version('1.40')
+    def test_init_swarm_data_path_port(self):
+        assert self.init_swarm(data_path_port=4242)
+        assert self.client.inspect_swarm()['DataPathPort'] == 4242


### PR DESCRIPTION
Adds support for `DataPathPort` in much the same way as `DataPathAddr` when initializing a swarm.

This option is supported as of api version 1.40:
https://docs.docker.com/engine/api/v1.40/#operation/SwarmInit