### PR TITLE
fix: use response.text to get string rather than bytes

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -27,7 +27,7 @@ def create_api_error_from_http_exception(e):
     try:
         explanation = response.json()['message']
     except ValueError:
-        explanation = (response.content or '').strip()
+        explanation = (response.text or '').strip()
     cls = APIError
     if response.status_code == 404:
         explanation_msg = (explanation or '').lower()


### PR DESCRIPTION
Fixes; https://github.com/docker/docker-py/issues/3151

`response.content` returns bytes which eventually fails at line 34 when searching for image not found error message.

This change fixes it by using `response.text` which returns string rather than bytes.