### PR TITLE
docs: fix markdown rendering

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,2 @@
-recommonmark==0.7.1
+myst-parser==0.18.0
 Sphinx==5.1.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,23 +33,18 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'myst_parser'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
 }
-
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-source_suffix = ['.rst', '.md']
-# source_suffix = '.md'
 
 # The encoding of source files.
 #
@@ -80,7 +75,7 @@ version = f'{version_info[0]}.{version_info[1]}'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Follow instructions at https://www.sphinx-doc.org/en/master/usage/markdown.html.

This switches from `recommonmark` (deprecated) to `myst-parser`
(recommended).

Only impacts the changelog page, which was broken after recent upgrades
to Sphinx for Python 3.10 compatibility.