### PR TITLE
Fix container.stats infinite blocking on stream mode

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1164,8 +1164,9 @@ class ContainerApiMixin:
                     'one_shot is only available in conjunction with '
                     'stream=False'
                 )
-            return self._stream_helper(self._get(url, params=params),
-                                       decode=decode)
+            return self._stream_helper(
+                self._get(url, stream=True, params=params), decode=decode
+            )
         else:
             if decode:
                 raise errors.InvalidArgument(

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1528,8 +1528,19 @@ class ContainerTest(BaseAPIClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/stats',
+            stream=True,
             timeout=60,
             params={'stream': True}
+        )
+
+    def test_container_stats_without_streaming(self):
+        self.client.stats(fake_api.FAKE_CONTAINER_ID, stream=False)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/stats',
+            timeout=60,
+            params={'stream': False}
         )
 
     def test_container_stats_with_one_shot(self):


### PR DESCRIPTION
Original Issue: #3118
 
**Cause**
The HTTP client is not invoked with the stream mode when making the GET HTTP call for the stats API, leading to the client trying to read the whole response instead of treating it as a stream, causing a infinite block. 

This seems to be a regression from e9d4ddfa

**Fix**
Add the removed `stream` parameter when making the GET Request call

**Notes**
Includes additional test for non streaming mode


Fixes #3118 
