### PR TITLE
tests/integration: Make the tests runnable on SELinux enabled daemon

### DIFF
--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -570,7 +570,10 @@ class VolumeBindTest(BaseAPIIntegrationTest):
         mount = docker.types.Mount(
             type="bind", source=self.mount_origin, target=self.mount_dest
         )
-        host_config = self.client.create_host_config(mounts=[mount])
+        host_config = self.client.create_host_config(
+            mounts=[mount],
+            security_opt=["label=disable"],
+        )
         container = self.run_container(
             TEST_IMG, ['ls', self.mount_dest],
             host_config=host_config
@@ -587,7 +590,10 @@ class VolumeBindTest(BaseAPIIntegrationTest):
             type="bind", source=self.mount_origin, target=self.mount_dest,
             read_only=True
         )
-        host_config = self.client.create_host_config(mounts=[mount])
+        host_config = self.client.create_host_config(
+            mounts=[mount],
+            security_opt=["label=disable"],
+        )
         container = self.run_container(
             TEST_IMG, ['ls', self.mount_dest],
             host_config=host_config
@@ -604,7 +610,10 @@ class VolumeBindTest(BaseAPIIntegrationTest):
             type="volume", source=helpers.random_name(),
             target=self.mount_dest, labels={'com.dockerpy.test': 'true'}
         )
-        host_config = self.client.create_host_config(mounts=[mount])
+        host_config = self.client.create_host_config(
+            mounts=[mount],
+            security_opt=["label=disable"],
+        )
         container = self.client.create_container(
             TEST_IMG, ['true'], host_config=host_config,
         )
@@ -693,7 +702,8 @@ class VolumeBindTest(BaseAPIIntegrationTest):
                         'ro': ro,
                     },
                 },
-                network_mode='none'
+                network_mode='none',
+                security_opt=["label=disable"],
             ),
             **kwargs
         )
@@ -710,7 +720,8 @@ class VolumeBindTest(BaseAPIIntegrationTest):
                         'propagation': propagation
                     },
                 },
-                network_mode='none'
+                network_mode='none',
+                security_opt=["label=disable"],
             ),
             **kwargs
         )

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -48,7 +48,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
 
         container = client.containers.run(
             "alpine", "sh -c 'echo \"hello\" > /insidecontainer/test'",
-            volumes=[f"{path}:/insidecontainer"],
+            volumes=[f"{path}:/insidecontainer:z"],
             detach=True
         )
         self.tmp_containers.append(container.id)
@@ -57,7 +57,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
         name = "container_volume_test"
         out = client.containers.run(
             "alpine", "cat /insidecontainer/test",
-            volumes=[f"{path}:/insidecontainer"],
+            volumes=[f"{path}:/insidecontainer:z"],
             name=name
         )
         self.tmp_containers.append(name)


### PR DESCRIPTION
Make the tests runnable on SELinux enabled daemon.

Otherwise I get failures like these: https://openqa.opensuse.org/tests/5393787/file/python_docker-integration.txt

```
=================================== FAILURES ===================================
___________________ VolumeBindTest.test_create_with_binds_ro ___________________
tests/integration/api_container_test.py:511: in setUp
    self.run_with_volume(
tests/integration/api_container_test.py:636: in run_with_volume
    return self.run_container(
tests/integration/base.py:106: in run_container
    raise Exception(
E   Exception: Container exited with code 1:
E   b'touch: /mnt/shared.txt: Permission denied\n'
___________________ VolumeBindTest.test_create_with_binds_rw ___________________
tests/integration/api_container_test.py:511: in setUp
    self.run_with_volume(
tests/integration/api_container_test.py:636: in run_with_volume
    return self.run_container(
tests/integration/base.py:106: in run_container
    raise Exception(
E   Exception: Container exited with code 1:
E   b'touch: /mnt/shared.txt: Permission denied\n'
_______________ VolumeBindTest.test_create_with_binds_rw_rshared _______________
tests/integration/api_container_test.py:511: in setUp
    self.run_with_volume(
tests/integration/api_container_test.py:636: in run_with_volume
    return self.run_container(
tests/integration/base.py:106: in run_container
    raise Exception(
E   Exception: Container exited with code 1:
E   b'touch: /mnt/shared.txt: Permission denied\n'
____________________ VolumeBindTest.test_create_with_mounts ____________________
tests/integration/api_container_test.py:511: in setUp
    self.run_with_volume(
tests/integration/api_container_test.py:636: in run_with_volume
    return self.run_container(
tests/integration/base.py:106: in run_container
    raise Exception(
E   Exception: Container exited with code 1:
E   b'touch: /mnt/shared.txt: Permission denied\n'
__________________ VolumeBindTest.test_create_with_mounts_ro ___________________
tests/integration/api_container_test.py:511: in setUp
    self.run_with_volume(
tests/integration/api_container_test.py:636: in run_with_volume
    return self.run_container(
tests/integration/base.py:106: in run_container
    raise Exception(
E   Exception: Container exited with code 1:
E   b'touch: /mnt/shared.txt: Permission denied\n'
_________________ VolumeBindTest.test_create_with_volume_mount _________________
tests/integration/api_container_test.py:511: in setUp
    self.run_with_volume(
tests/integration/api_container_test.py:636: in run_with_volume
    return self.run_container(
tests/integration/base.py:106: in run_container
    raise Exception(
E   Exception: Container exited with code 1:
E   b'touch: /mnt/shared.txt: Permission denied\n'
_________________ ContainerCollectionTest.test_run_with_volume _________________
tests/integration/models_containers_test.py:58: in test_run_with_volume
    out = client.containers.run(
docker/models/containers.py:905: in run
    raise ContainerError(
E   docker.errors.ContainerError: Command 'cat /insidecontainer/test' in image 'alpine' returned non-zero exit status 1: b"cat: can't open '/insidecontainer/test': No such file or directory\n"
```