### PR TITLE
integration: adjust tests for omitted "OnBuild"

### DIFF
--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -275,7 +275,7 @@ class BuildTest(BaseAPIIntegrationTest):
             pass
 
         info = self.client.inspect_image('build1')
-        assert not info['Config']['OnBuild']
+        assert 'OnBuild' not in info['Config'] or not info['Config']['OnBuild']
 
     @requires_api_version('1.25')
     def test_build_with_network_mode(self):

--- a/tests/ssh/api_build_test.py
+++ b/tests/ssh/api_build_test.py
@@ -266,7 +266,7 @@ class BuildTest(BaseAPIIntegrationTest):
             pass
 
         info = self.client.inspect_image('build1')
-        assert not info['Config']['OnBuild']
+        assert 'OnBuild' not in info['Config'] or not info['Config']['OnBuild']
 
     @requires_api_version('1.25')
     def test_build_with_network_mode(self):


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48457#issuecomment-2340015204

The Docker API may either return an empty "OnBuild" or omit the field altogether if it's not set.

Adjust the tests to make either satisfy the test.