### PR TITLE
Fix return type in `Container.top()` docstring

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -1221,7 +1221,7 @@ class ContainerApiMixin:
             ps_args (str): An optional arguments passed to ps (e.g. ``aux``)
 
         Returns:
-            (str): The output of the top
+            (dict): The output of the top
 
         Raises:
             :py:class:`docker.errors.APIError`

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -460,7 +460,7 @@ class Container(Model):
             ps_args (str): An optional arguments passed to ps (e.g. ``aux``)
 
         Returns:
-            (str): The output of the top
+            (dict): The output of the top
 
         Raises:
             :py:class:`docker.errors.APIError`


### PR DESCRIPTION
This is a small fix to reflect the real return type in `Container.top()` and `ContainerApiMixin.top()` methods.

Fixes #2958