### PR TITLE
tests/integration: fix flake8 failures (E721 do not compare types)

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -1392,7 +1392,7 @@ class GetContainerStatsTest(BaseAPIIntegrationTest):
         response = self.client.stats(container, stream=0)
         self.client.kill(container)
 
-        assert type(response) == dict
+        assert isinstance(response, dict)
         for key in ['read', 'networks', 'precpu_stats', 'cpu_stats',
                     'memory_stats', 'blkio_stats']:
             assert key in response
@@ -1405,7 +1405,7 @@ class GetContainerStatsTest(BaseAPIIntegrationTest):
             self.client.start(container)
             stream = self.client.stats(container)
             for chunk in stream:
-                assert type(chunk) == dict
+                assert isinstance(chunk, dict)
                 for key in ['read', 'network', 'precpu_stats', 'cpu_stats',
                             'memory_stats', 'blkio_stats']:
                     assert key in chunk

--- a/tests/integration/api_image_test.py
+++ b/tests/integration/api_image_test.py
@@ -32,7 +32,7 @@ class ListImagesTest(BaseAPIIntegrationTest):
 
     def test_images_quiet(self):
         res1 = self.client.images(quiet=True)
-        assert type(res1[0]) == str
+        assert isinstance(res1[0], str)
 
 
 class PullImageTest(BaseAPIIntegrationTest):
@@ -43,7 +43,7 @@ class PullImageTest(BaseAPIIntegrationTest):
             pass
         res = self.client.pull('hello-world')
         self.tmp_imgs.append('hello-world')
-        assert type(res) == str
+        assert isinstance(res, str)
         assert len(self.client.images('hello-world')) >= 1
         img_info = self.client.inspect_image('hello-world')
         assert 'Id' in img_info


### PR DESCRIPTION
- relates to https://github.com/docker/docker-py/pull/3165, where I saw these failures.


    Run flake8 docker/ tests/
      flake8 docker/ tests/
      shell: /usr/bin/bash -e {0}
      env:
        DOCKER_BUILDKIT: 1
        pythonLocation: /opt/hostedtoolcache/Python/3.11.4/x64
        PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib/pkgconfig
        Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
        Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
        Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.11.4/x64
        LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.11.4/x64/lib
    tests/integration/api_container_test.py:1395:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    tests/integration/api_container_test.py:1408:24: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    tests/integration/api_image_test.py:35:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    tests/integration/api_image_test.py:46:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    Error: Process completed with exit code 1.