### PR TITLE
remove misleading fileno method from NpipeFileIOBase class

### DIFF
--- a/docker/transport/npipesocket.py
+++ b/docker/transport/npipesocket.py
@@ -211,9 +211,6 @@ class NpipeFileIOBase(io.RawIOBase):
         super().close()
         self.sock = None
 
-    def fileno(self):
-        return self.sock.fileno()
-
     def isatty(self):
         return False
 


### PR DESCRIPTION
the underlying method used was removed in version 3.6.0, commit 2b2d711a5ba8be5cebe5913870c4dea1b9498af1