### PR TITLE
fix: tag regex should allow ports

### DIFF
--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -10,8 +10,9 @@ from ..constants import IS_WINDOWS_PLATFORM
 
 _SEP = re.compile('/|\\\\') if IS_WINDOWS_PLATFORM else re.compile('/')
 _TAG = re.compile(
-    r"^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*" \
-        + "(:[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127})?$"
+    r"^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*" \
+    + "(?::[0-9]+)?(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*" \
+    + "(:[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127})?$"
 )
 
 


### PR DESCRIPTION
Closes: https://github.com/docker/docker-py/issues/3195
Related: https://github.com/opencontainers/distribution-spec/pull/498

notice: there is a false positive warning from ruff during `make test`:

```
docker/utils/build.py:14:33: W605 [*] Invalid escape sequence: `\.`
```

but it's a valid escape sequence, because it's a regex, had no idea yet how to fix this without introducing more complexity.