### PR TITLE
feat: add pause option to commit api

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -112,7 +112,7 @@ class ContainerApiMixin:
 
     @utils.check_resource('container')
     def commit(self, container, repository=None, tag=None, message=None,
-               author=None, changes=None, conf=None):
+               author=None, pause=True, changes=None, conf=None):
         """
         Commit a container to an image. Similar to the ``docker commit``
         command.
@@ -123,6 +123,7 @@ class ContainerApiMixin:
             tag (str): The tag to push
             message (str): A commit message
             author (str): The name of the author
+            pause (bool): Whether to pause the container before committing
             changes (str): Dockerfile instructions to apply while committing
             conf (dict): The configuration for the container. See the
                 `Engine API documentation
@@ -139,6 +140,7 @@ class ContainerApiMixin:
             'tag': tag,
             'comment': message,
             'author': author,
+            'pause': pause,
             'changes': changes
         }
         u = self._url("/commit")

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -121,6 +121,7 @@ class Container(Model):
             tag (str): The tag to push
             message (str): A commit message
             author (str): The name of the author
+            pause (bool): Whether to pause the container before committing
             changes (str): Dockerfile instructions to apply while committing
             conf (dict): The configuration for the container. See the
                 `Engine API documentation

--- a/tests/unit/api_image_test.py
+++ b/tests/unit/api_image_test.py
@@ -102,6 +102,7 @@ class ImageTest(BaseAPIClientTest):
                 'tag': None,
                 'container': fake_api.FAKE_CONTAINER_ID,
                 'author': None,
+                'pause': True,
                 'changes': None
             },
             timeout=DEFAULT_TIMEOUT_SECONDS


### PR DESCRIPTION
When using `container.commit()` function, it default to pause the container before committing. In some case that could't pause the container, we need to use `container.commit(pause=False)`。