### PR TITLE
Close urllib3 Response objects. Fixes occasional exceptions "ValueError: I/O operation on closed file." at shutdown.

### DIFF
--- a/docker/api/exec_api.py
+++ b/docker/api/exec_api.py
@@ -173,4 +173,5 @@ class ExecApiMixin:
         if stream:
             return CancellableStream(output, res)
         else:
+            res.close()
             return output

--- a/docker/types/daemon.py
+++ b/docker/types/daemon.py
@@ -69,3 +69,5 @@ class CancellableStream:
 
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()
+
+        self._response.close()


### PR DESCRIPTION
Fix for https://github.com/docker/docker-py/issues/3345 issues.