### PR TITLE
deps: upgrade websocket-client to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ paramiko==2.11.0
 pywin32==304; sys_platform == 'win32'
 requests==2.28.1
 urllib3==1.26.11
-websocket-client==0.56.0
+websocket-client==1.3.3

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1197,7 +1197,7 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         sock = self.client.attach_socket(container, ws=False)
         assert sock.fileno() > -1
 
-    def test_run_container_reading_socket(self):
+    def test_run_container_reading_socket_http(self):
         line = 'hi there and stuff and things, words!'
         # `echo` appends CRLF, `printf` doesn't
         command = f"printf '{line}'"
@@ -1215,6 +1215,23 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         assert stream == 1  # correspond to stdout
         assert next_size == len(line)
         data = read_exactly(pty_stdout, next_size)
+        assert data.decode('utf-8') == line
+
+    def test_run_container_reading_socket_ws(self):
+        line = 'hi there and stuff and things, words!'
+        # `echo` appends CRLF, `printf` doesn't
+        command = f"printf '{line}'"
+        container = self.client.create_container(TEST_IMG, command,
+                                                 detach=True, tty=False)
+        self.tmp_containers.append(container)
+
+        opts = {"stdout": 1, "stream": 1, "logs": 1}
+        pty_stdout = self.client.attach_socket(container, opts, ws=True)
+        self.addCleanup(pty_stdout.close)
+
+        self.client.start(container)
+
+        data = pty_stdout.recv()
         assert data.decode('utf-8') == line
 
     @pytest.mark.timeout(10)

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1217,6 +1217,8 @@ class AttachContainerTest(BaseAPIIntegrationTest):
         data = read_exactly(pty_stdout, next_size)
         assert data.decode('utf-8') == line
 
+    @pytest.mark.xfail(condition=bool(os.environ.get('DOCKER_CERT_PATH', '')),
+                       reason='DOCKER_CERT_PATH not respected for websockets')
     def test_run_container_reading_socket_ws(self):
         line = 'hi there and stuff and things, words!'
         # `echo` appends CRLF, `printf` doesn't


### PR DESCRIPTION
This is the last of the dependency upgrades - I didn't do it with the others because there was no test coverage for the websocket version of log streaming, so this PR adds a basic one along with the upgrade.