### PR TITLE
feat: move websocket-client to extra dependency

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -5,7 +5,6 @@ from functools import partial
 
 import requests
 import requests.exceptions
-import websocket
 
 from .. import auth
 from ..constants import (DEFAULT_NUM_POOLS, DEFAULT_NUM_POOLS_SSH,
@@ -312,7 +311,16 @@ class APIClient(
         return self._create_websocket_connection(full_url)
 
     def _create_websocket_connection(self, url):
-        return websocket.create_connection(url)
+        try:
+            import websocket
+            return websocket.create_connection(url)
+        except ImportError as ie:
+            raise DockerException(
+                'The `websocket-client` library is required '
+                'for using websocket connections. '
+                'You can install the `docker` library '
+                'with the [websocket] extra to install it.'
+            ) from ie
 
     def _get_raw_response_socket(self, response):
         self._raise_for_status(response)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ requirements = [
     'packaging >= 14.0',
     'requests >= 2.26.0',
     'urllib3 >= 1.26.0',
-    'websocket-client >= 0.32.0',
 ]
 
 extras_require = {
@@ -27,6 +26,9 @@ extras_require = {
 
     # Only required when connecting using the ssh:// protocol
     'ssh': ['paramiko>=2.4.3'],
+
+    # Only required when using websockets
+    'websockets': ['websocket-client >= 1.3.0'],
 }
 
 with open('./test-requirements.txt') as test_reqs_txt:


### PR DESCRIPTION
Since `websocket-client` is _only_ required when using websockets for attaching to containers (https://github.com/docker/docker-py/pull/62), I don't think it needs to be a required dependency.

This also bumps the minimum required version of `websocket-client` to that pinned by #3022.