### PR TITLE
Set a dummy-version if none set, and remove unused APT_MIRROR build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:${PYTHON_VERSION}
 WORKDIR /src
 COPY . .
 
-ARG VERSION
+ARG VERSION=0.0.0.dev0
 RUN --mount=type=cache,target=/cache/pip \
     PIP_CACHE_DIR=/cache/pip \
     SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} \

--- a/Dockerfile-docs
+++ b/Dockerfile-docs
@@ -13,7 +13,7 @@ RUN addgroup --gid $gid sphinx \
 WORKDIR /src
 COPY . .
 
-ARG VERSION
+ARG VERSION=0.0.0.dev0
 RUN --mount=type=cache,target=/cache/pip \
     PIP_CACHE_DIR=/cache/pip \
     SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER ?= $(shell git describe --match '[0-9]*' --dirty='.m' --always --tags 2>/dev/null | sed -r 's/-([0-9]+)/.dev\1/' | sed 's/-/+/')
 ifeq ($(SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER),)
-	SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER = "dev"
+	SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER = "0.0.0.dev0"
 endif
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-dind-ssh:
 		--build-arg VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER} \
 		--build-arg ENGINE_VERSION=${TEST_ENGINE_VERSION} \
 		--build-arg API_VERSION=${TEST_API_VERSION} \
-		--build-arg APT_MIRROR .
+		.
 
 .PHONY: build
 build:
@@ -42,7 +42,7 @@ build:
 		-t docker-sdk-python3 \
 		-f tests/Dockerfile \
 		--build-arg VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION_DOCKER} \
-		--build-arg APT_MIRROR .
+		.
 
 .PHONY: build-docs
 build-docs:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
 WORKDIR /src
 COPY . .
 
-ARG VERSION
+ARG VERSION=0.0.0.dev0
 RUN --mount=type=cache,target=/cache/pip \
     PIP_CACHE_DIR=/cache/pip \
     SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION} \


### PR DESCRIPTION
- relates to https://github.com/docker/docker-py/pull/3145
- relates to https://github.com/moby/moby/pull/47092


### Set a dummy-version if none set

Make sure the Dockerfiles can be built even if no VERSION build-arg is passed.

### Makefile: remove unused APT_MIRROR build-arg

The APT_MIRROR build-arg was removed from the Dockerfile in commit
ee2310595d1362428f2826afac2e17077231473a, but wasn't removed from the
Makefile.
