### PR TITLE
chore: fix missing setuptools in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Generate Pacakge
         run: |
-          pip3 install wheel
+          pip3 install setuptools wheel
           python setup.py sdist bdist_wheel
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DOCKER: ${{ inputs.tag }}


### PR DESCRIPTION
Install `setuptools` in addition to `wheel` before trying to run `python setup.py` manually.

Note that `setuptools` is already correctly listed in the `pyproject.toml` file for consumers installing via `pip` etc, but in CI the file is run directly to generate `sdist` and `bdist_wheel` artifacts for PyPI.

See failing CI log here: https://github.com/docker/docker-py/actions/runs/6947629399/job/18901833765