### PR TITLE
chore: update changelog and maintainer

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -20,9 +20,11 @@ Changelog
 - Add `health()` property to container that returns status (e.g. `unhealthy`)
 - Add `pause` option to `container.commit()`
 - Add support for bind mount propagation (e.g. `rshared`, `private`)
+- Add `filters`, `keep_storage`, and `all` parameters to `prune_builds()` (requires API v1.39+)
 
 ### Bugfixes
 - Consistently return `docker.errors.NotFound` on 404 responses
+- Validate tag format before image push
 
 ### Miscellaneous
 - Upgraded urllib3 version in `requirements.txt` (used for development/tests)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,6 @@ setup(
         'Topic :: Utilities',
         'License :: OSI Approved :: Apache Software License',
     ],
-    maintainer='Ulysses Souza',
-    maintainer_email='ulysses.souza@docker.com',
+    maintainer='Docker, Inc.',
+    maintainer_email='no-reply@docker.com',
 )


### PR DESCRIPTION
Preparing for the 7.0.0 final release 🎉

Added a couple more changelog items that came in as part of `7.0.0b2` and updated the maintainer to be generically Docker, Inc. instead of an individual.