### PR TITLE
sshcon: remove use of self.ssh_conf

### DIFF
--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -204,7 +204,7 @@ class SSHHTTPAdapter(BaseHTTPAdapter):
             host_config = conf.lookup(base_url.hostname)
             if 'proxycommand' in host_config:
                 self.ssh_params["sock"] = paramiko.ProxyCommand(
-                    self.ssh_conf['proxycommand']
+                    host_config['proxycommand']
                 )
             if 'hostname' in host_config:
                 self.ssh_params['hostname'] = host_config['hostname']


### PR DESCRIPTION
Use of self.ssh_conf was left over after being removed at the following PR: https://github.com/docker/docker-py/pull/2846

This PR removes the use of it and uses `host_config` instead.

Encountered this when trying to use an ssh based DOCKER_HOST which uses a ProxyCommand config. Was getting the following error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/glicht/.pyenv/versions/3.10.1/lib/python3.10/site-packages/docker/client.py", line 45, in __init__
    self.api = APIClient(*args, **kwargs)
  File "/Users/glicht/.pyenv/versions/3.10.1/lib/python3.10/site-packages/docker/api/client.py", line 171, in __init__
    self._custom_adapter = SSHHTTPAdapter(
  File "/Users/glicht/.pyenv/versions/3.10.1/lib/python3.10/site-packages/docker/transport/sshconn.py", line 176, in __init__
    self._create_paramiko_client(base_url)
  File "/Users/glicht/.pyenv/versions/3.10.1/lib/python3.10/site-packages/docker/transport/sshconn.py", line 207, in _create_paramiko_client
    self.ssh_conf['proxycommand']
AttributeError: 'SSHHTTPAdapter' object has no attribute 'ssh_conf'
```