### PR TITLE
types: add missing log type enums

### DIFF
--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -15,9 +15,12 @@ class LogConfigTypesEnum:
         'journald',
         'gelf',
         'fluentd',
+        'awslogs',
+        'splunk',
+        'etwlogs',
         'none'
     )
-    JSON, SYSLOG, JOURNALD, GELF, FLUENTD, NONE = _values
+    JSON, SYSLOG, JOURNALD, GELF, FLUENTD, AWS, SPLUNK, ETW, NONE = _values
 
 
 class LogConfig(DictType):

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -262,9 +262,13 @@ class UlimitTest(unittest.TestCase):
             Ulimit(name='hello', hard='456')
 
 
-class LogConfigTest(unittest.TestCase):
-    def test_create_host_config_dict_logconfig(self):
-        dct = {'type': LogConfig.types.SYSLOG, 'config': {'key1': 'val1'}}
+@pytest.mark.parametrize(
+    "log_config_type",
+    [LogConfig.types.SYSLOG, LogConfig.types.AWS]
+)
+class LogConfigTest:
+    def test_create_host_config_dict_logconfig(self, log_config_type):
+        dct = {'type': log_config_type, 'config': {'key1': 'val1'}}
         config = create_host_config(
             version=DEFAULT_DOCKER_API_VERSION, log_config=dct
         )
@@ -272,8 +276,8 @@ class LogConfigTest(unittest.TestCase):
         assert isinstance(config['LogConfig'], LogConfig)
         assert dct['type'] == config['LogConfig'].type
 
-    def test_create_host_config_obj_logconfig(self):
-        obj = LogConfig(type=LogConfig.types.SYSLOG, config={'key1': 'val1'})
+    def test_create_host_config_obj_logconfig(self, log_config_type):
+        obj = LogConfig(type=log_config_type, config={'key1': 'val1'})
         config = create_host_config(
             version=DEFAULT_DOCKER_API_VERSION, log_config=obj
         )


### PR DESCRIPTION
See https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerCreate.

Closes #2849.