### PR TITLE
Make compatible with requests 2.29.0 and urllib3 2.0

### DIFF
--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -5,17 +5,13 @@ from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 from .npipesocket import NpipeSocket
 
-try:
-    import requests.packages.urllib3 as urllib3
-    import requests.packages.urllib3.connection as urllib3_connection
-except ImportError:
-    import urllib3
-    import urllib3.connection as urllib3_connection
+import urllib3
+import urllib3.connection
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
 
-class NpipeHTTPConnection(urllib3_connection.HTTPConnection):
+class NpipeHTTPConnection(urllib3.connection.HTTPConnection):
     def __init__(self, npipe_path, timeout=60):
         super().__init__(
             'localhost', timeout=timeout

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -5,17 +5,17 @@ from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 from .npipesocket import NpipeSocket
 
-import http.client as httplib
-
 try:
     import requests.packages.urllib3 as urllib3
+    import requests.packages.urllib3.connection as urllib3_connection
 except ImportError:
     import urllib3
+    import urllib3.connection as urllib3_connection
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
 
-class NpipeHTTPConnection(httplib.HTTPConnection):
+class NpipeHTTPConnection(urllib3_connection.HTTPConnection):
     def __init__(self, npipe_path, timeout=60):
         super().__init__(
             'localhost', timeout=timeout

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -11,12 +11,8 @@ import subprocess
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 
-try:
-    import requests.packages.urllib3 as urllib3
-    import requests.packages.urllib3.connection as urllib3_connection
-except ImportError:
-    import urllib3
-    import urllib3.connection as urllib3_connection
+import urllib3
+import urllib3.connection
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
@@ -99,7 +95,7 @@ class SSHSocket(socket.socket):
         self.proc.terminate()
 
 
-class SSHConnection(urllib3_connection.HTTPConnection):
+class SSHConnection(urllib3.connection.HTTPConnection):
     def __init__(self, ssh_transport=None, timeout=60, host=None):
         super().__init__(
             'localhost', timeout=timeout

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -11,12 +11,12 @@ import subprocess
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 
-import http.client as httplib
-
 try:
     import requests.packages.urllib3 as urllib3
+    import requests.packages.urllib3.connection as urllib3_connection
 except ImportError:
     import urllib3
+    import urllib3.connection as urllib3_connection
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
@@ -99,7 +99,7 @@ class SSHSocket(socket.socket):
         self.proc.terminate()
 
 
-class SSHConnection(httplib.HTTPConnection):
+class SSHConnection(urllib3_connection.HTTPConnection):
     def __init__(self, ssh_transport=None, timeout=60, host=None):
         super().__init__(
             'localhost', timeout=timeout

--- a/docker/transport/ssladapter.py
+++ b/docker/transport/ssladapter.py
@@ -7,10 +7,7 @@ from requests.adapters import HTTPAdapter
 
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 
-try:
-    import requests.packages.urllib3 as urllib3
-except ImportError:
-    import urllib3
+import urllib3
 
 
 PoolManager = urllib3.poolmanager.PoolManager

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -1,6 +1,5 @@
 import requests.adapters
 import socket
-import http.client as httplib
 
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
@@ -27,12 +26,6 @@ class UnixHTTPConnection(urllib3.connection.HTTPConnection):
         sock.settimeout(self.timeout)
         sock.connect(self.unix_socket)
         self.sock = sock
-
-    def putheader(self, header, *values):
-        super().putheader(header, *values)
-
-    def response_class(self, sock, *args, **kwargs):
-        return httplib.HTTPResponse(sock, *args, **kwargs)
 
 
 class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -5,18 +5,14 @@ import http.client as httplib
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
 
-try:
-    import requests.packages.urllib3 as urllib3
-    import requests.packages.urllib3.connection as urllib3_connection
-except ImportError:
-    import urllib3
-    import urllib3.connection as urllib3_connection
+import urllib3
+import urllib3.connection
 
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
 
-class UnixHTTPConnection(urllib3_connection.HTTPConnection):
+class UnixHTTPConnection(urllib3.connection.HTTPConnection):
 
     def __init__(self, base_url, unix_socket, timeout=60):
         super().__init__(

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -7,14 +7,16 @@ from .. import constants
 
 try:
     import requests.packages.urllib3 as urllib3
+    import requests.packages.urllib3.connection as urllib3_connection
 except ImportError:
     import urllib3
+    import urllib3.connection as urllib3_connection
 
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
 
-class UnixHTTPConnection(httplib.HTTPConnection):
+class UnixHTTPConnection(urllib3_connection.HTTPConnection):
 
     def __init__(self, base_url, unix_socket, timeout=60):
         super().__init__(

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -1,9 +1,6 @@
 import socket
 
-try:
-    import requests.packages.urllib3 as urllib3
-except ImportError:
-    import urllib3
+import urllib3
 
 from ..errors import DockerException
 

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -16,9 +16,9 @@ import http.server
 import docker
 import pytest
 import requests
+import urllib3
 from docker.api import APIClient
 from docker.constants import DEFAULT_DOCKER_API_VERSION
-from requests.packages import urllib3
 from unittest import mock
 
 from . import fake_api


### PR DESCRIPTION
Fixes at least part of #3113. (Recent requests versions declare that they need urllib3 < 2.0 since at least 2017, so the urllib3 problems themselves shouldn't really appear except when forcing invalid combinations of requests and urllib3. My hope is that the urllib3 2.0 compatibility is something that only needs changes on the side of requests, and not here - but who knows...)

Since requests 2.29.0, requests uses urllib3's native chunking ability (see https://github.com/psf/requests/pull/6226). By using urllib3's `HTTPConnection` class (which extends httplib.HTTPConnection`) we make sure that our HTTP transports support this as well.

I was able to reproduce the problem by calling `APIClient.put_archive()`; the change in this PR fixes the problem for me. (I'm working on a modified vendored version of Docker SDK for Python, so YMMV.)