### PR TITLE
integration: test_create_volume_invalid_driver allow either 400 or 404

### DIFF
--- a/tests/integration/api_volume_test.py
+++ b/tests/integration/api_volume_test.py
@@ -17,10 +17,16 @@ class TestVolumes(BaseAPIIntegrationTest):
         assert result['Driver'] == 'local'
 
     def test_create_volume_invalid_driver(self):
-        driver_name = 'invalid.driver'
+        # special name to avoid exponential timeout loop
+        # https://github.com/moby/moby/blob/9e00a63d65434cdedc444e79a2b33a7c202b10d8/pkg/plugins/client.go#L253-L254
+        driver_name = 'this-plugin-does-not-exist'
 
-        with pytest.raises(docker.errors.NotFound):
+        with pytest.raises(docker.errors.APIError) as cm:
             self.client.create_volume('perfectcherryblossom', driver_name)
+            assert (
+                cm.value.response.status_code == 404 or
+                cm.value.response.status_code == 400
+            )
 
     def test_list_volumes(self):
         name = 'imperishablenight'


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48773#issuecomment-2439740915


The API currently returns a 404 error when trying to create a volume with an invalid (non-existing) driver. We are considering changing this status code to be a 400 (invalid parameter), as even though the _reason_ of the error may be that the plugin / driver is not found, the _cause_ of the error is that the user provided a plugin / driver that's invalid for the engine they're connected to.

This patch updates the test to pass for either case.