### PR TITLE
Support all `Network.connect` parameters in `client.containers.run` and `client.containers.create`

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -1148,14 +1148,14 @@ def _create_container_args(kwargs):
     network = kwargs.pop('network', None)
     network_config = kwargs.pop('network_config', None)
     if network:
-        network_configuration = EndpointConfig(
+        endpoint_config = EndpointConfig(
             host_config_kwargs['version'],
             **network_config
         ) if network_config else None
 
         create_kwargs['networking_config'] = NetworkingConfig(
-            {network: network_configuration}
-        )
+            {network: endpoint_config}
+        ) if endpoint_config else {network: None}
         host_config_kwargs['network_mode'] = network
 
     # All kwargs should have been consumed by this point, so raise

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -870,9 +870,9 @@ class ContainerCollection(Collection):
                 'together.'
             )
 
-        if kwargs.get('network_driver_opt') and not kwargs.get('network'):
+        if kwargs.get('network_config') and not kwargs.get('network'):
             raise RuntimeError(
-                'The options "network_driver_opt" can not be used '
+                'The option "network_config" can not be used '
                 'without "network".'
             )
 

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -5,10 +5,10 @@ import threading
 import pytest
 
 import docker
-from ..helpers import random_name
-from ..helpers import requires_api_version
 from .base import BaseIntegrationTest
 from .base import TEST_API_VERSION
+from ..helpers import random_name
+from ..helpers import requires_api_version
 
 
 class ContainerCollectionTest(BaseIntegrationTest):
@@ -104,7 +104,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert 'Networks' in attrs['NetworkSettings']
         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
 
-    def test_run_with_network_config(self):
+    def test_run_with_networking_config(self):
         net_name = random_name()
         client = docker.from_env(version=TEST_API_VERSION)
         client.networks.create(net_name)
@@ -113,10 +113,16 @@ class ContainerCollectionTest(BaseIntegrationTest):
         test_aliases = ['hello']
         test_driver_opt = {'key1': 'a'}
 
+        networking_config = {
+            net_name: client.api.create_endpoint_config(
+                aliases=test_aliases,
+                driver_opt=test_driver_opt
+            )
+        }
+
         container = client.containers.run(
             'alpine', 'echo hello world', network=net_name,
-            network_config={'aliases': test_aliases,
-                            'driver_opt': test_driver_opt},
+            networking_config=networking_config,
             detach=True
         )
         self.tmp_containers.append(container.id)
@@ -131,7 +137,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert attrs['NetworkSettings']['Networks'][net_name]['DriverOpts'] \
                == test_driver_opt
 
-    def test_run_with_network_config_undeclared_params(self):
+    def test_run_with_networking_config_with_undeclared_network(self):
         net_name = random_name()
         client = docker.from_env(version=TEST_API_VERSION)
         client.networks.create(net_name)
@@ -140,11 +146,41 @@ class ContainerCollectionTest(BaseIntegrationTest):
         test_aliases = ['hello']
         test_driver_opt = {'key1': 'a'}
 
+        networking_config = {
+            net_name: client.api.create_endpoint_config(
+                aliases=test_aliases,
+                driver_opt=test_driver_opt
+            ),
+            'bar': client.api.create_endpoint_config(
+                aliases=['test'],
+                driver_opt={'key2': 'b'}
+            ),
+        }
+
+        with pytest.raises(docker.errors.APIError) as e:
+            container = client.containers.run(
+                'alpine', 'echo hello world', network=net_name,
+                networking_config=networking_config,
+                detach=True
+            )
+            self.tmp_containers.append(container.id)
+
+    def test_run_with_networking_config_only_undeclared_network(self):
+        net_name = random_name()
+        client = docker.from_env(version=TEST_API_VERSION)
+        client.networks.create(net_name)
+        self.tmp_networks.append(net_name)
+
+        networking_config = {
+            'bar': client.api.create_endpoint_config(
+                aliases=['hello'],
+                driver_opt={'key1': 'a'}
+            ),
+        }
+
         container = client.containers.run(
             'alpine', 'echo hello world', network=net_name,
-            network_config={'aliases': test_aliases,
-                            'driver_opt': test_driver_opt,
-                            'undeclared_param': 'random_value'},
+            networking_config=networking_config,
             detach=True
         )
         self.tmp_containers.append(container.id)
