### PR TITLE
Enable Ruff I (import sort), autofix

### DIFF
--- a/docker/__init__.py
+++ b/docker/__init__.py
@@ -1,7 +1,6 @@
 from .api import APIClient
 from .client import DockerClient, from_env
-from .context import Context
-from .context import ContextAPI
+from .context import Context, ContextAPI
 from .tls import TLSConfig
 from .version import __version__
 

--- a/docker/api/build.py
+++ b/docker/api/build.py
@@ -3,11 +3,7 @@ import logging
 import os
 import random
 
-from .. import auth
-from .. import constants
-from .. import errors
-from .. import utils
-
+from .. import auth, constants, errors, utils
 
 log = logging.getLogger(__name__)
 

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -8,12 +8,22 @@ import requests.adapters
 import requests.exceptions
 
 from .. import auth
-from ..constants import (DEFAULT_NUM_POOLS, DEFAULT_NUM_POOLS_SSH,
-                         DEFAULT_MAX_POOL_SIZE, DEFAULT_TIMEOUT_SECONDS,
-                         DEFAULT_USER_AGENT, IS_WINDOWS_PLATFORM,
-                         MINIMUM_DOCKER_API_VERSION, STREAM_HEADER_SIZE_BYTES)
-from ..errors import (DockerException, InvalidVersion, TLSParameterError,
-                      create_api_error_from_http_exception)
+from ..constants import (
+    DEFAULT_MAX_POOL_SIZE,
+    DEFAULT_NUM_POOLS,
+    DEFAULT_NUM_POOLS_SSH,
+    DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_USER_AGENT,
+    IS_WINDOWS_PLATFORM,
+    MINIMUM_DOCKER_API_VERSION,
+    STREAM_HEADER_SIZE_BYTES,
+)
+from ..errors import (
+    DockerException,
+    InvalidVersion,
+    TLSParameterError,
+    create_api_error_from_http_exception,
+)
 from ..tls import TLSConfig
 from ..transport import UnixHTTPAdapter
 from ..utils import check_resource, config, update_headers, utils

--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 
-from .. import errors
-from .. import utils
+from .. import errors, utils
 from ..constants import DEFAULT_DATA_CHUNK_SIZE
-from ..types import CancellableStream
-from ..types import ContainerConfig
-from ..types import EndpointConfig
-from ..types import HostConfig
-from ..types import NetworkingConfig
+from ..types import (
+    CancellableStream,
+    ContainerConfig,
+    EndpointConfig,
+    HostConfig,
+    NetworkingConfig,
+)
 
 
 class ContainerApiMixin:

--- a/docker/api/exec_api.py
+++ b/docker/api/exec_api.py
@@ -1,5 +1,4 @@
-from .. import errors
-from .. import utils
+from .. import errors, utils
 from ..types import CancellableStream
 
 

--- a/docker/api/network.py
+++ b/docker/api/network.py
@@ -1,7 +1,6 @@
-from ..errors import InvalidVersion
-from ..utils import check_resource, minimum_version
-from ..utils import version_lt
 from .. import utils
+from ..errors import InvalidVersion
+from ..utils import check_resource, minimum_version, version_lt
 
 
 class NetworkApiMixin:

--- a/docker/api/secret.py
+++ b/docker/api/secret.py
@@ -1,7 +1,6 @@
 import base64
 
-from .. import errors
-from .. import utils
+from .. import errors, utils
 
 
 class SecretApiMixin:

--- a/docker/api/swarm.py
+++ b/docker/api/swarm.py
@@ -1,9 +1,8 @@
-import logging
 import http.client as http_client
+import logging
+
+from .. import errors, types, utils
 from ..constants import DEFAULT_SWARM_ADDR_POOL, DEFAULT_SWARM_SUBNET_SIZE
-from .. import errors
-from .. import types
-from .. import utils
 
 log = logging.getLogger(__name__)
 

--- a/docker/api/volume.py
+++ b/docker/api/volume.py
@@ -1,5 +1,4 @@
-from .. import errors
-from .. import utils
+from .. import errors, utils
 
 
 class VolumeApiMixin:

--- a/docker/auth.py
+++ b/docker/auth.py
@@ -2,8 +2,7 @@ import base64
 import json
 import logging
 
-from . import credentials
-from . import errors
+from . import credentials, errors
 from .utils import config
 
 INDEX_NAME = 'docker.io'

--- a/docker/client.py
+++ b/docker/client.py
@@ -1,5 +1,5 @@
 from .api.client import APIClient
-from .constants import (DEFAULT_TIMEOUT_SECONDS, DEFAULT_MAX_POOL_SIZE)
+from .constants import DEFAULT_MAX_POOL_SIZE, DEFAULT_TIMEOUT_SECONDS
 from .models.configs import ConfigCollection
 from .models.containers import ContainerCollection
 from .models.images import ImageCollection

--- a/docker/constants.py
+++ b/docker/constants.py
@@ -1,4 +1,5 @@
 import sys
+
 from .version import __version__
 
 DEFAULT_DOCKER_API_VERSION = '1.43'

--- a/docker/context/__init__.py
+++ b/docker/context/__init__.py
@@ -1,2 +1,2 @@
-from .context import Context
 from .api import ContextAPI
+from .context import Context

--- a/docker/context/api.py
+++ b/docker/context/api.py
@@ -2,13 +2,14 @@ import json
 import os
 
 from docker import errors
