### PR TITLE
socket: fix for errors on pipe close in Windows

### DIFF
--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -49,7 +49,7 @@ def read(socket, n=4096):
         if is_pipe_ended:
             # npipes don't support duplex sockets, so we interpret
             # a PIPE_ENDED error as a close operation (0-length read).
-            return 0
+            return ''
         raise
 
 


### PR DESCRIPTION
Need to return data, not size. By returning an empty string, EOF will be detected properly since `len()` will be `0`.

Fixes #3098.