### PR TITLE
Change env var name in release pipeline to match hatch expectations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           # This is also supported by Hatch; see
           # https://github.com/ofek/hatch-vcs#version-source-environment-variables
-          SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER: ${{ inputs.tag }}
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.tag }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Since the Packaging job of the release pipeline doesn't go through our Makefile, we need the env var defined here to have the exact name `hatch` is expecting