@@ -154,12 +190,9 @@ class ContainerCollectionTest(BaseIntegrationTest):
         assert 'NetworkSettings' in attrs
         assert 'Networks' in attrs['NetworkSettings']
         assert list(attrs['NetworkSettings']['Networks'].keys()) == [net_name]
-        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] == \
-               test_aliases
-        assert attrs['NetworkSettings']['Networks'][net_name]['DriverOpts'] \
-               == test_driver_opt
-        assert 'undeclared_param' not in \
-               attrs['NetworkSettings']['Networks'][net_name]
+        assert attrs['NetworkSettings']['Networks'][net_name]['Aliases'] is None
+        assert (attrs['NetworkSettings']['Networks'][net_name]['DriverOpts']
+                is None)
 
     def test_run_with_none_driver(self):
         client = docker.from_env(version=TEST_API_VERSION)
@@ -244,7 +277,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         container = client.containers.run("alpine", "sleep 300", detach=True)
         self.tmp_containers.append(container.id)
         assert client.containers.get(container.id).attrs[
-            'Config']['Image'] == "alpine"
+                   'Config']['Image'] == "alpine"
 
     def test_list(self):
         client = docker.from_env(version=TEST_API_VERSION)

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -541,7 +541,6 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'foo'}
         )
 
-
     def test_get(self):
         client = make_fake_client()
         container = client.containers.get(FAKE_CONTAINER_ID)

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -390,6 +390,44 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'foo'}
         )
 
+    def test_run_network_config_undeclared_params(self):
+        client = make_fake_client()
+
+        client.containers.run(
+            image='alpine',
+            network='foo',
+            network_config={'aliases': ['test'],
+                            'driver_opt': {'key1': 'a'},
+                            'undeclared_param': 'random_value'}
+        )
+
+        client.api.create_container.assert_called_with(
+            detach=False,
+            image='alpine',
+            command=None,
+            networking_config={'EndpointsConfig': {
+                'foo': {'Aliases': ['test'], 'DriverOpts': {'key1': 'a'}}}
+            },
+            host_config={'NetworkMode': 'foo'}
+        )
+
+    def test_run_network_config_only_undeclared_params(self):
+        client = make_fake_client()
+
+        client.containers.run(
+            image='alpine',
+            network='foo',
+            network_config={'undeclared_param': 'random_value'}
+        )
+
+        client.api.create_container.assert_called_with(
+            detach=False,
+            image='alpine',
+            command=None,
+            networking_config={'foo': None},
+            host_config={'NetworkMode': 'foo'}
+        )
+
     def test_create(self):
         client = make_fake_client()
         container = client.containers.create(
@@ -466,6 +504,43 @@ class ContainerCollectionTest(unittest.TestCase):
             },
             host_config={'NetworkMode': 'foo'}
         )
+
+    def test_create_network_config_undeclared_params(self):
+        client = make_fake_client()
+
+        client.containers.create(
+            image='alpine',
+            network='foo',
+            network_config={'aliases': ['test'],
+                            'driver_opt': {'key1': 'a'},
+                            'undeclared_param': 'random_value'}
+        )
+
+        client.api.create_container.assert_called_with(
+            image='alpine',
+            command=None,
+            networking_config={'EndpointsConfig': {
+                'foo': {'Aliases': ['test'], 'DriverOpts': {'key1': 'a'}}}
+            },
+            host_config={'NetworkMode': 'foo'}
+        )
+
+    def test_create_network_config_only_undeclared_params(self):
+        client = make_fake_client()
+
+        client.containers.create(
+            image='alpine',
+            network='foo',
+            network_config={'undeclared_param': 'random_value'}
+        )
+
+        client.api.create_container.assert_called_with(
+            image='alpine',
+            command=None,
+            networking_config={'foo': None},
+            host_config={'NetworkMode': 'foo'}
+        )
+
 
     def test_get(self):
         client = make_fake_client()

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -2,7 +2,8 @@ import pytest
 import unittest
 
 import docker
