### PR TITLE
image load: don't depend on deprecated JSONMessage.error field

### DIFF
--- a/docker/models/images.py
+++ b/docker/models/images.py
@@ -407,8 +407,8 @@ class ImageCollection(Collection):
                 if match:
                     image_id = match.group(2)
                     images.append(image_id)
-            if 'error' in chunk:
-                raise ImageLoadError(chunk['error'])
+            if 'errorDetail' in chunk:
+                raise ImageLoadError(chunk['errorDetail']['message'])
 
         return [self.get(i) for i in images]
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49264
- relates to https://github.com/moby/moby/pull/1298


The error field  was deprecated in favor of the errorDetail struct in [moby@3043c26], but the API continued to return both. This patch updates docker-py to not depend on the deprecated field.

[moby@3043c26]: https://github.com/moby/moby/commit/3043c2641990d94298c6377b7ef14709263a4709