### PR TITLE
Fix APIClient docstring: correct version parameter default value

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -89,8 +89,9 @@ class APIClient(
     Args:
         base_url (str): URL to the Docker server. For example,
             ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:1234``.
-        version (str): The version of the API to use. Set to ``auto`` to
-            automatically detect the server's version. Default: ``1.35``
+        version (str or None): The version of the API to use. If ``None``
+            (default) or ``'auto'``, automatically detect the server's
+            version. Otherwise, use the specified version string.
         timeout (int): Default timeout for API calls, in seconds.
         tls (bool or :py:class:`~docker.tls.TLSConfig`): Enable TLS. Pass
             ``True`` to enable it with default options, or pass a


### PR DESCRIPTION
The docstring for APIClient incorrectly stated that the default value for the `version` parameter is `'1.35'`. In reality, the default is `None`, which triggers automatic API version detection (same behavior as `'auto'`).

This commit updates the docstring to accurately reflect:
- The default value is `None`, not `'1.35'`
- Both `None` and `'auto'` trigger automatic version detection
- The parameter type should be `str or None` to reflect the actual default

Fixes incorrect documentation that could mislead users about the API client's default behavior.

This PR was motivated from having encountered this issue personally following the docker v29 changes. I don't want others to fall into the same trap.