### PR TITLE
Fix urllib3 2.0 compatibility

### DIFF
--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -1,6 +1,5 @@
 import requests.adapters
 import socket
-import http.client as httplib
 
 from docker.transport.basehttpadapter import BaseHTTPAdapter
 from .. import constants
@@ -14,7 +13,7 @@ except ImportError:
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 
 
-class UnixHTTPConnection(httplib.HTTPConnection):
+class UnixHTTPConnection(urllib3.connection.HTTPConnection):
 
     def __init__(self, base_url, unix_socket, timeout=60):
         super().__init__(
@@ -29,12 +28,6 @@ class UnixHTTPConnection(httplib.HTTPConnection):
         sock.settimeout(self.timeout)
         sock.connect(self.unix_socket)
         self.sock = sock
-
-    def putheader(self, header, *values):
-        super().putheader(header, *values)
-
-    def response_class(self, sock, *args, **kwargs):
-        return httplib.HTTPResponse(sock, *args, **kwargs)
 
 
 class UnixHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):


### PR DESCRIPTION
By inheriting from `urllib3.connection.HTTPConnection` (that inherits from `httplib.HTTPConnection` itself), we can adapt to the internal changes in urllib3 2.0 that added a `request()` method that is incompatible with `httplib.HTTPConnection.request`.

See https://github.com/docker/docker-py/issues/3113#issuecomment-1531570788 for details.