### PR TITLE
[docker-container-exec_run] ExecDetachResult structure for exec_run in detached mode

### DIFF
--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -215,6 +215,12 @@ class Container(Model):
             resp['Id'], detach=detach, tty=tty, stream=stream, socket=socket,
             demux=demux
         )
+        if detach:
+            return ExecDetachResult(
+                resp["Id"],
+                self.client.api.exec_inspect(resp["Id"])["ExitCode"],
+                self.client.api.exec_inspect(resp["Id"])["Running"],
+            )
         if socket or stream:
             return ExecResult(None, exec_output)
 
@@ -1196,3 +1202,6 @@ def _host_volume_from_bind(bind):
 ExecResult = namedtuple('ExecResult', 'exit_code,output')
 """ A result of Container.exec_run with the properties ``exit_code`` and
     ``output``. """
+ExecDetachResult = namedtuple('ExecDetachResult', 'id,exit_code,status')
+""" A result of Container.exec_run in detached mode
+    with the properties ``id``, ``exit_code`` and ``status``. """


### PR DESCRIPTION
Tested PoC  - there is no way to trace exec_run's exit_codes once detach=True is specified as Id is lost within this library. 

As Id will be retreived - user can use self.client.api.exec_inspect on its own - checking retrived exit_code when the command is done (or not). 

I suggest not to combine ExecDetachResult into ExecResult namedtuple as status checking require additional request to docker daemon. Also, currently retreived `ExecResult`  with exit_code as None is problematic as no other information is provided and there is no other way to check it. 