### PR TITLE
Check presence of errors in server response to image push

### DIFF
--- a/docker/utils/json_stream.py
+++ b/docker/utils/json_stream.py
@@ -1,4 +1,3 @@
-import json
 import json.decoder
 
 from ..errors import StreamParseError
@@ -37,30 +36,12 @@ def json_stream(stream):
     This handles streams which are inconsistently buffered (some entries may
     be newline delimited, and others are not).
     """
-    return split_buffer(stream, json_splitter, json_decoder.decode)
-
-
-def line_splitter(buffer, separator='\n'):
-    index = buffer.find(str(separator))
-    if index == -1:
-        return None
-    return buffer[:index + 1], buffer[index + 1:]
-
-
-def split_buffer(stream, splitter=None, decoder=lambda a: a):
-    """Given a generator which yields strings and a splitter function,
-    joins all input, splits on the separator and yields each chunk.
-    Unlike string.split(), each chunk includes the trailing
-    separator, except for the last one if none was found on the end
-    of the input.
-    """
-    splitter = splitter or line_splitter
     buffered = ''
 
     for data in stream_as_text(stream):
         buffered += data
         while True:
-            buffer_split = splitter(buffered)
+            buffer_split = json_splitter(buffered)
             if buffer_split is None:
                 break
 
@@ -69,6 +50,13 @@ def split_buffer(stream, splitter=None, decoder=lambda a: a):
 
     if buffered:
         try:
-            yield decoder(buffered)
+            yield json_decoder.decode(buffered)
         except Exception as e:
             raise StreamParseError(e) from e
+
+
+def line_splitter(buffer: str, separator='\n'):
+    index = buffer.find(str(separator))
+    if index == -1:
+        return None
+    return buffer[:index + 1], buffer[index + 1:]

--- a/tests/unit/api_image_test.py
+++ b/tests/unit/api_image_test.py
@@ -288,6 +288,33 @@ class ImageTest(BaseAPIClientTest):
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
+
+    def test_push_image_stream_with_auth(self):
+        auth_config = {
+            'username': "test_user",
+            'password': "test_password",
+            'serveraddress': "test_server",
+        }
+        encoded_auth = auth.encode_header(auth_config)
+        self.client.push(
+            fake_api.FAKE_IMAGE_NAME, tag=fake_api.FAKE_TAG_NAME,
+            auth_config=auth_config, stream=True
+        )
+
+        fake_request.assert_called_with(
+            'POST',
+            f"{url_prefix}images/test_image/push",
+            params={
+                'tag': fake_api.FAKE_TAG_NAME,
+            },
+            data='{}',
+            headers={'Content-Type': 'application/json',
+                     'X-Registry-Auth': encoded_auth},
+            stream=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
+
     def test_tag_image(self):
         self.client.tag(fake_api.FAKE_IMAGE_ID, fake_api.FAKE_REPO_NAME)
 

--- a/tests/unit/api_image_test.py
+++ b/tests/unit/api_image_test.py
@@ -271,6 +271,33 @@ class ImageTest(BaseAPIClientTest):
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
+
+    def test_push_image_with_auth_error(self):
+        auth_config = {
+            'username': "test_user",
+            'password': "test_password",
+            'serveraddress': "test_server",
+        }
+        encoded_auth = auth.encode_header(auth_config)
+        with pytest.raises(docker.errors.APIError, match='bad auth'):
+            self.client.push(
+                fake_api.FAKE_IMAGE_NAME_ERROR, tag=fake_api.FAKE_TAG_NAME,
+                auth_config=auth_config
+            )
+
+        fake_request.assert_called_with(
+            'POST',
+            f"{url_prefix}images/test_image_error/push",
+            params={
+                'tag': fake_api.FAKE_TAG_NAME,
+            },
+            data='{}',
+            headers={'Content-Type': 'application/json',
+                     'X-Registry-Auth': encoded_auth},
+            stream=False,
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
+
     def test_push_image_stream(self):
         with mock.patch('docker.auth.resolve_authconfig',
                         fake_resolve_authconfig):
@@ -314,6 +341,32 @@ class ImageTest(BaseAPIClientTest):
             timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
+
+    def test_push_image_stream_with_auth_error(self):
+        auth_config = {
+            'username': "test_user",
+            'password': "test_password",
+            'serveraddress': "test_server",
+        }
+        encoded_auth = auth.encode_header(auth_config)
+        with pytest.raises(docker.errors.APIError, match='bad auth'):
+            self.client.push(
+                fake_api.FAKE_IMAGE_NAME_ERROR, tag=fake_api.FAKE_TAG_NAME,
+                auth_config=auth_config, stream=True
+            )
+
+        fake_request.assert_called_with(
+            'POST',
+            f"{url_prefix}images/test_image_error/push",
+            params={
+                'tag': fake_api.FAKE_TAG_NAME,
+            },
+            data='{}',
+            headers={'Content-Type': 'application/json',
+                     'X-Registry-Auth': encoded_auth},
+            stream=True,
+            timeout=DEFAULT_TIMEOUT_SECONDS
+        )
 
     def test_tag_image(self):
         self.client.tag(fake_api.FAKE_IMAGE_ID, fake_api.FAKE_REPO_NAME)

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -31,6 +31,8 @@ def response(status_code=200, content='', headers=None, reason=None, elapsed=0,
              request=None, raw=None):
     res = requests.Response()
     res.status_code = status_code
+    if isinstance(content, str):
+        content = content.encode('ascii')
     if not isinstance(content, bytes):
         content = json.dumps(content).encode('ascii')
     res._content = content

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -1,3 +1,5 @@
+import json
+
 from docker import constants
 
 from . import fake_stat
@@ -9,6 +11,7 @@ FAKE_IMAGE_ID = 'sha256:fe7a8fc91d3f17835cbb3b86a1c60287500ab01a53bc79c4497d09f0
 FAKE_EXEC_ID = 'b098ec855f10434b5c7c973c78484208223a83f663ddaefb0f02a242840cb1c7'
 FAKE_NETWORK_ID = '1999cfb42e414483841a125ade3c276c3cb80cb3269b14e339354ac63a31b02c'
 FAKE_IMAGE_NAME = 'test_image'
+FAKE_IMAGE_NAME_ERROR = 'test_image_error'
 FAKE_TARBALL_PATH = '/path/to/tarball'
 FAKE_REPO_NAME = 'repo'
 FAKE_TAG_NAME = 'tag'
@@ -359,6 +362,12 @@ def post_fake_push():
     return status_code, response
 
 
+def post_fake_push_error():
+    status_code = 200
+    response = '{"status": "intermediate update"}\r\n{"error": "bad auth"}\r\n'
+    return status_code, response
+
+
 def post_fake_build_container():
     status_code = 200
     response = {'Id': FAKE_CONTAINER_ID}
@@ -603,6 +612,8 @@ fake_responses = {
     get_fake_insert_image,
     f'{prefix}/{CURRENT_VERSION}/images/test_image/push':
     post_fake_push,
+    f'{prefix}/{CURRENT_VERSION}/images/test_image_error/push':
+    post_fake_push_error,
     f'{prefix}/{CURRENT_VERSION}/commit':
     post_fake_commit,
     f'{prefix}/{CURRENT_VERSION}/containers/create':


### PR DESCRIPTION
When pushing an image, the server response might have status code 200 (OK) even though the operation has failed.

To detect the occurrence of an error, inspect each JSON chunk in the server response and verify that no "error" field is present.

The PR also:
- adds some unit tests with streaming responses,
- simplifies some code that is more generic than needed.

Fixes: #3277