### PR TITLE
docs: install package in ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,11 +4,14 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-    os: ubuntu-20.04
-    tools:
-        python: '3.10'
+  os: ubuntu-20.04
+  tools:
+    python: '3.10'
 
 python:
   install:
     - requirements: docs-requirements.txt
-    - requirements: requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - ssh


### PR DESCRIPTION
The `setuptools_scm` docs have a recommended way to query
the version for Sphinx integration which we use:
https://github.com/docker/docker-py/blob/e901eac7a8c5f29c7720eafb9f58c8356cca2324/docs/conf.py#L62-L70

However, this is currently failing because it requires the `docker`
package (this one!) to be importable, so it really needs to have
the equivalent of `pip install -e .` done on it.

This updates the RTD config to actually install this package as
part of the build vs just its dependencies, so that the version
introspection (hopefully) works.