### PR TITLE
api: preserve cause when re-raising error

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -28,7 +28,7 @@ def create_api_error_from_http_exception(e):
             cls = ImageNotFound
         else:
             cls = NotFound
-    raise cls(e, response=response, explanation=explanation)
+    raise cls(e, response=response, explanation=explanation) from e
 
 
 class APIError(requests.exceptions.HTTPError, DockerException):


### PR DESCRIPTION
Use `from e` to ensure that the error context is propagated
correctly.

Fixes #2702.