### PR TITLE
deps: remove backports.ssl_match_hostname

### DIFF
--- a/docker/transport/ssladapter.py
+++ b/docker/transport/ssladapter.py
@@ -2,8 +2,6 @@
       https://lukasa.co.uk/2013/01/Choosing_SSL_Version_In_Requests/
       https://github.com/kennethreitz/requests/pull/799
 """
-import sys
-
 from packaging.version import Version
 from requests.adapters import HTTPAdapter
 
@@ -16,12 +14,6 @@ except ImportError:
 
 
 PoolManager = urllib3.poolmanager.PoolManager
-
-# Monkey-patching match_hostname with a version that supports
-# IP-address checking. Not necessary for Python 3.5 and above
-if sys.version_info[0] < 3 or sys.version_info[1] < 5:
-    from backports.ssl_match_hostname import match_hostname
-    urllib3.connection.match_hostname = match_hostname
 
 
 class SSLHTTPAdapter(BaseHTTPAdapter):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 appdirs==1.4.3
 asn1crypto==0.22.0
-backports.ssl-match-hostname==3.5.0.1
 cffi==1.14.4
 cryptography==3.4.7
 enum34==1.1.6

--- a/tests/unit/ssladapter_test.py
+++ b/tests/unit/ssladapter_test.py
@@ -1,15 +1,8 @@
 import unittest
-from docker.transport import ssladapter
-import pytest
+from ssl import match_hostname, CertificateError
 
-try:
-    from backports.ssl_match_hostname import (
-        match_hostname, CertificateError
-    )
-except ImportError:
-    from ssl import (
-        match_hostname, CertificateError
-    )
+import pytest
+from docker.transport import ssladapter
 
 try:
     from ssl import OP_NO_SSLv3, OP_NO_SSLv2, OP_NO_TLSv1


### PR DESCRIPTION
This is no longer needed as it exists in every supported (non-EOL)
version of Python that we target.