### PR TITLE
Fix env var name in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           # This is also supported by Hatch; see
           # https://github.com/ofek/hatch-vcs#version-source-environment-variables
-          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DOCKER: ${{ inputs.tag }}
+          SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER: ${{ inputs.tag }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixed the env var name passed into the `Generate Package` job of the release pipeline to match what is used in the Makefile