### PR TITLE
test: fix a couple flaky/broken tests

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1217,12 +1217,14 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         data = read_exactly(pty_stdout, next_size)
         assert data.decode('utf-8') == line
 
+    @pytest.mark.timeout(10)
     def test_attach_no_stream(self):
         container = self.client.create_container(
             TEST_IMG, 'echo hello'
         )
         self.tmp_containers.append(container)
         self.client.start(container)
+        self.client.wait(container, condition='not-running')
         output = self.client.attach(container, stream=False, logs=True)
         assert output == 'hello\n'.encode(encoding='ascii')
 

--- a/tests/integration/regression_test.py
+++ b/tests/integration/regression_test.py
@@ -8,6 +8,7 @@ import pytest
 
 
 class TestRegressions(BaseAPIIntegrationTest):
+    @pytest.mark.xfail(True, reason='Docker API always returns chunked resp')
     def test_443_handle_nonchunked_response_in_stream(self):
         dfile = io.BytesIO()
         with pytest.raises(docker.errors.APIError) as exc:


### PR DESCRIPTION
### [test: fix flaky container log test](https://github.com/docker/docker-py/commit/74e0c5eb8c38f0a219cc0120bc51de99c1c8159e)
Ensure the container has exited before attempting to grab the logs.

Since we are not streaming them, it's possible to attach + grab logs
before the output is processed, resulting in a test failure. If the
container has exited, it's guaranteed to have logged :)

### [test: mark invalid test as xfail](https://github.com/docker/docker-py/commit/4765f624419c503012508f0fecbe4f63e492cde1)
This test looks for some behavior on non-chunked HTTP requests.

It now fails because it looks like recent versions of Docker Engine
ALWAYS return chunked responses (or perhaps this specific response
changed somehow to now trigger chunking whereas it did not previously).

The actual logic it's trying to test is also unusual because it's
trying to hackily propagate errors under the assumption that it'd get
a non-chunked response on failure, which is...not reliable. Arguably,
the chunked reader should be refactored somehow but that's a refactor
we can't really commit to (and it's evidently been ok enough as is
up until now).