-from docker.context import Context
-from docker.context.config import (
+
+from .config import (
     METAFILE,
     get_current_context_name,
     get_meta_dir,
     write_context_name_to_docker_config,
 )
+from .context import Context
 
 
 class ContextAPI:

--- a/docker/context/api.py
+++ b/docker/context/api.py
@@ -2,11 +2,13 @@ import json
 import os
 
 from docker import errors
-from docker.context.config import get_meta_dir
-from docker.context.config import METAFILE
-from docker.context.config import get_current_context_name
-from docker.context.config import write_context_name_to_docker_config
 from docker.context import Context
+from docker.context.config import (
+    METAFILE,
+    get_current_context_name,
+    get_meta_dir,
+    write_context_name_to_docker_config,
+)
 
 
 class ContextAPI:

--- a/docker/context/config.py
+++ b/docker/context/config.py
@@ -1,10 +1,9 @@
-import os
-import json
 import hashlib
+import json
+import os
 
 from docker import utils
-from docker.constants import IS_WINDOWS_PLATFORM
-from docker.constants import DEFAULT_UNIX_SOCKET
+from docker.constants import DEFAULT_UNIX_SOCKET, IS_WINDOWS_PLATFORM
 from docker.utils.config import find_config_file
 
 METAFILE = "meta.json"

--- a/docker/context/context.py
+++ b/docker/context/context.py
@@ -2,14 +2,15 @@ import json
 import os
 from shutil import copyfile, rmtree
 
-from docker.context.config import (
+from docker.errors import ContextException
+from docker.tls import TLSConfig
+
+from .config import (
     get_context_host,
     get_meta_dir,
     get_meta_file,
     get_tls_dir,
 )
-from docker.errors import ContextException
-from docker.tls import TLSConfig
 
 
 class Context:

--- a/docker/context/context.py
+++ b/docker/context/context.py
@@ -1,12 +1,15 @@
-import os
 import json
+import os
 from shutil import copyfile, rmtree
-from docker.tls import TLSConfig
+
+from docker.context.config import (
+    get_context_host,
+    get_meta_dir,
+    get_meta_file,
+    get_tls_dir,
+)
 from docker.errors import ContextException
-from docker.context.config import get_meta_dir
-from docker.context.config import get_meta_file
-from docker.context.config import get_tls_dir
-from docker.context.config import get_context_host
+from docker.tls import TLSConfig
 
 
 class Context:

--- a/docker/credentials/__init__.py
+++ b/docker/credentials/__init__.py
@@ -1,8 +1,8 @@
-from .store import Store
-from .errors import StoreError, CredentialsNotFound
 from .constants import (
     DEFAULT_LINUX_STORE,
     DEFAULT_OSX_STORE,
     DEFAULT_WIN32_STORE,
     PROGRAM_PREFIX,
 )
+from .errors import CredentialsNotFound, StoreError
+from .store import Store

--- a/docker/credentials/store.py
+++ b/docker/credentials/store.py
@@ -4,8 +4,7 @@ import shutil
 import subprocess
 import warnings
 
-from . import constants
-from . import errors
+from . import constants, errors
 from .utils import create_environment_dict
 
 

--- a/docker/models/configs.py
+++ b/docker/models/configs.py
@@ -1,5 +1,5 @@
 from ..api import APIClient
-from .resource import Model, Collection
+from .resource import Collection, Model
 
 
 class Config(Model):

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -2,16 +2,19 @@ import copy
 import ntpath
 from collections import namedtuple
 
-from .images import Image
-from .resource import Collection, Model
 from ..api import APIClient
 from ..constants import DEFAULT_DATA_CHUNK_SIZE
 from ..errors import (
-    ContainerError, DockerException, ImageNotFound,
-    NotFound, create_unexpected_kwargs_error
+    ContainerError,
+    DockerException,
+    ImageNotFound,
+    NotFound,
+    create_unexpected_kwargs_error,
 )
 from ..types import HostConfig, NetworkingConfig
 from ..utils import version_gte
+from .images import Image
+from .resource import Collection, Model
 
 
 class Container(Model):

--- a/docker/models/networks.py
+++ b/docker/models/networks.py
@@ -1,7 +1,7 @@
 from ..api import APIClient
 from ..utils import version_gte
 from .containers import Container
-from .resource import Model, Collection
+from .resource import Collection, Model
 
 
 class Network(Model):

--- a/docker/models/nodes.py
+++ b/docker/models/nodes.py
@@ -1,4 +1,4 @@
-from .resource import Model, Collection
+from .resource import Collection, Model
 
 
 class Node(Model):

--- a/docker/models/secrets.py
+++ b/docker/models/secrets.py
@@ -1,5 +1,5 @@
 from ..api import APIClient
-from .resource import Model, Collection
+from .resource import Collection, Model
 
 
 class Secret(Model):

--- a/docker/models/services.py
+++ b/docker/models/services.py
@@ -1,7 +1,9 @@
 import copy
-from docker.errors import create_unexpected_kwargs_error, InvalidArgument
-from docker.types import TaskTemplate, ContainerSpec, Placement, ServiceMode
-from .resource import Model, Collection
+
+from docker.errors import InvalidArgument, create_unexpected_kwargs_error
+from docker.types import ContainerSpec, Placement, ServiceMode, TaskTemplate
+
+from .resource import Collection, Model
 
 
 class Service(Model):

--- a/docker/models/swarm.py
+++ b/docker/models/swarm.py
@@ -1,5 +1,6 @@
 from docker.api import APIClient
 from docker.errors import APIError
+
 from .resource import Model
 
 

--- a/docker/models/volumes.py
+++ b/docker/models/volumes.py
@@ -1,5 +1,5 @@
 from ..api import APIClient
-from .resource import Model, Collection
+from .resource import Collection, Model
 
 
 class Volume(Model):

--- a/docker/transport/__init__.py
+++ b/docker/transport/__init__.py
@@ -1,4 +1,5 @@
 from .unixconn import UnixHTTPAdapter
+
 try:
     from .npipeconn import NpipeHTTPAdapter
     from .npipesocket import NpipeSocket

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -4,9 +4,8 @@ import requests.adapters
 import urllib3
 import urllib3.connection
 
-from docker.transport.basehttpadapter import BaseHTTPAdapter
-
 from .. import constants
+from .basehttpadapter import BaseHTTPAdapter
 from .npipesocket import NpipeSocket
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer

--- a/docker/transport/npipeconn.py
+++ b/docker/transport/npipeconn.py
@@ -1,12 +1,13 @@
 import queue
+
 import requests.adapters
-
-from docker.transport.basehttpadapter import BaseHTTPAdapter
-from .. import constants
-from .npipesocket import NpipeSocket
-
 import urllib3
 import urllib3.connection
+
+from docker.transport.basehttpadapter import BaseHTTPAdapter
+
+from .. import constants
+from .npipesocket import NpipeSocket
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 

--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -1,12 +1,12 @@
 import functools
-import time
 import io
+import time
 
+import pywintypes
+import win32api
+import win32event
 import win32file
 import win32pipe
-import pywintypes
-import win32event
-import win32api
 
 cERROR_PIPE_BUSY = 0xe7
 cSECURITY_SQOS_PRESENT = 0x100000

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -11,9 +11,8 @@ import requests.adapters
 import urllib3
 import urllib3.connection
 
-from docker.transport.basehttpadapter import BaseHTTPAdapter
-
 from .. import constants
+from .basehttpadapter import BaseHTTPAdapter
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 

--- a/docker/transport/sshconn.py
+++ b/docker/transport/sshconn.py
@@ -1,18 +1,19 @@
-import paramiko
-import queue
-import urllib.parse
-import requests.adapters
 import logging
 import os
+import queue
 import signal
 import socket
 import subprocess
+import urllib.parse
 
-from docker.transport.basehttpadapter import BaseHTTPAdapter
-from .. import constants
-
+import paramiko
+import requests.adapters
 import urllib3
 import urllib3.connection
+
+from docker.transport.basehttpadapter import BaseHTTPAdapter
+
+from .. import constants
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -4,9 +4,8 @@ import requests.adapters
 import urllib3
 import urllib3.connection
 
-from docker.transport.basehttpadapter import BaseHTTPAdapter
-
 from .. import constants
+from .basehttpadapter import BaseHTTPAdapter
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 

--- a/docker/transport/unixconn.py
+++ b/docker/transport/unixconn.py
@@ -1,12 +1,12 @@
-import requests.adapters
 import socket
 
-from docker.transport.basehttpadapter import BaseHTTPAdapter
-from .. import constants
-
+import requests.adapters
 import urllib3
 import urllib3.connection
 
+from docker.transport.basehttpadapter import BaseHTTPAdapter
+
+from .. import constants
 
 RecentlyUsedContainer = urllib3._collections.RecentlyUsedContainer
 

--- a/docker/types/__init__.py
+++ b/docker/types/__init__.py
@@ -1,13 +1,24 @@
-from .containers import (
-    ContainerConfig, HostConfig, LogConfig, Ulimit, DeviceRequest
-)
+from .containers import ContainerConfig, DeviceRequest, HostConfig, LogConfig, Ulimit
 from .daemon import CancellableStream
 from .healthcheck import Healthcheck
 from .networks import EndpointConfig, IPAMConfig, IPAMPool, NetworkingConfig
 from .services import (
-    ConfigReference, ContainerSpec, DNSConfig, DriverConfig, EndpointSpec,
-    Mount, Placement, PlacementPreference, Privileges, Resources,
-    RestartPolicy, RollbackConfig, SecretReference, ServiceMode, TaskTemplate,
-    UpdateConfig, NetworkAttachmentConfig
+    ConfigReference,
+    ContainerSpec,
+    DNSConfig,
+    DriverConfig,
+    EndpointSpec,
+    Mount,
+    NetworkAttachmentConfig,
+    Placement,
+    PlacementPreference,
+    Privileges,
+    Resources,
+    RestartPolicy,
+    RollbackConfig,
+    SecretReference,
+    ServiceMode,
+    TaskTemplate,
+    UpdateConfig,
 )
-from .swarm import SwarmSpec, SwarmExternalCA
+from .swarm import SwarmExternalCA, SwarmSpec

--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -1,8 +1,16 @@
 from .. import errors
 from ..utils.utils import (
-    convert_port_bindings, convert_tmpfs_mounts, convert_volume_binds,
-    format_environment, format_extra_hosts, normalize_links, parse_bytes,
-    parse_devices, split_command, version_gte, version_lt,
+    convert_port_bindings,
+    convert_tmpfs_mounts,
+    convert_volume_binds,
+    format_environment,
+    format_extra_hosts,
+    normalize_links,
+    parse_bytes,
+    parse_devices,
+    split_command,
+    version_gte,
+    version_lt,
 )
 from .base import DictType
 from .healthcheck import Healthcheck

--- a/docker/types/services.py
+++ b/docker/types/services.py
@@ -1,8 +1,12 @@
 from .. import errors
 from ..constants import IS_WINDOWS_PLATFORM
 from ..utils import (
-    check_resource, format_environment, format_extra_hosts, parse_bytes,
-    split_command, convert_service_networks,
+    check_resource,
+    convert_service_networks,
+    format_environment,
+    format_extra_hosts,
+    parse_bytes,
+    split_command,
 )
 
 

--- a/docker/utils/__init__.py
+++ b/docker/utils/__init__.py
@@ -1,13 +1,28 @@
 
-from .build import match_tag, create_archive, exclude_paths, mkbuildcontext, tar
+from .build import create_archive, exclude_paths, match_tag, mkbuildcontext, tar
 from .decorators import check_resource, minimum_version, update_headers
 from .utils import (
-    compare_version, convert_port_bindings, convert_volume_binds,
-    parse_repository_tag, parse_host,
-    kwargs_from_env, convert_filters, datetime_to_timestamp,
-    create_host_config, parse_bytes, parse_env_file, version_lt,
-    version_gte, decode_json_header, split_command, create_ipam_config,
-    create_ipam_pool, parse_devices, normalize_links, convert_service_networks,
-    format_environment, format_extra_hosts
+    compare_version,
+    convert_filters,
+    convert_port_bindings,
+    convert_service_networks,
+    convert_volume_binds,
+    create_host_config,
+    create_ipam_config,
+    create_ipam_pool,
+    datetime_to_timestamp,
+    decode_json_header,
+    format_environment,
+    format_extra_hosts,
+    kwargs_from_env,
+    normalize_links,
+    parse_bytes,
+    parse_devices,
+    parse_env_file,
+    parse_host,
+    parse_repository_tag,
+    split_command,
+    version_gte,
+    version_lt,
 )
 

--- a/docker/utils/build.py
+++ b/docker/utils/build.py
@@ -4,9 +4,8 @@ import re
 import tarfile
 import tempfile
 
-from .fnmatch import fnmatch
 from ..constants import IS_WINDOWS_PLATFORM
-
+from .fnmatch import fnmatch
 
 _SEP = re.compile('/|\\\\') if IS_WINDOWS_PLATFORM else re.compile('/')
 _TAG = re.compile(

--- a/docker/utils/json_stream.py
+++ b/docker/utils/json_stream.py
@@ -3,7 +3,6 @@ import json.decoder
 
 from ..errors import StreamParseError
 
-
 json_decoder = json.JSONDecoder()
 
 

--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -8,15 +8,16 @@ import string
 from datetime import datetime, timezone
 from functools import lru_cache
 from itertools import zip_longest
+from urllib.parse import urlparse, urlunparse
 
 from .. import errors
-from ..constants import DEFAULT_HTTP_HOST
-from ..constants import DEFAULT_UNIX_SOCKET
-from ..constants import DEFAULT_NPIPE
-from ..constants import BYTE_UNITS
+from ..constants import (
+    BYTE_UNITS,
+    DEFAULT_HTTP_HOST,
+    DEFAULT_NPIPE,
+    DEFAULT_UNIX_SOCKET,
+)
 from ..tls import TLSConfig
-
-from urllib.parse import urlparse, urlunparse
 
 URLComponents = collections.namedtuple(
     'URLComponents',

--- a/docker/version.py
+++ b/docker/version.py
@@ -1,7 +1,7 @@
 try:
     from ._version import __version__
 except ImportError:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
     try:
         __version__ = version('docker')
     except PackageNotFoundError:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ import datetime
 import os
 import sys
 from importlib.metadata import version
+
 sys.path.insert(0, os.path.abspath('..'))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ extend-select = [
     "B",
     "C",
     "F",
+    "I",
     "UP",
     "W",
 ]

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 import codecs
 import os
 
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,9 +8,10 @@ import tarfile
 import tempfile
 import time
 
-import docker
 import paramiko
 import pytest
+
+import docker
 
 
 def make_tree(dirs, files):

--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -3,13 +3,13 @@ import os
 import shutil
 import tempfile
 
+import pytest
+
 from docker import errors
 from docker.utils.proxy import ProxyConfig
 
-import pytest
-
-from .base import BaseAPIIntegrationTest, TEST_IMG
 from ..helpers import random_name, requires_api_version, requires_experimental
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class BuildTest(BaseAPIIntegrationTest):

--- a/tests/integration/api_config_test.py
+++ b/tests/integration/api_config_test.py
@@ -1,5 +1,6 @@
-import docker
 import pytest
+
+import docker
 
 from ..helpers import force_leave_swarm, requires_api_version
 from .base import BaseAPIIntegrationTest

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -9,15 +9,17 @@ import pytest
 import requests
 
 import docker
-from .. import helpers
-from ..helpers import assert_cat_socket_detached_with_keys
-from ..helpers import ctrl_with
-from ..helpers import requires_api_version, skip_if_desktop
-from .base import BaseAPIIntegrationTest
-from .base import TEST_IMG
 from docker.constants import IS_WINDOWS_PLATFORM
-from docker.utils.socket import next_frame_header
-from docker.utils.socket import read_exactly
+from docker.utils.socket import next_frame_header, read_exactly
+
+from .. import helpers
+from ..helpers import (
+    assert_cat_socket_detached_with_keys,
+    ctrl_with,
+    requires_api_version,
+    skip_if_desktop,
+)
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class ListContainersTest(BaseAPIIntegrationTest):

--- a/tests/integration/api_exec_test.py
+++ b/tests/integration/api_exec_test.py
@@ -1,11 +1,12 @@
-from ..helpers import assert_cat_socket_detached_with_keys
-from ..helpers import ctrl_with
-from ..helpers import requires_api_version
-from .base import BaseAPIIntegrationTest
-from .base import TEST_IMG
 from docker.utils.proxy import ProxyConfig
-from docker.utils.socket import next_frame_header
-from docker.utils.socket import read_exactly
+from docker.utils.socket import next_frame_header, read_exactly
+
+from ..helpers import (
+    assert_cat_socket_detached_with_keys,
+    ctrl_with,
+    requires_api_version,
+)
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class ExecTest(BaseAPIIntegrationTest):

--- a/tests/integration/api_healthcheck_test.py
+++ b/tests/integration/api_healthcheck_test.py
@@ -1,5 +1,5 @@
-from .base import BaseAPIIntegrationTest, TEST_IMG
 from .. import helpers
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 SECOND = 1000000000
 

--- a/tests/integration/api_image_test.py
+++ b/tests/integration/api_image_test.py
@@ -2,19 +2,18 @@ import contextlib
 import json
 import shutil
 import socket
+import socketserver
 import tarfile
 import tempfile
 import threading
+from http.server import SimpleHTTPRequestHandler
 
 import pytest
-from http.server import SimpleHTTPRequestHandler
-import socketserver
-
 
 import docker
 
 from ..helpers import requires_api_version, requires_experimental
-from .base import BaseAPIIntegrationTest, TEST_IMG
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class ListImagesTest(BaseAPIIntegrationTest):

--- a/tests/integration/api_network_test.py
+++ b/tests/integration/api_network_test.py
@@ -1,9 +1,10 @@
-import docker
-from docker.types import IPAMConfig, IPAMPool
 import pytest
 
+import docker
+from docker.types import IPAMConfig, IPAMPool
+
 from ..helpers import random_name, requires_api_version
-from .base import BaseAPIIntegrationTest, TEST_IMG
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class TestNetworks(BaseAPIIntegrationTest):

--- a/tests/integration/api_plugin_test.py
+++ b/tests/integration/api_plugin_test.py
@@ -1,10 +1,11 @@
 import os
 
-import docker
 import pytest
 
-from .base import BaseAPIIntegrationTest
+import docker
+
 from ..helpers import requires_api_version
+from .base import BaseAPIIntegrationTest
 
 SSHFS = 'vieux/sshfs:latest'
 

--- a/tests/integration/api_secret_test.py
+++ b/tests/integration/api_secret_test.py
@@ -1,5 +1,6 @@
-import docker
 import pytest
+
+import docker
 
 from ..helpers import force_leave_swarm, requires_api_version
 from .base import BaseAPIIntegrationTest

--- a/tests/integration/api_service_test.py
+++ b/tests/integration/api_service_test.py
@@ -1,13 +1,12 @@
 import random
 import time
 
-import docker
 import pytest
 
-from ..helpers import (
-    force_leave_swarm, requires_api_version, requires_experimental
-)
-from .base import BaseAPIIntegrationTest, TEST_IMG
+import docker
+
+from ..helpers import force_leave_swarm, requires_api_version, requires_experimental
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class ServiceTest(BaseAPIIntegrationTest):

--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -1,6 +1,8 @@
 import copy
-import docker
+
 import pytest
+
+import docker
 
 from ..helpers import force_leave_swarm, requires_api_version
 from .base import BaseAPIIntegrationTest

--- a/tests/integration/api_volume_test.py
+++ b/tests/integration/api_volume_test.py
@@ -1,5 +1,6 @@
-import docker
 import pytest
+
+import docker
 
 from ..helpers import requires_api_version
 from .base import BaseAPIIntegrationTest

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -3,8 +3,9 @@ import shutil
 import unittest
 
 import docker
-from .. import helpers
 from docker.utils import kwargs_from_env
+
+from .. import helpers
 
 TEST_IMG = 'alpine:3.10'
 TEST_API_VERSION = os.environ.get('DOCKER_TEST_API_VERSION')

--- a/tests/integration/client_test.py
+++ b/tests/integration/client_test.py
@@ -1,9 +1,8 @@
 import threading
 import unittest
+from datetime import datetime, timedelta
 
 import docker
-
-from datetime import datetime, timedelta
 
 from ..helpers import requires_api_version
 from .base import TEST_API_VERSION

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,10 @@
 import sys
 import warnings
 
+import pytest
+
 import docker.errors
 from docker.utils import kwargs_from_env
-import pytest
 
 from .base import TEST_IMG
 

--- a/tests/integration/context_api_test.py
+++ b/tests/integration/context_api_test.py
@@ -1,9 +1,12 @@
 import os
 import tempfile
+
 import pytest
+
 from docker import errors
 from docker.context import ContextAPI
 from docker.tls import TLSConfig
+
 from .base import BaseAPIIntegrationTest
 
 

--- a/tests/integration/credentials/store_test.py
+++ b/tests/integration/credentials/store_test.py
@@ -6,8 +6,11 @@ import sys
 import pytest
 
 from docker.credentials import (
-    CredentialsNotFound, Store, StoreError, DEFAULT_LINUX_STORE,
-    DEFAULT_OSX_STORE
+    DEFAULT_LINUX_STORE,
+    DEFAULT_OSX_STORE,
+    CredentialsNotFound,
+    Store,
+    StoreError,
 )
 
 

--- a/tests/integration/credentials/utils_test.py
+++ b/tests/integration/credentials/utils_test.py
@@ -1,7 +1,7 @@
 import os
+from unittest import mock
 
 from docker.credentials.utils import create_environment_dict
-from unittest import mock
 
 
 @mock.patch.dict(os.environ)

--- a/tests/integration/errors_test.py
+++ b/tests/integration/errors_test.py
@@ -1,6 +1,8 @@
-from docker.errors import APIError
-from .base import BaseAPIIntegrationTest, TEST_IMG
 import pytest
+
+from docker.errors import APIError
+
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class ErrorsTest(BaseAPIIntegrationTest):

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -5,10 +5,9 @@ import threading
 import pytest
 
 import docker
-from .base import BaseIntegrationTest
-from .base import TEST_API_VERSION
-from ..helpers import random_name
-from ..helpers import requires_api_version
+
+from ..helpers import random_name, requires_api_version
+from .base import TEST_API_VERSION, BaseIntegrationTest
 
 
 class ContainerCollectionTest(BaseIntegrationTest):

--- a/tests/integration/models_images_test.py
+++ b/tests/integration/models_images_test.py
@@ -1,11 +1,12 @@
 import io
 import tempfile
 
-import docker
 import pytest
 
-from .base import BaseIntegrationTest, TEST_IMG, TEST_API_VERSION
+import docker
+
 from ..helpers import random_name
+from .base import TEST_API_VERSION, TEST_IMG, BaseIntegrationTest
 
 
 class ImageCollectionTest(BaseIntegrationTest):

--- a/tests/integration/models_networks_test.py
+++ b/tests/integration/models_networks_test.py
@@ -1,6 +1,7 @@
 import docker
+
 from .. import helpers
-from .base import BaseIntegrationTest, TEST_API_VERSION
+from .base import TEST_API_VERSION, BaseIntegrationTest
 
 
 class NetworkCollectionTest(BaseIntegrationTest):

--- a/tests/integration/models_resources_test.py
+++ b/tests/integration/models_resources_test.py
@@ -1,5 +1,6 @@
 import docker
-from .base import BaseIntegrationTest, TEST_API_VERSION
+
+from .base import TEST_API_VERSION, BaseIntegrationTest
 
 
 class ModelTest(BaseIntegrationTest):

--- a/tests/integration/models_services_test.py
+++ b/tests/integration/models_services_test.py
@@ -1,12 +1,13 @@
 import unittest
 
-import docker
 import pytest
+
+import docker
+from docker.errors import InvalidArgument
+from docker.types.services import ServiceMode
 
 from .. import helpers
 from .base import TEST_API_VERSION
-from docker.errors import InvalidArgument
-from docker.types.services import ServiceMode
 
 
 class ServiceTest(unittest.TestCase):

--- a/tests/integration/models_swarm_test.py
+++ b/tests/integration/models_swarm_test.py
@@ -1,10 +1,11 @@
 import unittest
 
+import pytest
+
 import docker
 
 from .. import helpers
 from .base import TEST_API_VERSION
-import pytest
 
 
 class SwarmTest(unittest.TestCase):

--- a/tests/integration/models_volumes_test.py
+++ b/tests/integration/models_volumes_test.py
@@ -1,5 +1,6 @@
 import docker
-from .base import BaseIntegrationTest, TEST_API_VERSION
+
+from .base import TEST_API_VERSION, BaseIntegrationTest
 
 
 class VolumesTest(BaseIntegrationTest):

--- a/tests/integration/regression_test.py
+++ b/tests/integration/regression_test.py
@@ -1,10 +1,11 @@
 import io
 import random
 
+import pytest
+
 import docker
 
-from .base import BaseAPIIntegrationTest, TEST_IMG
-import pytest
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class TestRegressions(BaseAPIIntegrationTest):

--- a/tests/ssh/api_build_test.py
+++ b/tests/ssh/api_build_test.py
@@ -3,13 +3,13 @@ import os
 import shutil
 import tempfile
 
+import pytest
+
 from docker import errors
 from docker.utils.proxy import ProxyConfig
 
-import pytest
-
-from .base import BaseAPIIntegrationTest, TEST_IMG
 from ..helpers import random_name, requires_api_version, requires_experimental
+from .base import TEST_IMG, BaseAPIIntegrationTest
 
 
 class BuildTest(BaseAPIIntegrationTest):

--- a/tests/ssh/base.py
+++ b/tests/ssh/base.py
@@ -5,8 +5,9 @@ import unittest
 import pytest
 
 import docker
-from .. import helpers
 from docker.utils import kwargs_from_env
+
+from .. import helpers
 
 TEST_IMG = 'alpine:3.10'
 TEST_API_VERSION = os.environ.get('DOCKER_TEST_API_VERSION')

--- a/tests/ssh/connect_test.py
+++ b/tests/ssh/connect_test.py
@@ -1,9 +1,11 @@
 import os
 import unittest
 
-import docker
 import paramiko.ssh_exception
 import pytest
+
+import docker
+
 from .base import TEST_API_VERSION
 
 

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1,17 +1,22 @@
 import datetime
 import json
 import signal
+from unittest import mock
+
+import pytest
 
 import docker
 from docker.api import APIClient
-from unittest import mock
-import pytest
 
-from . import fake_api
 from ..helpers import requires_api_version
+from . import fake_api
 from .api_test import (
-    BaseAPIClientTest, url_prefix, fake_request, DEFAULT_TIMEOUT_SECONDS,
-    fake_inspect_container, url_base
+    DEFAULT_TIMEOUT_SECONDS,
+    BaseAPIClientTest,
+    fake_inspect_container,
+    fake_request,
+    url_base,
+    url_prefix,
 )
 
 

--- a/tests/unit/api_exec_test.py
+++ b/tests/unit/api_exec_test.py
@@ -2,7 +2,10 @@ import json
 
 from . import fake_api
 from .api_test import (
-    BaseAPIClientTest, url_prefix, fake_request, DEFAULT_TIMEOUT_SECONDS,
+    DEFAULT_TIMEOUT_SECONDS,
+    BaseAPIClientTest,
+    fake_request,
+    url_prefix,
 )
 
 

--- a/tests/unit/api_image_test.py
+++ b/tests/unit/api_image_test.py
@@ -1,12 +1,17 @@
-import docker
+from unittest import mock
+
 import pytest
 
-from . import fake_api
+import docker
 from docker import auth
-from unittest import mock
+
+from . import fake_api
 from .api_test import (
-    BaseAPIClientTest, fake_request, DEFAULT_TIMEOUT_SECONDS, url_prefix,
-    fake_resolve_authconfig
+    DEFAULT_TIMEOUT_SECONDS,
+    BaseAPIClientTest,
+    fake_request,
+    fake_resolve_authconfig,
+    url_prefix,
 )
 
 

--- a/tests/unit/api_network_test.py
+++ b/tests/unit/api_network_test.py
@@ -1,8 +1,9 @@
 import json
-
-from .api_test import BaseAPIClientTest, url_prefix, response
-from docker.types import IPAMConfig, IPAMPool
 from unittest import mock
+
+from docker.types import IPAMConfig, IPAMPool
+
+from .api_test import BaseAPIClientTest, response, url_prefix
 
 
 class NetworkTest(BaseAPIClientTest):

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -1,28 +1,28 @@
 import datetime
+import http.server
 import io
 import json
 import os
 import re
 import shutil
 import socket
+import socketserver
 import struct
 import tempfile
 import threading
 import time
 import unittest
-import socketserver
-import http.server
+from unittest import mock
 
-import docker
 import pytest
 import requests
 import urllib3
+
+import docker
 from docker.api import APIClient
 from docker.constants import DEFAULT_DOCKER_API_VERSION
-from unittest import mock
 
 from . import fake_api
-
 
 DEFAULT_TIMEOUT_SECONDS = docker.constants.DEFAULT_TIMEOUT_SECONDS
 

--- a/tests/unit/api_volume_test.py
+++ b/tests/unit/api_volume_test.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from ..helpers import requires_api_version
-from .api_test import BaseAPIClientTest, url_prefix, fake_request
+from .api_test import BaseAPIClientTest, fake_request, url_prefix
 
 
 class VolumeTest(BaseAPIClientTest):

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -6,10 +6,11 @@ import random
 import shutil
 import tempfile
 import unittest
+from unittest import mock
+
+import pytest
 
 from docker import auth, credentials, errors
-from unittest import mock
-import pytest
 
 
 class RegressionTest(unittest.TestCase):

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1,15 +1,18 @@
 import datetime
 import os
 import unittest
+from unittest import mock
+
+import pytest
 
 import docker
-import pytest
 from docker.constants import (
-    DEFAULT_DOCKER_API_VERSION, DEFAULT_TIMEOUT_SECONDS,
-    DEFAULT_MAX_POOL_SIZE, IS_WINDOWS_PLATFORM
+    DEFAULT_DOCKER_API_VERSION,
+    DEFAULT_MAX_POOL_SIZE,
+    DEFAULT_TIMEOUT_SECONDS,
+    IS_WINDOWS_PLATFORM,
 )
 from docker.utils import kwargs_from_env
-from unittest import mock
 
 from . import fake_api
 

--- a/tests/unit/context_test.py
+++ b/tests/unit/context_test.py
@@ -1,10 +1,10 @@
 import unittest
-import docker
+
 import pytest
-from docker.constants import DEFAULT_UNIX_SOCKET
-from docker.constants import DEFAULT_NPIPE
-from docker.constants import IS_WINDOWS_PLATFORM
-from docker.context import ContextAPI, Context
+
+import docker
+from docker.constants import DEFAULT_NPIPE, DEFAULT_UNIX_SOCKET, IS_WINDOWS_PLATFORM
+from docker.context import Context, ContextAPI
 
 
 class BaseContextTest(unittest.TestCase):

--- a/tests/unit/dockertypes_test.py
+++ b/tests/unit/dockertypes_test.py
@@ -1,15 +1,22 @@
 import unittest
+from unittest import mock
 
 import pytest
 
 from docker.constants import DEFAULT_DOCKER_API_VERSION
 from docker.errors import InvalidArgument, InvalidVersion
 from docker.types import (
-    ContainerSpec, EndpointConfig, HostConfig, IPAMConfig,
-    IPAMPool, LogConfig, Mount, ServiceMode, Ulimit,
+    ContainerSpec,
+    EndpointConfig,
+    HostConfig,
+    IPAMConfig,
+    IPAMPool,
+    LogConfig,
+    Mount,
+    ServiceMode,
+    Ulimit,
 )
 from docker.types.services import convert_service_ports
-from unittest import mock
 
 
 def create_host_config(*args, **kwargs):

--- a/tests/unit/errors_test.py
+++ b/tests/unit/errors_test.py
@@ -2,9 +2,14 @@ import unittest
 
 import requests
 
-from docker.errors import (APIError, ContainerError, DockerException,
-                           create_unexpected_kwargs_error,
-                           create_api_error_from_http_exception)
+from docker.errors import (
+    APIError,
+    ContainerError,
+    DockerException,
+    create_api_error_from_http_exception,
+    create_unexpected_kwargs_error,
+)
+
 from .fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID
 from .fake_api_client import make_fake_client
 

--- a/tests/unit/fake_api_client.py
+++ b/tests/unit/fake_api_client.py
@@ -1,8 +1,9 @@
 import copy
+from unittest import mock
 
 import docker
 from docker.constants import DEFAULT_DOCKER_API_VERSION
-from unittest import mock
+
 from . import fake_api
 
 

--- a/tests/unit/models_configs_test.py
+++ b/tests/unit/models_configs_test.py
@@ -1,7 +1,8 @@
 import unittest
 
-from .fake_api_client import make_fake_client
 from .fake_api import FAKE_CONFIG_NAME
+from .fake_api_client import make_fake_client
+
 
 class CreateConfigsTest(unittest.TestCase):
     def test_create_config(self):

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -3,12 +3,12 @@ import unittest
 import pytest
 
 import docker
-from docker.constants import DEFAULT_DATA_CHUNK_SIZE, \
-    DEFAULT_DOCKER_API_VERSION
+from docker.constants import DEFAULT_DATA_CHUNK_SIZE, DEFAULT_DOCKER_API_VERSION
 from docker.models.containers import Container, _create_container_args
 from docker.models.images import Image
 from docker.types import EndpointConfig
-from .fake_api import FAKE_CONTAINER_ID, FAKE_IMAGE_ID, FAKE_EXEC_ID
+
+from .fake_api import FAKE_CONTAINER_ID, FAKE_EXEC_ID, FAKE_IMAGE_ID
 from .fake_api_client import make_fake_client
 
 

--- a/tests/unit/models_networks_test.py
+++ b/tests/unit/models_networks_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from .fake_api import FAKE_NETWORK_ID, FAKE_CONTAINER_ID
+from .fake_api import FAKE_CONTAINER_ID, FAKE_NETWORK_ID
 from .fake_api_client import make_fake_client
 
 

--- a/tests/unit/models_secrets_test.py
+++ b/tests/unit/models_secrets_test.py
@@ -1,7 +1,7 @@
 import unittest
 
-from .fake_api_client import make_fake_client
 from .fake_api import FAKE_SECRET_NAME
+from .fake_api_client import make_fake_client
 
 
 class CreateServiceTest(unittest.TestCase):

--- a/tests/unit/models_services_test.py
+++ b/tests/unit/models_services_test.py
@@ -1,4 +1,5 @@
 import unittest
+
 from docker.models.services import _get_create_service_kwargs
 
 

--- a/tests/unit/sshadapter_test.py
+++ b/tests/unit/sshadapter_test.py
@@ -1,4 +1,5 @@
 import unittest
+
 import docker
 from docker.transport.sshconn import SSHSocket
 

--- a/tests/unit/swarm_test.py
+++ b/tests/unit/swarm_test.py
@@ -1,8 +1,8 @@
 import json
 
-from . import fake_api
 from ..helpers import requires_api_version
-from .api_test import BaseAPIClientTest, url_prefix, fake_request
+from . import fake_api
+from .api_test import BaseAPIClientTest, fake_request, url_prefix
 
 
 class SwarmTest(BaseAPIClientTest):

--- a/tests/unit/utils_build_test.py
+++ b/tests/unit/utils_build_test.py
@@ -9,7 +9,7 @@ import unittest
 import pytest
 
 from docker.constants import IS_WINDOWS_PLATFORM
-from docker.utils import exclude_paths, tar, match_tag
+from docker.utils import exclude_paths, match_tag, tar
 
 from ..helpers import make_tree
 

--- a/tests/unit/utils_config_test.py
+++ b/tests/unit/utils_config_test.py
@@ -1,11 +1,11 @@
+import json
 import os
-import unittest
 import shutil
 import tempfile
-import json
-
-from pytest import mark, fixture
+import unittest
 from unittest import mock
+
+from pytest import fixture, mark
 
 from docker.utils import config
 

--- a/tests/unit/utils_json_stream_test.py
+++ b/tests/unit/utils_json_stream_test.py
@@ -1,4 +1,4 @@
-from docker.utils.json_stream import json_splitter, stream_as_text, json_stream
+from docker.utils.json_stream import json_splitter, json_stream, stream_as_text
 
 
 class TestJsonSplitter:

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -7,14 +7,26 @@ import tempfile
 import unittest
 
 import pytest
+
 from docker.api.client import APIClient
-from docker.constants import IS_WINDOWS_PLATFORM, DEFAULT_DOCKER_API_VERSION
+from docker.constants import DEFAULT_DOCKER_API_VERSION, IS_WINDOWS_PLATFORM
 from docker.errors import DockerException
 from docker.utils import (
-    compare_version, convert_filters, convert_volume_binds, decode_json_header,
-    format_environment, kwargs_from_env, parse_bytes, parse_devices,
-    parse_env_file, parse_host, parse_repository_tag, split_command,
-    update_headers, version_gte, version_lt
+    compare_version,
+    convert_filters,
+    convert_volume_binds,
+    decode_json_header,
+    format_environment,
+    kwargs_from_env,
+    parse_bytes,
+    parse_devices,
+    parse_env_file,
+    parse_host,
+    parse_repository_tag,
+    split_command,
+    update_headers,
+    version_gte,
+    version_lt,
 )
 from docker.utils.ports import build_port_bindings, split_port
 


### PR DESCRIPTION
I didn't have a good time sorting imports by hand in the tests for #3205, so maybe a machine should do it for us 🤖.

The first commit is entirely mechanical, but it turns out it uncovered circular import issues, so the second commit takes care of them.