### PR TITLE
feat: add support for floats to docker logs params since / until sinc…

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -826,11 +826,12 @@ class ContainerApiMixin:
             tail (str or int): Output specified number of lines at the end of
                 logs. Either an integer of number of lines or the string
                 ``all``. Default ``all``
-            since (datetime or int): Show logs since a given datetime or
-                integer epoch (in seconds)
+            since (datetime, int, or float): Show logs since a given datetime,
+                integer epoch (in seconds) or float (in nanoseconds)
             follow (bool): Follow log output. Default ``False``
-            until (datetime or int): Show logs that occurred before the given
-                datetime or integer epoch (in seconds)
+            until (datetime, int, or float): Show logs that occurred before
+                the given datetime, integer epoch (in seconds), or
+                float (in nanoseconds)
 
         Returns:
             (generator or str)
@@ -855,6 +856,8 @@ class ContainerApiMixin:
                 params['since'] = utils.datetime_to_timestamp(since)
             elif (isinstance(since, int) and since > 0):
                 params['since'] = since
+            elif (isinstance(since, float) and since > 0.0):
+                params['since'] = since
             else:
                 raise errors.InvalidArgument(
                     'since value should be datetime or positive int, '
@@ -869,6 +872,8 @@ class ContainerApiMixin:
             if isinstance(until, datetime):
                 params['until'] = utils.datetime_to_timestamp(until)
             elif (isinstance(until, int) and until > 0):
+                params['until'] = until
+            elif (isinstance(until, float) and until > 0.0):
                 params['until'] = until
             else:
                 raise errors.InvalidArgument(

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -831,7 +831,7 @@ class ContainerApiMixin:
             follow (bool): Follow log output. Default ``False``
             until (datetime, int, or float): Show logs that occurred before
                 the given datetime, integer epoch (in seconds), or
-                float (in nanoseconds)
+                float (in fractional seconds)
 
         Returns:
             (generator or str)

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -860,7 +860,7 @@ class ContainerApiMixin:
                 params['since'] = since
             else:
                 raise errors.InvalidArgument(
-                    'since value should be datetime or positive int, '
+                    'since value should be datetime or positive int/float, '
                     'not {}'.format(type(since))
                 )
 

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -827,7 +827,7 @@ class ContainerApiMixin:
                 logs. Either an integer of number of lines or the string
                 ``all``. Default ``all``
             since (datetime, int, or float): Show logs since a given datetime,
-                integer epoch (in seconds) or float (in nanoseconds)
+                integer epoch (in seconds) or float (in fractional seconds)
             follow (bool): Follow log output. Default ``False``
             until (datetime, int, or float): Show logs that occurred before
                 the given datetime, integer epoch (in seconds), or

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -877,7 +877,7 @@ class ContainerApiMixin:
                 params['until'] = until
             else:
                 raise errors.InvalidArgument(
-                    'until value should be datetime or positive int, '
+                    'until value should be datetime or positive int/float, '
                     'not {}'.format(type(until))
                 )
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -290,11 +290,12 @@ class Container(Model):
             tail (str or int): Output specified number of lines at the end of
                 logs. Either an integer of number of lines or the string
                 ``all``. Default ``all``
-            since (datetime or int): Show logs since a given datetime or
-                integer epoch (in seconds)
+            since (datetime, int, or float): Show logs since a given datetime,
+                integer epoch (in seconds) or float (in nanoseconds)
             follow (bool): Follow log output. Default ``False``
-            until (datetime or int): Show logs that occurred before the given
-                datetime or integer epoch (in seconds)
+            until (datetime, int, or float): Show logs that occurred before
+                the given datetime, integer epoch (in seconds), or
+                float (in nanoseconds)
 
         Returns:
             (generator or str): Logs from the container.

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1279,6 +1279,22 @@ class ContainerTest(BaseAPIClientTest):
             stream=False
         )
 
+    def test_log_since_with_float(self):
+        ts = 809222400.000000
+        with mock.patch('docker.api.client.APIClient.inspect_container',
+                        fake_inspect_container):
+            self.client.logs(fake_api.FAKE_CONTAINER_ID, stream=False,
+                             follow=False, since=ts)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/logs',
+            params={'timestamps': 0, 'follow': 0, 'stderr': 1, 'stdout': 1,
+                    'tail': 'all', 'since': ts},
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            stream=False
+        )
+
     def test_log_since_with_datetime(self):
         ts = 809222400
         time = datetime.datetime.utcfromtimestamp(ts)
@@ -1301,7 +1317,7 @@ class ContainerTest(BaseAPIClientTest):
                         fake_inspect_container):
             with pytest.raises(docker.errors.InvalidArgument):
                 self.client.logs(fake_api.FAKE_CONTAINER_ID, stream=False,
-                                 follow=False, since=42.42)
+                                 follow=False, since="42.42")
 
     def test_log_tty(self):
         m = mock.Mock()


### PR DESCRIPTION
feature to add support for floats to docker container logs method params `since / until` due to the fact that [docker engine supports it](https://github.com/moby/moby/issues/41784#issuecomment-822371593)

Related:
https://github.com/docker/docker-py/issues/1515
https://github.com/docker/docker-py/issues/2825

