### PR TITLE
fix(store): warn on init instead of throw

### DIFF
--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -2,6 +2,7 @@ import errno
 import json
 import shutil
 import subprocess
+import warnings
 
 from . import constants
 from . import errors
@@ -18,7 +19,7 @@ class Store:
         self.exe = shutil.which(self.program)
         self.environment = environment
         if self.exe is None:
-            raise errors.InitializationError(
+            warnings.warn(
                 '{} not installed or not available in PATH'.format(
                     self.program
                 )
@@ -70,6 +71,12 @@ class Store:
         return json.loads(data.decode('utf-8'))
 
     def _execute(self, subcmd, data_input):
+        if self.exe is None:
+            raise errors.StoreError(
+                    '{} not installed or not available in PATH'.format(
+                        self.program
+                    )
+                )
         output = None
         env = create_environment_dict(self.environment)
         try:

--- a/tests/integration/credentials/store_test.py
+++ b/tests/integration/credentials/store_test.py
@@ -84,3 +84,10 @@ class TestStore:
         data = self.store._execute('--null', '')
         assert b'\0FOO=bar\0' in data
         assert 'FOO' not in os.environ
+
+    def test_unavailable_store(self):
+        some_unavailable_store = None
+        with pytest.warns(UserWarning):
+            some_unavailable_store = Store('that-does-not-exist')
+        with pytest.raises(StoreError):
+            some_unavailable_store.get('anything-this-does-not-matter')


### PR DESCRIPTION
This tries to resolve https://github.com/docker/docker-py/issues/3070