### PR TITLE
raise exception from chunked responses

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -349,6 +349,7 @@ class APIClient(
             if decode:
                 yield from json_stream(self._stream_helper(response, False))
             else:
+                self._raise_for_status(response)
                 reader = response.raw
                 while not reader.closed:
                     # this read call will block until we get a chunk


### PR DESCRIPTION
Currently the low level build call will not raise exceptions when reading chunked responses. This results in the call incorrectly succeeding on mac machines, but correctly throwing an error on linux machines. Adding this method call here ensures that an exception will be raised for chunked responses.