### PR TITLE
Avoid import-untyped errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,9 @@ packaging==21.3
 paramiko==2.11.0
 pywin32==304; sys_platform == 'win32'
 requests==2.31.0
+types-paramiko==3.4.0.20240120
+types-pywin32==306.0.0.20240106
+types-requests==2.31.0.6
+types-urllib3==1.26.25.14  # This is only needed as we use urllib3 < 2.0.0
 urllib3==1.26.18
-websocket-client==1.3.3
+websocket-client==1.7.0


### PR DESCRIPTION
This bumps the websocket-client test requirement to 1.7.0 as that version ships type hints.

This adds types-* packages as test requirements.

This is progress towards #2796.