### PR TITLE
test: remove APT_MIRROR from Dockerfile

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,10 +4,6 @@ ARG PYTHON_VERSION=3.10
 
 FROM python:${PYTHON_VERSION}
 
-ARG APT_MIRROR
-RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
-    && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
-
 RUN apt-get update && apt-get -y install --no-install-recommends \
     gnupg2 \
     pass


### PR DESCRIPTION
The official Python images on Docker Hub switched to debian bookworm, which is now the current stable version of Debian.

However, the location of the apt repository config file changed, which causes the Dockerfile build to fail;

    Loaded image: emptyfs:latest
    Loaded image ID: sha256:0df1207206e5288f4a989a2f13d1f5b3c4e70467702c1d5d21dfc9f002b7bd43
    INFO: Building docker-sdk-python3:5.0.3...
    tests/Dockerfile:6
    --------------------
       5 |     ARG APT_MIRROR
       6 | >>> RUN sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
       7 | >>>     && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list
       8 |
    --------------------
    ERROR: failed to solve: process "/bin/sh -c sed -ri \"s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g\" /etc/apt/sources.list     && sed -ri \"s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g\" /etc/apt/sources.list" did not complete successfully: exit code: 2

The APT_MIRROR build-arg was originally added when the Debian package repositories were known to be unreliable, but that hasn't been the case for quite a while, so let's remove this altogether.