-from docker.constants import DEFAULT_DATA_CHUNK_SIZE, DEFAULT_DOCKER_API_VERSION
+from docker.constants import DEFAULT_DATA_CHUNK_SIZE, \
+    DEFAULT_DOCKER_API_VERSION
 from docker.models.containers import Container, _create_container_args
 from docker.models.images import Image
 from .fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID, FAKE_EXEC_ID

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -1,11 +1,13 @@
-import pytest
 import unittest
+
+import pytest
 
 import docker
 from docker.constants import DEFAULT_DATA_CHUNK_SIZE, \
     DEFAULT_DOCKER_API_VERSION
 from docker.models.containers import Container, _create_container_args
 from docker.models.images import Image
+from docker.types import EndpointConfig
 from .fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID, FAKE_EXEC_ID
 from .fake_api_client import make_fake_client
 
@@ -32,6 +34,13 @@ class ContainerCollectionTest(unittest.TestCase):
         )
 
     def test_create_container_args(self):
+        networking_config = {
+            'foo': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
+
         create_kwargs = _create_container_args(dict(
             image='alpine',
             command='echo hello world',
@@ -75,7 +84,7 @@ class ContainerCollectionTest(unittest.TestCase):
             name='somename',
             network_disabled=False,
             network='foo',
-            network_config={'aliases': ['test'], 'driver_opt': {'key1': 'a'}},
+            networking_config=networking_config,
             oom_kill_disable=True,
             oom_score_adj=5,
             pid_mode='host',
@@ -349,35 +358,41 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'default'},
         )
 
-    def test_run_network_config_without_network(self):
+    def test_run_networking_config_without_network(self):
         client = make_fake_client()
 
         with pytest.raises(RuntimeError):
             client.containers.run(
                 image='alpine',
-                network_config={'aliases': ['test'],
-                                'driver_opt': {'key1': 'a'}}
+                networking_config={'aliases': ['test'],
+                                   'driver_opt': {'key1': 'a'}}
             )
 
-    def test_run_network_config_with_network_mode(self):
+    def test_run_networking_config_with_network_mode(self):
         client = make_fake_client()
 
         with pytest.raises(RuntimeError):
             client.containers.run(
                 image='alpine',
                 network_mode='none',
-                network_config={'aliases': ['test'],
-                                'driver_opt': {'key1': 'a'}}
+                networking_config={'aliases': ['test'],
+                                   'driver_opt': {'key1': 'a'}}
             )
 
-    def test_run_network_config(self):
+    def test_run_networking_config(self):
         client = make_fake_client()
+
+        networking_config = {
+            'foo': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
 
         client.containers.run(
             image='alpine',
             network='foo',
-            network_config={'aliases': ['test'],
-                            'driver_opt': {'key1': 'a'}}
+            networking_config=networking_config
         )
 
         client.api.create_container.assert_called_with(
@@ -390,15 +405,24 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'foo'}
         )
 
-    def test_run_network_config_undeclared_params(self):
+    def test_run_networking_config_with_undeclared_network(self):
         client = make_fake_client()
+
+        networking_config = {
+            'foo': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test_foo'],
+                driver_opt={'key2': 'b'}
+            ),
+            'bar': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
 
         client.containers.run(
             image='alpine',
             network='foo',
-            network_config={'aliases': ['test'],
-                            'driver_opt': {'key1': 'a'},
-                            'undeclared_param': 'random_value'}
+            networking_config=networking_config
         )
 
         client.api.create_container.assert_called_with(
@@ -406,18 +430,26 @@ class ContainerCollectionTest(unittest.TestCase):
             image='alpine',
             command=None,
             networking_config={'EndpointsConfig': {
-                'foo': {'Aliases': ['test'], 'DriverOpts': {'key1': 'a'}}}
-            },
+                'foo': {'Aliases': ['test_foo'], 'DriverOpts': {'key2': 'b'}},
+                'bar': {'Aliases': ['test'], 'DriverOpts': {'key1': 'a'}},
+            }},
             host_config={'NetworkMode': 'foo'}
         )
 
