### PR TITLE
Signal Parameter to Container Stop and Restart

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1074,7 +1074,7 @@ class ContainerApiMixin:
         self._raise_for_status(res)
 
     @utils.check_resource('container')
-    def restart(self, container, timeout=10):
+    def restart(self, container, timeout=10, signal=None):
         """
         Restart a container. Similar to the ``docker restart`` command.
 
@@ -1084,6 +1084,7 @@ class ContainerApiMixin:
             timeout (int): Number of seconds to try to stop for before killing
                 the container. Once killed it will then be restarted. Default
                 is 10 seconds.
+            signal (str or int): The signal to send. Defaults to ``SIGTERM``
 
         Raises:
             :py:class:`docker.errors.APIError`
@@ -1092,6 +1093,10 @@ class ContainerApiMixin:
         params = {'t': timeout}
         url = self._url("/containers/{0}/restart", container)
         conn_timeout = self.timeout
+        if signal is not None:
+            if not isinstance(signal, str):
+                signal = int(signal)
+            params["signal"] = signal
         if conn_timeout is not None:
             conn_timeout += timeout
         res = self._post(url, params=params, timeout=conn_timeout)
@@ -1184,7 +1189,7 @@ class ContainerApiMixin:
             return self._result(self._get(url, params=params), json=True)
 
     @utils.check_resource('container')
-    def stop(self, container, timeout=None):
+    def stop(self, container, timeout=None, signal=None):
         """
         Stops a container. Similar to the ``docker stop`` command.
 
@@ -1194,6 +1199,7 @@ class ContainerApiMixin:
                 stop before sending a ``SIGKILL``. If None, then the
                 StopTimeout value of the container will be used.
                 Default: None
+            signal (str or int): The signal to send. Defaults to ``SIGTERM``
 
         Raises:
             :py:class:`docker.errors.APIError`
@@ -1206,6 +1212,10 @@ class ContainerApiMixin:
             params = {'t': timeout}
         url = self._url("/containers/{0}/stop", container)
         conn_timeout = self.timeout
+        if signal is not None:
+            if not isinstance(signal, str):
+                signal = int(signal)
+            params["signal"] = signal
         if conn_timeout is not None:
             conn_timeout += timeout
         res = self._post(url, params=params, timeout=conn_timeout)

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -402,7 +402,7 @@ class Container(Model):
             timeout (int): Number of seconds to try to stop for before killing
                 the container. Once killed it will then be restarted. Default
                 is 10 seconds.
-
+            signal (str or int): The signal to send. Defaults to ``SIGTERM``
         Raises:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
@@ -445,7 +445,7 @@ class Container(Model):
         Args:
             timeout (int): Timeout in seconds to wait for the container to
                 stop before sending a ``SIGKILL``. Default: 10
-
+            signal (str or int): The signal to send. Defaults to ``SIGTERM``
         Raises:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -726,6 +726,34 @@ class ContainerTest(unittest.TestCase):
         container = client.containers.get(FAKE_CONTAINER_ID)
         assert container.image.id == FAKE_IMAGE_ID
 
+    def test_restart_with_signal(self):
+        client = make_fake_client()
+        container = client.containers.get(FAKE_CONTAINER_ID)
+        container.restart(timeout=2, signal='SIGTERM')
+        client.api.restart.assert_called_with(FAKE_CONTAINER_ID, timeout=2,
+                                              signal='SIGTERM')
+
+    def test_stop_with_signal(self):
+        client = make_fake_client()
+        container = client.containers.get(FAKE_CONTAINER_ID)
+        container.stop(timeout=2, signal='SIGTERM')
+        client.api.stop.assert_called_with(FAKE_CONTAINER_ID, timeout=2,
+                                           signal='SIGTERM')
+
+    def test_restart_with_sigint(self):
+        client = make_fake_client()
+        container = client.containers.get(FAKE_CONTAINER_ID)
+        container.restart(timeout=2, signal=2)
+        client.api.restart.assert_called_with(FAKE_CONTAINER_ID, timeout=2,
+                                              signal=2)
+
+    def test_stop_with_sigint(self):
+        client = make_fake_client()
+        container = client.containers.get(FAKE_CONTAINER_ID)
+        container.stop(timeout=2, signal=2)
+        client.api.stop.assert_called_with(FAKE_CONTAINER_ID, timeout=2,
+                                           signal=2)
+
     def test_kill(self):
         client = make_fake_client()
         container = client.containers.get(FAKE_CONTAINER_ID)


### PR DESCRIPTION
Closes #3304 

This PR aims to provide support for signal that is sent to the container in `stop` and `restart` according to `API v1.42`.

Adds following changes:

- `signal` argument to `restart` and `stop` in `docker/api/container.py`
- `signal` docstring in `docker/models/containers.py`
-  unit tests in `tests/unit/models_containers_test.py`

> Refer [API version here](https://docs.docker.com/reference/api/engine/version-history/#v142-api-changes)