### PR TITLE
Optimize consume_socket_output to O(n) by replacing byte concatenation with join

### DIFF
--- a/docker/utils/socket.py
+++ b/docker/utils/socket.py
@@ -185,3 +185,36 @@ def demux_adaptor(stream_id, data):
         return (None, data)
     else:
         raise ValueError(f'{stream_id} is not a valid stream')
+
+def consume_socket_output(frames, demux=False):
+    """
+    Iterate through frames read from the socket and return the result.
+
+    Args:
+        demux (bool):
+            If False, stdout and stderr are multiplexed, and the result is the
+            concatenation of all the frames. If True, the streams are
+            demultiplexed, and the result is a 2-tuple where each item is the
+            concatenation of frames belonging to the same stream.
+    """
+
+    if not demux:
+        # When not demuxed, frames is a generator yielding byte chunks.
+        # Using join ensures O(n) complexity instead of O(n²)
+        return b"".join(frames)
+
+    # When demux=True, frames yields tuples like (stdout_bytes, stderr_bytes)
+    stdout_chunks = []
+    stderr_chunks = []
+
+    for stdout_part, stderr_part in frames:
+        # Exactly one of them is not None
+        if stdout_part is not None:
+            stdout_chunks.append(stdout_part)
+        elif stderr_part is not None:
+            stderr_chunks.append(stderr_part)
+
+    stdout = b"".join(stdout_chunks) if stdout_chunks else None
+    stderr = b"".join(stderr_chunks) if stderr_chunks else None
+    return (stdout, stderr)
+


### PR DESCRIPTION
This PR improves the performance of consume_socket_output() in docker/utils/socket.py by replacing repeated byte concatenation with a list-based accumulation approach followed by b''.join().

The optimization reduces the overall time complexity from O(n²) to O(n), leading to significant improvements in speed and efficiency for large container log streams.

The fix preserves functional behavior and passes all existing test cases.