-    def test_run_network_config_only_undeclared_params(self):
+    def test_run_networking_config_only_undeclared_network(self):
         client = make_fake_client()
+
+        networking_config = {
+            'bar': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
 
         client.containers.run(
             image='alpine',
             network='foo',
-            network_config={'undeclared_param': 'random_value'}
+            networking_config=networking_config
         )
 
         client.api.create_container.assert_called_with(
@@ -455,13 +487,13 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'default'}
         )
 
-    def test_create_network_config_without_network(self):
+    def test_create_networking_config_without_network(self):
         client = make_fake_client()
 
         client.containers.create(
             image='alpine',
-            network_config={'aliases': ['test'],
-                            'driver_opt': {'key1': 'a'}}
+            networking_config={'aliases': ['test'],
+                               'driver_opt': {'key1': 'a'}}
         )
 
         client.api.create_container.assert_called_with(
@@ -470,14 +502,14 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'default'}
         )
 
-    def test_create_network_config_with_network_mode(self):
+    def test_create_networking_config_with_network_mode(self):
         client = make_fake_client()
 
         client.containers.create(
             image='alpine',
             network_mode='none',
-            network_config={'aliases': ['test'],
-                            'driver_opt': {'key1': 'a'}}
+            networking_config={'aliases': ['test'],
+                               'driver_opt': {'key1': 'a'}}
         )
 
         client.api.create_container.assert_called_with(
@@ -486,14 +518,20 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'none'}
         )
 
-    def test_create_network_config(self):
+    def test_create_networking_config(self):
         client = make_fake_client()
+
+        networking_config = {
+            'foo': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
 
         client.containers.create(
             image='alpine',
             network='foo',
-            network_config={'aliases': ['test'],
-                            'driver_opt': {'key1': 'a'}}
+            networking_config=networking_config
         )
 
         client.api.create_container.assert_called_with(
@@ -505,33 +543,50 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'foo'}
         )
 
-    def test_create_network_config_undeclared_params(self):
+    def test_create_networking_config_with_undeclared_network(self):
         client = make_fake_client()
+
+        networking_config = {
+            'foo': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test_foo'],
+                driver_opt={'key2': 'b'}
+            ),
+            'bar': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
 
         client.containers.create(
             image='alpine',
             network='foo',
-            network_config={'aliases': ['test'],
-                            'driver_opt': {'key1': 'a'},
-                            'undeclared_param': 'random_value'}
+            networking_config=networking_config
         )
 
         client.api.create_container.assert_called_with(
             image='alpine',
             command=None,
             networking_config={'EndpointsConfig': {
-                'foo': {'Aliases': ['test'], 'DriverOpts': {'key1': 'a'}}}
-            },
+                'foo': {'Aliases': ['test_foo'], 'DriverOpts': {'key2': 'b'}},
+                'bar': {'Aliases': ['test'], 'DriverOpts': {'key1': 'a'}},
+            }},
             host_config={'NetworkMode': 'foo'}
         )
 
-    def test_create_network_config_only_undeclared_params(self):
+    def test_create_networking_config_only_undeclared_network(self):
         client = make_fake_client()
+
+        networking_config = {
+            'bar': EndpointConfig(
+                DEFAULT_DOCKER_API_VERSION, aliases=['test'],
+                driver_opt={'key1': 'a'}
+            )
+        }
 
         client.containers.create(
             image='alpine',
             network='foo',
-            network_config={'undeclared_param': 'random_value'}
+            networking_config=networking_config
         )
 
         client.api.create_container.assert_called_with(


### PR DESCRIPTION
In PR #3083, I introduced the support for the `network_driver_opt` parameter in `client.containers` `run` and `create`.

This PR will further extend this support, by adding all the parameters of `Network.connect` to the aforementioned methods.

I changed the methods signature a bit, removing the `network_driver_opts` parameter and adding a dict called `network_config` that supports all the parameters.

I would kindly request if it possible to release a newer version of dockerpy with this feature merged soon, since I need it to continue developing some [Kathará](https://github.com/KatharaFramework/Kathara) features. Thanks.