### PR TITLE
CI fix 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-python@v4
+            - uses: actions/setup-python@v5
               with:
                   python-version: '3.x'
             - run: pip install -U ruff==0.1.8
@@ -22,7 +22,7 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@v4
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: '3.x'
         - run: pip3 install build && python -m build .
@@ -40,7 +40,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
                 allow-prereleases: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+                fetch-tags: true
             - name: make ${{ matrix.variant }}
               run: |
                   docker logout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
Adds `fetch-depth:0` and `fetch-tags: true` to successfully get the repo tags, needed to properly build the library.

See https://github.com/docker/docker-py/pull/3259 attempts for more details