### PR TITLE
[Bug report] Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - uses: actions/setup-python@v4
               with:
-                  python-version: '3.11'
+                  python-version: '3.x'
             - run: pip install -U ruff==0.0.284
             - name: Run ruff
               run: ruff docker tests
@@ -21,14 +21,15 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+                python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
+                allow-prereleases: true
             - name: Install dependencies
               run: |
                   python3 -m pip install --upgrade pip
@@ -46,7 +47,7 @@ jobs:
                 variant: [ "integration-dind", "integration-dind-ssl", "integration-dind-ssh" ]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: make ${{ matrix.variant }}
               run: |
                   docker logout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   DOCKER_BUILDKIT: '1'
+  FORCE_COLOR: 1
 
 jobs:
     lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         type: boolean
         default: true
 
+env:
+  DOCKER_BUILDKIT: '1'
+  FORCE_COLOR: 1
+
 jobs:
   publish:
     runs-on: ubuntu-22.04

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development',
         'Topic :: Utilities',
         'License :: OSI Approved :: Apache Software License',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 setuptools==65.5.1
-coverage==6.4.2
+coverage==7.2.7
 ruff==0.0.284
-pytest==7.1.2
-pytest-cov==3.0.0
+pytest==7.4.2
+pytest-cov==4.1.0
 pytest-timeout==2.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}, ruff
+envlist = py{37,38,39,310,311,312}, ruff
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
The [second and final Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

The full Python 3.12.0 release is in under a month: 2023-10-02.


# Bug report

Consider this a PR a bug report, the Python 3.12 build fails:

```pytb
________________ ERROR collecting tests/unit/ssladapter_test.py ________________
ImportError while importing test module '/home/runner/work/docker-py/docker-py/tests/unit/ssladapter_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.12.0-rc.2/x64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/unit/ssladapter_test.py:2: in <module>
    from ssl import match_hostname, CertificateError
E   ImportError: cannot import name 'match_hostname' from 'ssl' (/opt/hostedtoolcache/Python/3.12.0-rc.2/x64/lib/python3.12/ssl.py)
```

This is because `ssl.match_hostname` was removed in Python 3.12 after being deprecated in 3.7:

* https://docs.python.org/3.12/whatsnew/3.12.html#removed
* https://docs.python.org/3.11/library/ssl.html#ssl.match_hostname

# Replacements

Here's how a couple of other projects dealt with it:

* https://github.com/urllib3/urllib3/pull/2448 vendored `ssl.match_hostname`
* https://github.com/aiortc/aioquic/pull/389 replaced `ssl.match_hostname` with PyCA's `service-identity`

Feel free to use this PR as a starting point for fixing it as you see best, or close this as needed.

Thanks!