### PR TITLE
utils: Fix datetime_to_timestamp

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -5,7 +5,7 @@ import os
 import os.path
 import shlex
 import string
-from datetime import datetime
+from datetime import datetime, timezone
 from packaging.version import Version
 
 from .. import errors
@@ -394,8 +394,8 @@ def convert_filters(filters):
 
 
 def datetime_to_timestamp(dt):
-    """Convert a UTC datetime to a Unix timestamp"""
-    delta = dt - datetime.utcfromtimestamp(0)
+    """Convert a datetime to a Unix timestamp"""
+    delta = dt.astimezone(timezone.utc) - datetime(1970, 1, 1, tzinfo=timezone.utc)
     return delta.seconds + delta.days * 24 * 3600
 
 


### PR DESCRIPTION
Replace usage of deprecated function `datetime.utcfromtimestamp` and make sure the input date is UTC before subtracting.

Fixes warning:
```
 tests/integration/client_test.py::CancellableEventsTest::test_cancel_events
  /src/docker/utils/utils.py:398: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    delta = dt - datetime.utcfromtimestamp(0)
```