### PR TITLE
tests: Fix deprecation warning for utcfromtimestamp()

### DIFF
--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1302,7 +1302,7 @@ class ContainerTest(BaseAPIClientTest):
 
     def test_log_since_with_datetime(self):
         ts = 809222400
-        time = datetime.datetime.utcfromtimestamp(ts)
+        time = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
         with mock.patch('docker.api.client.APIClient.inspect_container',
                         fake_inspect_container):
             self.client.logs(fake_api.FAKE_CONTAINER_ID, stream=False,

--- a/tests/unit/api_test.py
+++ b/tests/unit/api_test.py
@@ -231,7 +231,7 @@ class DockerApiTest(BaseAPIClientTest):
 
     def test_events_with_since_until(self):
         ts = 1356048000
-        now = datetime.datetime.utcfromtimestamp(ts)
+        now = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
         since = now - datetime.timedelta(seconds=10)
         until = now + datetime.timedelta(seconds=10)
 


### PR DESCRIPTION
Fix DeprecationWarning for `datetime.datetime.utcfromtimestamp()`

It suggests to use timezone-aware objects to represent datetimes in UTC with `datetime.UTC` but `datetime.timezone.utc` is backwards compatible.

Verification run: https://openqa.opensuse.org/tests/5261910#downloads

```
tests/unit/api_container_test.py::ContainerTest::test_log_since_with_datetime
  /src/tests/unit/api_container_test.py:1305: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    time = datetime.datetime.utcfromtimestamp(ts)

tests/unit/api_test.py::DockerApiTest::test_events_with_since_until
  /src/tests/unit/api_test.py:234: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    now = datetime.datetime.utcfromtimestamp(ts)
```