### PR TITLE
Add `copyUIDGID` support for `container.put_archive()`

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -957,7 +957,7 @@ class ContainerApiMixin:
         return h_ports
 
     @utils.check_resource('container')
-    def put_archive(self, container, path, data):
+    def put_archive(self, container, path, data, copy_uid_gid=False):
         """
         Insert a file or folder in an existing container using a tar archive as
         source.
@@ -967,6 +967,7 @@ class ContainerApiMixin:
             path (str): Path inside the container where the file(s) will be
                 extracted. Must exist.
             data (bytes or stream): tar data to be extracted
+            copy_uid_gid (bool): copy UID/GID maps to the dest file or dir
 
         Returns:
             (bool): True if the call succeeds.
@@ -975,7 +976,7 @@ class ContainerApiMixin:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
         """
-        params = {'path': path}
+        params = {'path': path, 'copyUIDGID': copy_uid_gid}
         url = self._url('/containers/{0}/archive', container)
         res = self._put(url, params=params, data=data)
         self._raise_for_status(res)

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -316,7 +316,7 @@ class Container(Model):
         """
         return self.client.api.pause(self.id)
 
-    def put_archive(self, path, data):
+    def put_archive(self, path, data, **kwargs):
         """
         Insert a file or folder in this container using a tar archive as
         source.
@@ -325,6 +325,7 @@ class Container(Model):
             path (str): Path inside the container where the file(s) will be
                 extracted. Must exist.
             data (bytes or stream): tar data to be extracted
+            copy_uid_gid (bool): copy UID/GID maps to the dest file or dir
 
         Returns:
             (bool): True if the call succeeds.
@@ -332,7 +333,7 @@ class Container(Model):
         Raises:
             :py:class:`~docker.errors.APIError` If an error occurs.
         """
-        return self.client.api.put_archive(self.id, path, data)
+        return self.client.api.put_archive(self.id, path, data, **kwargs)
 
     def remove(self, **kwargs):
         """


### PR DESCRIPTION
It should be noted though, it will use the `user` passed in `containers.create()`/`containers.run()` AND the user has to be made on the host machine with the same name/uid or else it'll fail. I ran into this issue while using `dind` and just added in it's `Dockerfile` to generate the same user with the same uid.