### PR TITLE
Change raise of exception which does not exist

### DIFF
--- a/docker/models/plugins.py
+++ b/docker/models/plugins.py
@@ -113,7 +113,7 @@ class Plugin(Model):
                 A generator streaming the decoded API logs
         """
         if self.enabled:
-            raise errors.DockerError(
+            raise errors.DockerException(
                 'Plugin must be disabled before upgrading.'
             )
 


### PR DESCRIPTION
This changes a use of ``DockerError`` (which does not exist) to ``DockerException``.