### PR TITLE
api: update return type of `diff` method

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -678,7 +678,8 @@ class ContainerApiMixin:
             container (str): The container to diff
 
         Returns:
-            (str)
+            (list) A list of dictionaries containing the attributes `Path`
+                and `Kind`.
 
         Raises:
             :py:class:`docker.errors.APIError`

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -141,7 +141,8 @@ class Container(Model):
         Inspect changes on a container's filesystem.
 
         Returns:
-            (str)
+            (list) A list of dictionaries containing the attributes `Path`
+                and `Kind`.
 
         Raises:
             :py:class:`docker.errors.APIError`


### PR DESCRIPTION
A minor fix, updating the documentation for the return type of the `diff` method for the Container model.