### PR TITLE
lint: fix string formatting

### DIFF
--- a/tests/unit/models_configs_test.py
+++ b/tests/unit/models_configs_test.py
@@ -7,4 +7,4 @@ class CreateConfigsTest(unittest.TestCase):
     def test_create_config(self):
         client = make_fake_client()
         config = client.configs.create(name="super_config", data="config")
-        assert config.__repr__() == "<Config: '{}'>".format(FAKE_CONFIG_NAME)
+        assert config.__repr__() == f"<Config: '{FAKE_CONFIG_NAME}'>"


### PR DESCRIPTION
Merged a linter upgrade along with an older PR, so this was immediately in violation