### PR TITLE
fix: exec_run -- default user-root

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -150,7 +150,7 @@ class Container(Model):
         return self.client.api.diff(self.id)
 
     def exec_run(self, cmd, stdout=True, stderr=True, stdin=False, tty=False,
-                 privileged=False, user='', detach=False, stream=False,
+                 privileged=False, user='root', detach=False, stream=False,
                  socket=False, environment=None, workdir=None, demux=False):
         """
         Run a command inside this container. Similar to


### PR DESCRIPTION
Fix #2979

According to [Docker docs](https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.Container.exec_run), `exec_run()` has user - `default: root` whereas `exec_run()` has `default:None` in its implementation


Changes Made:
```diff
- privileged=False, user='', detach=False, stream=False,
+ privileged=False, user='root', detach=False, stream=False,
```
> The relevant documentation appears to be the same in 4.1.0 (installed), stable, and latest.