### PR TITLE
Adding build progress callback to client.images.build

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -219,7 +219,7 @@ class RegistryData(Model):
 class ImageCollection(Collection):
     model = Image
 
-    def build(self, **kwargs):
+    def build(self, progress_callback=None, **kwargs):
         """
         Build an image and return it. Similar to the ``docker build``
         command. Either ``path`` or ``fileobj`` must be set.
@@ -281,6 +281,9 @@ class ImageCollection(Collection):
                 configuration file (``~/.docker/config.json`` by default)
                 contains a proxy configuration, the corresponding environment
                 variables will be set in the container being built.
+            progress_callback Callable[[int, int, str], None]: Will get called
+                with the following arguments: current_step, max_step, details
+                Default: `None`.
 
         Returns:
             (tuple): The first item is the :py:class:`Image` object for the
@@ -305,12 +308,24 @@ class ImageCollection(Collection):
             if 'error' in chunk:
                 raise BuildError(chunk['error'], result_stream)
             if 'stream' in chunk:
+
                 match = re.search(
                     r'(^Successfully built |sha256:)([0-9a-f]+)$',
                     chunk['stream']
                 )
                 if match:
                     image_id = match.group(2)
+                else:
+                    match = re.match(
+                        r'Step (\d+)/(\d+) : (.+)',
+                        chunk['stream']
+                    )
+                    if match and callable(progress_callback):
+                        progress_callback(
+                            int(match.group(1)),
+                            int(match.group(2)),
+                            match.group(3)
+                        )
             last_event = chunk
         if image_id:
             return (self.get(image_id), result_stream)


### PR DESCRIPTION
## Description

Since the `ImageCollection.build` function return (image_id, result_stream), it cannot be used as generator for getting progress. I added a `progress_callback: Callable[[int, int, str], None]` functions that can be passed as argument when building an image.

The existing program is already parsing the stream from `BuildApiMixin.build`, I simply added a regex which is looking for string matching the format `Step X/Y: details`, and sending to the callable function the current_step, the maximum number of step, and the step details.

## Related issues
- https://github.com/docker/docker-py/issues/1400
- https://github.com/kinu-garage/docker_vcstool/issues/1
- https://github.com/docker/docker-py/issues/2080