### PR TITLE
feat: implement healthcheck start_interval #3157

### DIFF
--- a/docker/types/containers.py
+++ b/docker/types/containers.py
@@ -703,6 +703,11 @@ class ContainerConfig(dict):
                     'healthcheck start period was introduced in API '
                     'version 1.29'
                 )
+            
+            if version_lt(version, '1.44') and 'StartInterval' in healthcheck:
+                raise errors.InvalidVersion(
+                    'healthcheck start interval was introduced in API version 1.44'
+                )
 
         if isinstance(command, str):
             command = split_command(command)

--- a/docker/types/healthcheck.py
+++ b/docker/types/healthcheck.py
@@ -26,6 +26,8 @@ class Healthcheck(DictType):
             start_period (int): Start period for the container to
                 initialize before starting health-retries countdown in
                 nanoseconds. It should be 0 or at least 1000000 (1 ms).
+            start_interval (int): It is interval to be used by healthchecks during the start period in 
+            nanoseconds. It should be 0 or at least 1000000 (1 ms).
     """
     def __init__(self, **kwargs):
         test = kwargs.get('test', kwargs.get('Test'))
@@ -36,13 +38,15 @@ class Healthcheck(DictType):
         timeout = kwargs.get('timeout', kwargs.get('Timeout'))
         retries = kwargs.get('retries', kwargs.get('Retries'))
         start_period = kwargs.get('start_period', kwargs.get('StartPeriod'))
+        start_interval = kwargs.get('start_interval', kwargs.get('StartInterval'))
 
         super().__init__({
             'Test': test,
             'Interval': interval,
             'Timeout': timeout,
             'Retries': retries,
-            'StartPeriod': start_period
+            'StartPeriod': start_period,
+            'StartInterval': start_interval
         })
 
     @property
@@ -86,3 +90,11 @@ class Healthcheck(DictType):
     @start_period.setter
     def start_period(self, value):
         self['StartPeriod'] = value
+
+    @property
+    def start_interval(self):
+        return self['StartInterval']
+    
+    @start_interval.setter
+    def start_interval(self, value):
+        self['StartInterval'] = value

--- a/tests/integration/api_healthcheck_test.py
+++ b/tests/integration/api_healthcheck_test.py
@@ -66,3 +66,20 @@ class HealthcheckTest(BaseAPIIntegrationTest):
         self.tmp_containers.append(container)
         self.client.start(container)
         wait_on_health_status(self.client, container, "healthy")
+
+    @helpers.requires_api_version('1.44')
+    def test_healthcheck_start_interval(self):
+        container = self.client.create_container(
+            TEST_IMG, 'top', healthcheck={
+                'test': "echo 'hello docker'",
+                'interval': 1 * SECOND,
+                'timeout': 1 * SECOND,
+                'retries': 1,
+                'start_interval': 1 * SECOND
+            }
+        )
+
+        self.tmp_containers.append(container)
+        self.client.start(container)
+        wait_on_health_status(self.client, container, "healthy")
+        


### PR DESCRIPTION
Added support for `StartInterval` as `POST /containers/create` now accepts a `HealthConfig.StartInterval` to set the
interval for health checks during the start period. This extends the interval that health checks can use during the initial phase. Usually, you want to verify that a container is ready sooner rather than later than when it is just getting started.


It was introduced as part of [v1.44 API changes](https://docs.docker.com/engine/api/version-history/#v144-api-changes)

> Refer https://github.com/moby/moby/pull/40894.