### PR TITLE
lint: fix line length violation

### DIFF
--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -436,7 +436,8 @@ class UpdateConfig(dict):
 
 class RollbackConfig(UpdateConfig):
     """
-    Used to specify the way container rollbacks should be performed by a service
+    Used to specify the way container rollbacks should be performed by a
+    service
 
     Args:
         parallelism (int): Maximum number of tasks to be rolled back in one


### PR DESCRIPTION
This slipped through when I was merging PRs and getting the linter running in CI 🙃 