### PR TITLE
Fix for requests 2.32

### DIFF
--- a/docker/transport/basehttpadapter.py
+++ b/docker/transport/basehttpadapter.py
@@ -6,3 +6,10 @@ class BaseHTTPAdapter(requests.adapters.HTTPAdapter):
         super().close()
         if hasattr(self, 'pools'):
             self.pools.clear()
+
+    # Hotfix for requests 2.32.0: its commit
+    # https://github.com/psf/requests/commit/c0813a2d910ea6b4f8438b91d315b8d181302356
+    # changes requests.adapters.HTTPAdapter to no longer call get_connection() from
+    # send(), but instead call _get_connection().
+    def _get_connection(self, request, *args, proxies=None, **kwargs):
+        return self.get_connection(request.url, proxies)

--- a/docker/transport/basehttpadapter.py
+++ b/docker/transport/basehttpadapter.py
@@ -7,13 +7,6 @@ class BaseHTTPAdapter(requests.adapters.HTTPAdapter):
         if hasattr(self, 'pools'):
             self.pools.clear()
 
-    # Hotfix for requests 2.32.0 and 2.32.1: its commit
-    # https://github.com/psf/requests/commit/c0813a2d910ea6b4f8438b91d315b8d181302356
-    # changes requests.adapters.HTTPAdapter to no longer call get_connection() from
-    # send(), but instead call _get_connection().
-    def _get_connection(self, request, *args, proxies=None, **kwargs):
-        return self.get_connection(request.url, proxies)
-
     # Fix for requests 2.32.2+:
     # https://github.com/psf/requests/commit/c98e4d133ef29c46a9b68cd783087218a8075e05
     def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):

--- a/docker/transport/basehttpadapter.py
+++ b/docker/transport/basehttpadapter.py
@@ -7,9 +7,14 @@ class BaseHTTPAdapter(requests.adapters.HTTPAdapter):
         if hasattr(self, 'pools'):
             self.pools.clear()
 
-    # Hotfix for requests 2.32.0: its commit
+    # Hotfix for requests 2.32.0 and 2.32.1: its commit
     # https://github.com/psf/requests/commit/c0813a2d910ea6b4f8438b91d315b8d181302356
     # changes requests.adapters.HTTPAdapter to no longer call get_connection() from
     # send(), but instead call _get_connection().
     def _get_connection(self, request, *args, proxies=None, **kwargs):
+        return self.get_connection(request.url, proxies)
+
+    # Fix for requests 2.32.2+:
+    # https://github.com/psf/requests/commit/c98e4d133ef29c46a9b68cd783087218a8075e05
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
         return self.get_connection(request.url, proxies)


### PR DESCRIPTION
The current requests 2.32.0 release breaks Docker SDK for Python (see #3256) due to https://github.com/psf/requests/commit/c0813a2d910ea6b4f8438b91d315b8d181302356.

That commit makes `send()` call `_get_connection()` instead of `get_connection()`. Now the Docker SDK for Python code overwrites `get_connection()`, but of course doesn't magically overwrite `_get_connection()` as well...

This PR introduces a `BaseHTTPAdapter._get_connection()` method that simply calls `get_connection()`.

See for example https://github.com/docker/docker-py/blob/main/docker/transport/unixconn.py#L66.

Fixes #3256.
