### PR TITLE
Add `one-shot` to container API `stats`

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1158,6 +1158,11 @@ class ContainerApiMixin:
                 )
             params['one-shot'] = one_shot
         if stream:
+            if one_shot is not None:
+                raise errors.InvalidArgument(
+                    'one_shot is only available in conjunction with '
+                    'stream=False'
+                )
             return self._stream_helper(self._get(url, params=params),
                                        decode=decode)
         else:

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1158,7 +1158,7 @@ class ContainerApiMixin:
                 )
             params['one-shot'] = one_shot
         if stream:
-            if one_shot is not None:
+            if one_shot:
                 raise errors.InvalidArgument(
                     'one_shot is only available in conjunction with '
                     'stream=False'

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1126,7 +1126,7 @@ class ContainerApiMixin:
         self._raise_for_status(res)
 
     @utils.check_resource('container')
-    def stats(self, container, decode=None, stream=True):
+    def stats(self, container, decode=None, stream=True, one_shot=False):
         """
         Stream statistics for a specific container. Similar to the
         ``docker stats`` command.
@@ -1138,6 +1138,9 @@ class ContainerApiMixin:
                 False by default.
             stream (bool): If set to false, only the current stats will be
                 returned instead of a stream. True by default.
+            one_shot (bool): If set to true, Only get a single stat instead of
+                waiting for 2 cycles. Must be used with stream=false. False by
+                default.
 
         Raises:
             :py:class:`docker.errors.APIError`
@@ -1146,15 +1149,15 @@ class ContainerApiMixin:
         """
         url = self._url("/containers/{0}/stats", container)
         if stream:
-            return self._stream_helper(self._get(url, stream=True),
-                                       decode=decode)
+            return self._stream_helper(self._get(url, params={'stream': True,
+                                       'one-shot': one_shot}), decode=decode)
         else:
             if decode:
                 raise errors.InvalidArgument(
                     "decode is only available in conjunction with stream=True"
                 )
-            return self._result(self._get(url, params={'stream': False}),
-                                json=True)
+            return self._result(self._get(url, params={'stream': False,
+                                'one-shot': one_shot}), json=True)
 
     @utils.check_resource('container')
     def stop(self, container, timeout=None):

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1533,7 +1533,8 @@ class ContainerTest(BaseAPIClientTest):
         )
 
     def test_container_stats_with_one_shot(self):
-        self.client.stats(fake_api.FAKE_CONTAINER_ID, stream=False, one_shot=True)
+        self.client.stats(
+            fake_api.FAKE_CONTAINER_ID, stream=False, one_shot=True)
 
         fake_request.assert_called_with(
             'GET',

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1529,7 +1529,17 @@ class ContainerTest(BaseAPIClientTest):
             'GET',
             url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/stats',
             timeout=60,
-            params={'stream': True, 'one-shot': False}
+            params={'stream': True}
+        )
+
+    def test_container_stats_with_one_shot(self):
+        self.client.stats(fake_api.FAKE_CONTAINER_ID, stream=False, one_shot=True)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/stats',
+            timeout=60,
+            params={'stream': False, 'one-shot': True}
         )
 
     def test_container_top(self):

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1529,7 +1529,7 @@ class ContainerTest(BaseAPIClientTest):
             'GET',
             url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/stats',
             timeout=60,
-            stream=True
+            params={'stream': True, 'one-shot': False}
         )
 
     def test_container_top(self):


### PR DESCRIPTION
Add the `one-shot` parameter to container stats to enable pulling just a single stats update.  New in docker engine [20.10.0](https://docs.docker.com/engine/release-notes/#20100).

See the moby PR: https://github.com/moby/moby/pull/40478