### PR TITLE
docs: fix simple typo, containe -> container

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -436,7 +436,7 @@ class UpdateConfig(dict):
 
 class RollbackConfig(UpdateConfig):
     """
-    Used to specify the way containe rollbacks should be performed by a service
+    Used to specify the way container rollbacks should be performed by a service
 
     Args:
         parallelism (int): Maximum number of tasks to be rolled back in one


### PR DESCRIPTION
There is a small typo in docker/types/services.py.

Should read `container` rather than `containe`.

Signed-off-by: Tim Gates <tim.gates@iress.com>