### PR TITLE
Avoid stripping characters in volume names

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -1147,8 +1147,10 @@ def _host_volume_from_bind(bind):
     bits = rest.split(':', 1)
     if len(bits) == 1 or bits[1] in ('ro', 'rw'):
         return drive + bits[0]
+    elif bits[1].endswith(':ro') or bits[1].endswith(':rw'):
+        return bits[1][:-3]
     else:
-        return bits[1].rstrip(':ro').rstrip(':rw')
+        return bits[1]
 
 
 ExecResult = namedtuple('ExecResult', 'exit_code,output')

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -103,7 +103,7 @@ class ContainerCollectionTest(unittest.TestCase):
             volumes=[
                 '/home/user1/:/mnt/vol2',
                 '/var/www:/mnt/vol1:ro',
-                'volumename:/mnt/vol3',
+                'volumename:/mnt/vol3r',
                 '/volumewithnohostpath',
                 '/anothervolumewithnohostpath:ro',
                 'C:\\windows\\path:D:\\hello\\world:rw'
@@ -123,7 +123,7 @@ class ContainerCollectionTest(unittest.TestCase):
                 'Binds': [
                     '/home/user1/:/mnt/vol2',
                     '/var/www:/mnt/vol1:ro',
-                    'volumename:/mnt/vol3',
+                    'volumename:/mnt/vol3r',
                     '/volumewithnohostpath',
                     '/anothervolumewithnohostpath:ro',
                     'C:\\windows\\path:D:\\hello\\world:rw'
@@ -198,7 +198,7 @@ class ContainerCollectionTest(unittest.TestCase):
             volumes=[
                 '/mnt/vol2',
                 '/mnt/vol1',
-                '/mnt/vol3',
+                '/mnt/vol3r',
                 '/volumewithnohostpath',
                 '/anothervolumewithnohostpath',
                 'D:\\hello\\world'


### PR DESCRIPTION
When a volume name ends in "r", "o", or "w", it currently gets stripped which results in a mount created on the host with an incorrect name. The fix simply consists in not using the `rstrip` method but manually checking for ":rw" and ":ro" at the end of the string.

Signed-off-by: Loïc Leyendecker <loic.leyendecker@gmail.com>