### PR TITLE
Add return types to all __str__ methods

### DIFF
--- a/docker/context/context.py
+++ b/docker/context/context.py
@@ -175,7 +175,7 @@ class Context:
     def __repr__(self):
         return f"<{self.__class__.__name__}: '{self.name}'>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self.__call__(), indent=2)
 
     def __call__(self):

--- a/docker/errors.py
+++ b/docker/errors.py
@@ -50,7 +50,7 @@ class APIError(requests.exceptions.HTTPError, DockerException):
         self.response = response
         self.explanation = explanation
 
-    def __str__(self):
+    def __str__(self) -> str:
         message = super().__str__()
 
         if self.is_client_error():
@@ -121,7 +121,7 @@ class TLSParameterError(DockerException):
     def __init__(self, msg):
         self.msg = msg
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.msg + (". TLS configurations should map the Docker CLI "
                            "client configurations. See "
                            "https://docs.docker.com/engine/articles/https/ "
@@ -181,7 +181,7 @@ class MissingContextParameter(DockerException):
     def __init__(self, param):
         self.param = param
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (f"missing parameter: {self.param}")
 
 
@@ -189,7 +189,7 @@ class ContextAlreadyExists(DockerException):
     def __init__(self, name):
         self.name = name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (f"context {self.name} already exists")
 
 
@@ -197,7 +197,7 @@ class ContextException(DockerException):
     def __init__(self, msg):
         self.msg = msg
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (self.msg)
 
 
@@ -205,5 +205,5 @@ class ContextNotFound(DockerException):
     def __init__(self, name):
         self.name = name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (f"context '{self.name}' not found")

--- a/docker/utils/proxy.py
+++ b/docker/utils/proxy.py
@@ -68,7 +68,7 @@ class ProxyConfig(dict):
         # variables defined in "environment" to take precedence.
         return proxy_env + environment
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             'ProxyConfig('
             f'http={self.http}, https={self.https}, '

--- a/scripts/versions.py
+++ b/scripts/versions.py
@@ -51,7 +51,7 @@ class Version(namedtuple('_Version', 'major minor patch stage edition')):
 
         return (int(self.major), int(self.minor), int(self.patch)) + stage
 
-    def __str__(self):
+    def __str__(self) -> str:
         stage = f'-{self.stage}' if self.stage else ''
         edition = f'-{self.edition}' if self.edition else ''
         return '.'.join(map(str, self[:3])) + edition + stage


### PR DESCRIPTION
If this library is to ship type hints, it is important that those type hints are valid.
A type checker (e.g. `mypy` or `pyright`) can check that those type hints are valid, but to do so, the codebase must be type hinted throughout. This PR is one small step towards that goal.

This change replaces all instances of `def __str__(self):` with `def __str__(self) -> str:`.
I chose to do a small PR, as to add passing type checking to the whole codebase involves hundreds or maybe thousands of changes, some of which may need real consideration.