### PR TITLE
Clarify documentation of `path` argument when building an image

### DIFF
--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -59,7 +59,11 @@ class BuildApiMixin:
              '{"stream":"Successfully built 032b8b2855fc\\n"}']
 
         Args:
-            path (str): Path to the directory containing the Dockerfile
+            path (str): Path to the directory containing the Dockerfile.
+                Typically, the Dockerfile is a direct child of `path`,
+                but it can also be in a nested directory.
+                A copy of the `path` directory, excluding files specified
+                in `.dockerignore`, will be used as the build context.
             fileobj: A file object to use as the Dockerfile. (Or a file-like
                 object)
             tag (str): A tag to add to the final image

--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -234,7 +234,11 @@ class ImageCollection(Collection):
         low-level API.
 
         Args:
-            path (str): Path to the directory containing the Dockerfile
+            path (str): Path to the directory containing the Dockerfile.
+                Typically, the Dockerfile is a direct child of `path`,
+                but it can also be in a nested directory.
+                A copy of the `path` directory, excluding files specified
+                in `.dockerignore`, will be used as the build context.
             fileobj: A file object to use as the Dockerfile. (Or a file-like
                 object)
             tag (str): A tag to add to the final image


### PR DESCRIPTION
Current documentation of some important arguments to the `build` command is:

```
path (str) – Path to the directory containing the Dockerfile
dockerfile (str) – path within the build context to the Dockerfile
```

The documentation for `path` seems a bit ambiguous.

Does this mean:

1. the immediate parent directory containing the `Dockerfile`? 
2. a directory that ultimately contains the `Dockerfile`, which might be nested in child folder(s)?

When I first read [the docs](https://docker-py.readthedocs.io/en/stable/api.html#module-docker.api.build) I thought `1.` was the right interpretation.

But from my knowledge of docker, and double-checking the source - it seems `2.` is the right intpretation.

So this PR updates the documentation to be more clear. I added this text:

```
Typically, the Dockerfile is a direct child of `path`,
but it can also be in a nested directory.
```

This will avoid misunderstandings by developers in future.

To further clarify - I made the link between the `path` and `dockerfile` arguments more explicit. 

`dockerfile` is the `path within the build context to the Dockerfile`

But what exactly is the `build context`? 

It's closely related to `path` but this is not mentioned in the documentation for `path`.

So I added this text:

```
A copy of the `path` directory, excluding files specified
in `.dockerignore`, will be used as the build context.
```

This makes a clear link between the `path` and `dockerfile` arguments.

It also makes a clear link between `path` and `build context`, and explains what `build context` is. 