### PR TITLE
fix: eventlet compatibility

### DIFF
--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -3,7 +3,6 @@ import os
 import select
 import socket as pysocket
 import struct
-import sys
 
 try:
     from ..transport import NpipeSocket
@@ -32,7 +31,7 @@ def read(socket, n=4096):
     recoverable_errors = (errno.EINTR, errno.EDEADLK, errno.EWOULDBLOCK)
 
     if not isinstance(socket, NpipeSocket):
-        if sys.platform == 'win32':
+        if not hasattr(select, "poll"):
             # Limited to 1024
             select.select([socket], [], [])
         else:


### PR DESCRIPTION
The implementation done in #2865 is breaking usage of docker-py library within eventlet. As per the Python `select.poll` documentation (https://docs.python.org/3/library/select.html#select.poll) and eventlet select removal advice (https://github.com/eventlet/eventlet/issues/608#issuecomment-612359458), it is preferable to use an implementation based on the availability of the `poll()` method that trying to check if the platform is `win32`.

Fixes #3131