### PR TITLE
fix user_guides/multiplex.rst

### DIFF
--- a/docs/user_guides/multiplex.rst
+++ b/docs/user_guides/multiplex.rst
@@ -16,10 +16,13 @@ Prepare the command we are going to use. It prints "hello stdout"
 in `stdout`, followed by "hello stderr" in `stderr`:
 
 >>> cmd = '/bin/sh -c "echo hello stdout ; echo hello stderr >&2"'
+
 We'll run this command with all four the combinations of ``stream``
 and ``demux``.
+
 With ``stream=False`` and ``demux=False``, the output is a string
 that contains both the `stdout` and the `stderr` output:
+
 >>> res = container.exec_run(cmd, stream=False, demux=False)
 >>> res.output
 b'hello stderr\nhello stdout\n'
@@ -52,15 +55,8 @@ Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 StopIteration
 
-Finally, with ``stream=False`` and ``demux=True``, the whole output
-is returned, but the streams are still separated:
+Finally, with ``stream=False`` and ``demux=True``, the output is a tuple ``(stdout, stderr)``:
 
->>> res = container.exec_run(cmd, stream=True, demux=True)
->>> next(res.output)
-(b'hello stdout\n', None)
->>> next(res.output)
-(None, b'hello stderr\n')
->>> next(res.output)
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-StopIteration
+>>> res = container.exec_run(cmd, stream=False, demux=True)
+>>> res.output
+(b'hello stdout\n', b'hello stderr\n')


### PR DESCRIPTION
The format is wrong and the code in last case (``stream=False`` and ``demux=True``) is the same as the ``stream=True`` and ``demux=True`` one.