### PR TITLE
tests/exec: expect 127 exit code for missing executable

### DIFF
--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -353,6 +353,15 @@ class ContainerTest(BaseIntegrationTest):
         assert exec_output[0] == 0
         assert exec_output[1] == b"hello\n"
 
+    def test_exec_run_error_code_from_exec(self):
+        client = docker.from_env(version=TEST_API_VERSION)
+        container = client.containers.run(
+            "alpine", "sh -c 'sleep 20'", detach=True
+        )
+        self.tmp_containers.append(container.id)
+        exec_output = container.exec_run("sh -c 'exit 42'")
+        assert exec_output[0] == 42
+
     def test_exec_run_failed(self):
         client = docker.from_env(version=TEST_API_VERSION)
         container = client.containers.run(
@@ -363,7 +372,7 @@ class ContainerTest(BaseIntegrationTest):
         # older versions of docker return `126` in the case that an exec cannot
         # be started due to a missing executable. We're fixing this for the
         # future, so accept both for now.
-        assert exec_output[0] == 127 or exec_output == 126
+        assert exec_output[0] == 127 or exec_output[0] == 126
 
     def test_kill(self):
         client = docker.from_env(version=TEST_API_VERSION)

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -359,8 +359,11 @@ class ContainerTest(BaseIntegrationTest):
             "alpine", "sh -c 'sleep 60'", detach=True
         )
         self.tmp_containers.append(container.id)
-        exec_output = container.exec_run("docker ps")
-        assert exec_output[0] == 126
+        exec_output = container.exec_run("non-existent")
+        # older versions of docker return `126` in the case that an exec cannot
+        # be started due to a missing executable. We're fixing this for the
+        # future, so accept both for now.
+        assert exec_output[0] == 127 or exec_output == 126
 
     def test_kill(self):
         client = docker.from_env(version=TEST_API_VERSION)


### PR DESCRIPTION
The Docker Engine has always returned `126` when starting an exec fails due to a missing binary, but this was due to a bug in the daemon causing the correct exit code to be overwritten in some cases – see: https://github.com/moby/moby/issues/45795

Change tests to expect correct exit code (`127`).

Note: Must take some care to what's the best way to fix this without breaking engine or vice-versa, due to the engine running tests against docker-py and docker-py running tests against the engine. It might be necessary to 1st. skip the test, then fix the engine, then fix/unskip the test.