### PR TITLE
feat(docker/api/container): inspect container with size

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -775,7 +775,7 @@ class ContainerApiMixin:
         )
 
     @utils.check_resource('container')
-    def inspect_container(self, container):
+    def inspect_container(self, container, size=False):
         """
         Identical to the `docker inspect` command, but only for containers.
 
@@ -790,8 +790,9 @@ class ContainerApiMixin:
             :py:class:`docker.errors.APIError`
                 If the server returns an error.
         """
+        params = {"size": "true" if size else "false"}
         return self._result(
-            self._get(self._url("/containers/{0}/json", container)), True
+            self._get(self._url("/containers/{0}/json", container), params=params), True
         )
 
     @utils.check_resource('container')

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -1517,7 +1517,18 @@ class ContainerTest(BaseAPIClientTest):
         fake_request.assert_called_with(
             'GET',
             url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/json',
-            timeout=DEFAULT_TIMEOUT_SECONDS
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            params={'size': 'false'}
+        )
+
+    def test_inspect_container_with_size(self):
+        self.client.inspect_container(fake_api.FAKE_CONTAINER_ID, size=True)
+
+        fake_request.assert_called_with(
+            'GET',
+            url_prefix + 'containers/' + fake_api.FAKE_CONTAINER_ID + '/json',
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+            params={'size': 'true'}
         )
 
     def test_inspect_container_undefined_id(self):

--- a/tests/unit/fake_api.py
+++ b/tests/unit/fake_api.py
@@ -143,7 +143,7 @@ def post_fake_create_container():
     return status_code, response
 
 
-def get_fake_inspect_container(tty=False):
+def get_fake_inspect_container(tty=False, size=False):
     status_code = 200
     response = {
         'Id': FAKE_CONTAINER_ID,
@@ -167,6 +167,11 @@ def get_fake_inspect_container(tty=False):
         },
         "MacAddress": "02:42:ac:11:00:0a"
     }
+    if size:
+        response.update({
+            "SizeRw": 50178,
+            "SizeRootFs": 152129365
+        })
     return status_code, response
 
 


### PR DESCRIPTION
## Rationale
The docker inspect command allows clients to view the total file sizes of a container. This PR enables callers to pass the `size` argument while inspecting a container in order to get statistics on file sizes in the container.

### Changes
- add optional parameter `size` to inspect_container