### PR TITLE
chore: remove support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
         steps:
             - uses: actions/checkout@v4

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,14 +1,8 @@
 try:
     from ._version import __version__
 except ImportError:
+    from importlib.metadata import version, PackageNotFoundError
     try:
-        # importlib.metadata available in Python 3.8+, the fallback (0.0.0)
-        # is fine because release builds use _version (above) rather than
-        # this code path, so it only impacts developing w/ 3.7
-        from importlib.metadata import version, PackageNotFoundError
-        try:
-            __version__ = version('docker')
-        except PackageNotFoundError:
-            __version__ = '0.0.0'
-    except ImportError:
+        __version__ = version('docker')
+    except PackageNotFoundError:
         __version__ = '0.0.0'

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=requirements,
     tests_require=test_requirements,
     extras_require=extras_require,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     zip_safe=False,
     test_suite='tests',
     classifiers=[
@@ -69,7 +69,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Python 3.7 reached EOL in June 2023: https://endoflife.date/python