### PR TITLE
test_connect_with_ipv6_address: enable IPv6

### DIFF
--- a/tests/integration/api_network_test.py
+++ b/tests/integration/api_network_test.py
@@ -384,6 +384,7 @@ class TestNetworks(BaseAPIIntegrationTest):
     @requires_api_version('1.22')
     def test_connect_with_ipv6_address(self):
         net_name, net_id = self.create_network(
+            enable_ipv6=True,
             ipam=IPAMConfig(
                 driver='default',
                 pool_configs=[


### PR DESCRIPTION
`test_connect_with_ipv6_address` creates a network with IPv6 IPAM, and checks it's possible to start a container with a configured IPv6 address ... but it doesn't enable IPv6 in the network.

The test passes because the daemon checks the configured IPv6 address is in a configured subnet - and it is, but the IPv6 subnet wasn't used. So, the IPv6 address isn't assigned to an interface in the container, it just appears in its config.

https://github.com/moby/moby/pull/51577 updates the daemon to check the network is using a subnet containing the configured address - so this test will fail.