### PR TITLE
deps: upgrade pywin32 & relax version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ paramiko==2.10.1
 pycparser==2.17
 pyOpenSSL==18.0.0
 pyparsing==2.2.0
-pywin32==301; sys_platform == 'win32'
+pywin32==304; sys_platform == 'win32'
 requests==2.26.0
 urllib3==1.26.5
 websocket-client==0.56.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
 
 extras_require = {
     # win32 APIs if on Windows (required for npipe support)
-    ':sys_platform == "win32"': 'pywin32==227',
+    ':sys_platform == "win32"': 'pywin32>=304',
 
     # If using docker-py over TLS, highly recommend this option is
     # pip-installed or pinned.


### PR DESCRIPTION
Upgrade to latest pywin32, which has support for Python 3.10 and
resolves a CVE (related to ACL APIs, outside the scope of what
`docker-py` relies on, which is npipe support, but still gets
flagged by scanners).

The version constraint has also been relaxed in `setup.py` to allow
newer versions of pywin32. This is similar to how we handle the
other packages there, and should be safe from a compatibility
perspective.

Fixes #2902.
Closes #2972 and closes #2980.