### PR TITLE
ci: bump version to 6.0.0-dev

### DIFF
--- a/docker/version.py
+++ b/docker/version.py
@@ -1,2 +1,2 @@
-version = "5.1.0-dev"
+version = "6.0.0-dev"
 version_info = tuple(int(d) for d in version.split("-")[0].split("."))


### PR DESCRIPTION
It's been a long time without a release, and we've included a
number of fixes as well as raised the minimum Python version,
so a major release seems in order.

Signed-off-by: Milas Bowman <milas.bowman@docker.com>