### PR TITLE
chore: update MAINTAINERS and remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# GitHub code owners
-# See https://help.github.com/articles/about-codeowners/
-#
-# KEEP THIS FILE SORTED. Order is important. Last match takes precedence.
-
-*       @aiordache @ulyssessouza

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,17 +11,19 @@
 [Org]
 	[Org."Core maintainers"]
 		people = [
-			"aiordache",
-			"ulyssessouza",
+		    "glours",
+		    "milas",
 		]
 	[Org.Alumni]
 		people = [
+		    "aiordache",
 			"aanand",
 			"bfirsh",
 			"dnephin",
 			"mnowster",
 			"mpetazzoni",
 			"shin-",
+			"ulyssessouza",
 		]
 
 [people]
@@ -51,6 +53,16 @@
 	Name = "Daniel Nephin"
 	Email = "dnephin@gmail.com"
 	GitHub = "dnephin"
+
+	[people.glours]
+	Name = "Guillaume Lours"
+	Email = "705411+glours@users.noreply.github.com"
+	GitHub = "glours"
+
+	[people.milas]
+	Name = "Milas Bowman"
+	Email = "devnull@milas.dev"
+	GitHub = "milas"
 
 	[people.mnowster]
 	Name = "Mazz Mosley"


### PR DESCRIPTION
Update `MAINTAINERS` with the current folks, adn remove the `CODEOWNERS` file entirely -- it's not really helpful here, as this project isn't big enough to have multiple subsections with different maintainers/owners.