### PR TITLE
Avoid socket timeouts when executing commands

### DIFF
--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -37,7 +37,7 @@ def read(socket, n=4096):
             select.select([socket], [], [])
         else:
             poll = select.poll()
-            poll.register(socket)
+            poll.register(socket, select.POLLIN | select.POLLPRI)
             poll.poll()
 
     try:


### PR DESCRIPTION
Only listen to read events when polling a socket in order to avoid incorrectly trying to read from a socket that is not actually ready.