### PR TITLE
Remove and return container when start fails

### DIFF
--- a/docker/errors.py
+++ b/docker/errors.py
@@ -150,6 +150,19 @@ class ContainerError(DockerException):
         )
 
 
+class ContainerStartError(DockerException):
+    """
+    Represents a container that has failed to start.
+    """
+    def __init__(self, container, reason):
+        self.container = container
+        self.msg = reason
+
+        super().__init__(
+            f"Container '{container.short_id}' failed to start: {reason}"
+        )
+
+
 class StreamParseError(RuntimeError):
     def __init__(self, reason):
         self.msg = reason

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -158,13 +158,13 @@ class ContainerCollectionTest(BaseIntegrationTest):
             ),
         }
 
-        with pytest.raises(docker.errors.APIError):
-            container = client.containers.run(
+        with pytest.raises(docker.errors.ContainerStartError) as err:
+            client.containers.run(
                 'alpine', 'echo hello world', network=net_name,
                 networking_config=networking_config,
                 detach=True
             )
-            self.tmp_containers.append(container.id)
+            self.tmp_containers.append(err.container.id)
 
     def test_run_with_networking_config_only_undeclared_network(self):
         net_name = random_name()


### PR DESCRIPTION
When the container fail to start and the user has set the `remove` flag we should remove the containter, also if the flag is not set, we lose track of the container, leaving it dangling on the system. By adding this execption return whenever the container fails to start we provide means to the user to remove the container if needed.