### PR TITLE
Use windows api to honour timeouts (fixes #3111)

### DIFF
--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -188,7 +188,7 @@ class NpipeSocket:
             raise ValueError('Timeout value out of range')
         else:
             # Timeout mode - Value converted to milliseconds
-            self._timeout = value * 1000
+            self._timeout = int(value * 1000)
 
     def gettimeout(self):
         return self._timeout

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -4,6 +4,8 @@ import io
 
 import win32file
 import win32pipe
+import pywintypes
+import win32event
 
 cERROR_PIPE_BUSY = 0xe7
 cSECURITY_SQOS_PRESENT = 0x100000
@@ -131,13 +133,22 @@ class NpipeSocket:
         if not isinstance(buf, memoryview):
             readbuf = memoryview(buf)
 
+        event = win32event.CreateEvent(None, True, True, None)
+        overlapped = pywintypes.OVERLAPPED()
+        overlapped.hEvent = event
         err, data = win32file.ReadFile(
             self._handle,
-            readbuf[:nbytes] if nbytes else readbuf
+            readbuf[:nbytes] if nbytes else readbuf,
+            overlapped
         )
-        return len(data)
+        wait_result = win32event.WaitForSingleObject(event, self._timeout)
+        if wait_result == win32event.WAIT_TIMEOUT:
+            win32file.CancelIo(self._handle)
+            raise TimeoutError
+        return win32file.GetOverlappedResult(self._handle, overlapped, 0)
 
     def _recv_into_py2(self, buf, nbytes):
+        raise RuntimeError
         err, data = win32file.ReadFile(self._handle, nbytes or len(buf))
         n = len(data)
         buf[:n] = data
@@ -165,12 +176,9 @@ class NpipeSocket:
     def settimeout(self, value):
         if value is None:
             # Blocking mode
-            self._timeout = win32pipe.NMPWAIT_WAIT_FOREVER
+            self._timeout = win32event.INFINITE
         elif not isinstance(value, (float, int)) or value < 0:
             raise ValueError('Timeout value out of range')
-        elif value == 0:
-            # Non-blocking mode
-            self._timeout = win32pipe.NMPWAIT_NO_WAIT
         else:
             # Timeout mode - Value converted to milliseconds
             self._timeout = value * 1000

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -147,13 +147,6 @@ class NpipeSocket:
             raise TimeoutError
         return win32file.GetOverlappedResult(self._handle, overlapped, 0)
 
-    def _recv_into_py2(self, buf, nbytes):
-        raise RuntimeError
-        err, data = win32file.ReadFile(self._handle, nbytes or len(buf))
-        n = len(data)
-        buf[:n] = data
-        return n
-
     @check_closed
     def send(self, string, flags=0):
         event = win32event.CreateEvent(None, True, True, None)

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -56,7 +56,7 @@ class NpipeSocket:
                 0,
                 None,
                 win32file.OPEN_EXISTING,
-                cSECURITY_ANONYMOUS | cSECURITY_SQOS_PRESENT,
+                cSECURITY_ANONYMOUS | cSECURITY_SQOS_PRESENT | win32file.FILE_FLAG_OVERLAPPED,
                 0
             )
         except win32pipe.error as e:

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -57,7 +57,9 @@ class NpipeSocket:
                 0,
                 None,
                 win32file.OPEN_EXISTING,
-                cSECURITY_ANONYMOUS | cSECURITY_SQOS_PRESENT | win32file.FILE_FLAG_OVERLAPPED,
+                (cSECURITY_ANONYMOUS
+                    | cSECURITY_SQOS_PRESENT
+                    | win32file.FILE_FLAG_OVERLAPPED),
                 0
             )
         except win32pipe.error as e:


### PR DESCRIPTION
This fixes #3111 by using the overlapped file IO mode and associated wait windows api functions.