### PR TITLE
Use latest stable syntax for Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG PYTHON_VERSION=3.10
 
 FROM python:${PYTHON_VERSION}

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG PYTHON_VERSION=3.10
 
 FROM python:${PYTHON_VERSION}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,7 @@
-# syntax = docker/dockerfile:1.4
+# syntax=docker/dockerfile:1
+
 ARG PYTHON_VERSION=3.10
+
 FROM python:${PYTHON_VERSION}
 
 ARG APT_MIRROR

--- a/tests/Dockerfile-dind-certs
+++ b/tests/Dockerfile-dind-certs
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG PYTHON_VERSION=3.10
 
 FROM python:${PYTHON_VERSION}

--- a/tests/Dockerfile-ssh-dind
+++ b/tests/Dockerfile-ssh-dind
@@ -1,18 +1,20 @@
+# syntax=docker/dockerfile:1
+
 ARG API_VERSION=1.41
 ARG ENGINE_VERSION=20.10
 
 FROM docker:${ENGINE_VERSION}-dind
 
 RUN apk add --no-cache --upgrade \
-		openssh
+    openssh
 
 COPY tests/ssh/config/server /etc/ssh/
-RUN chmod -R 600 /etc/ssh
 
 # set authorized keys for client paswordless connection
 COPY tests/ssh/config/client/id_rsa.pub /root/.ssh/authorized_keys
-RUN chmod -R 600 /root/.ssh
 
 # RUN echo "root:root" | chpasswd
-RUN ln -s /usr/local/bin/docker /usr/bin/docker
+RUN chmod -R 600 /etc/ssh \
+ && chmod -R 600 /root/.ssh \
+ && ln -s /usr/local/bin/docker /usr/bin/docker
 EXPOSE 22


### PR DESCRIPTION
I noticed one Dockerfile was pinned to 1.4; given that there's a
backward compatibility guarantee on the stable syntax, the general
recommendation is to use `dockerfile:1`, which makes sure that the
latest stable release of the Dockerfile syntax is pulled before
building.

While changing, I also made some minor changes to some Dockerfiles
to reduce some unneeded layers.
