### PR TITLE
build: cohere pywin32 ver. with requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
-    ':sys_platform == "win32"': 'pywin32==227',
+    ':sys_platform == "win32"': 'pywin32==301',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
Although pywin32 is an extra, its old and unsafe version here may still confuse tools like poetry.