### PR TITLE
Handle errorDetails and raise exception on failure instead of Str Stream

### DIFF
--- a/docker/api/image.py
+++ b/docker/api/image.py
@@ -495,7 +495,11 @@ class ImageApiMixin:
         self._raise_for_status(response)
 
         if stream:
-            return self._stream_helper(response, decode=decode)
+            for line in self._stream_helper(response, decode=decode):
+                if isinstance(line, dict) and "errorDetail" in line:
+                    raise errors.APIError(line["errorDetail"]["message"])
+                yield line
+
 
         return self._result(response)
 


### PR DESCRIPTION
Closes #3161 

This aims to eliminate silent failures in image push while using `client.images.push`

Adds the following:

- Error raising in stream handling via `errorDetails`
- Tests with error raise asserts


> Engine API doesn't raise error but return JSON with errorDetail and progressDetail [See [here](https://docs.docker.com/reference/api/engine/version-history/#v148-api-changes)]