### PR TITLE
integration: Remove tests for dropped features on Docker v29

### DIFF
--- a/tests/integration/api_build_test.py
+++ b/tests/integration/api_build_test.py
@@ -349,32 +349,6 @@ class BuildTest(BaseAPIIntegrationTest):
         assert '127.0.0.1\textrahost.local.test' in logs
         assert '127.0.0.1\thello.world.test' in logs
 
-    @requires_experimental(until=None)
-    @requires_api_version('1.25')
-    def test_build_squash(self):
-        script = io.BytesIO('\n'.join([
-            'FROM busybox',
-            'RUN echo blah > /file_1',
-            'RUN echo blahblah > /file_2',
-            'RUN echo blahblahblah > /file_3'
-        ]).encode('ascii'))
-
-        def build_squashed(squash):
-            tag = 'squash' if squash else 'nosquash'
-            stream = self.client.build(
-                fileobj=script, tag=tag, squash=squash
-            )
-            self.tmp_imgs.append(tag)
-            for _chunk in stream:
-                pass
-
-            return self.client.inspect_image(tag)
-
-        non_squashed = build_squashed(False)
-        squashed = build_squashed(True)
-        assert len(non_squashed['RootFS']['Layers']) == 4
-        assert len(squashed['RootFS']['Layers']) == 2
-
     def test_build_stderr_data(self):
         control_chars = ['\x1b[91m', '\x1b[0m']
         snippet = 'Ancient Temple (Mystic Oriental Dream ~ Ancient Temple)'

--- a/tests/integration/api_container_test.py
+++ b/tests/integration/api_container_test.py
@@ -64,53 +64,6 @@ class CreateContainerTest(BaseAPIIntegrationTest):
         assert 'PidMode' in host_config
         assert host_config['PidMode'] == 'host'
 
-    def test_create_with_links(self):
-        res0 = self.client.create_container(
-            TEST_IMG, 'cat',
-            detach=True, stdin_open=True,
-            environment={'FOO': '1'})
-
-        container1_id = res0['Id']
-        self.tmp_containers.append(container1_id)
-
-        self.client.start(container1_id)
-
-        res1 = self.client.create_container(
-            TEST_IMG, 'cat',
-            detach=True, stdin_open=True,
-            environment={'FOO': '1'})
-
-        container2_id = res1['Id']
-        self.tmp_containers.append(container2_id)
-
-        self.client.start(container2_id)
-
-        # we don't want the first /
-        link_path1 = self.client.inspect_container(container1_id)['Name'][1:]
-        link_alias1 = 'mylink1'
-        link_env_prefix1 = link_alias1.upper()
-
-        link_path2 = self.client.inspect_container(container2_id)['Name'][1:]
-        link_alias2 = 'mylink2'
-        link_env_prefix2 = link_alias2.upper()
-
-        res2 = self.client.create_container(
-            TEST_IMG, 'env', host_config=self.client.create_host_config(
-                links={link_path1: link_alias1, link_path2: link_alias2},
-                network_mode='bridge'
-            )
-        )
-        container3_id = res2['Id']
-        self.tmp_containers.append(container3_id)
-        self.client.start(container3_id)
-        assert self.client.wait(container3_id)['StatusCode'] == 0
-
-        logs = self.client.logs(container3_id).decode('utf-8')
-        assert f'{link_env_prefix1}_NAME=' in logs
-        assert f'{link_env_prefix1}_ENV_FOO=1' in logs
-        assert f'{link_env_prefix2}_NAME=' in logs
-        assert f'{link_env_prefix2}_ENV_FOO=1' in logs
-
     def test_create_with_restart_policy(self):
         container = self.client.create_container(
             TEST_IMG, ['sleep', '2'],

--- a/tests/integration/models_containers_test.py
+++ b/tests/integration/models_containers_test.py
@@ -36,7 +36,7 @@ class ContainerCollectionTest(BaseIntegrationTest):
 
     def test_run_with_image_that_does_not_exist(self):
         client = docker.from_env(version=TEST_API_VERSION)
-        with pytest.raises(docker.errors.ImageNotFound):
+        with pytest.raises((docker.errors.ImageNotFound, docker.errors.NotFound)):
             client.containers.run("dockerpytest_does_not_exist")
 
     @pytest.mark.skipif(

--- a/tests/ssh/api_build_test.py
+++ b/tests/ssh/api_build_test.py
@@ -340,32 +340,6 @@ class BuildTest(BaseAPIIntegrationTest):
         assert '127.0.0.1\textrahost.local.test' in logs
         assert '127.0.0.1\thello.world.test' in logs
 
-    @requires_experimental(until=None)
-    @requires_api_version('1.25')
-    def test_build_squash(self):
-        script = io.BytesIO('\n'.join([
-            'FROM busybox',
-            'RUN echo blah > /file_1',
-            'RUN echo blahblah > /file_2',
-            'RUN echo blahblahblah > /file_3'
-        ]).encode('ascii'))
-
-        def build_squashed(squash):
-            tag = 'squash' if squash else 'nosquash'
-            stream = self.client.build(
-                fileobj=script, tag=tag, squash=squash
-            )
-            self.tmp_imgs.append(tag)
-            for _chunk in stream:
-                pass
-
-            return self.client.inspect_image(tag)
-
-        non_squashed = build_squashed(False)
-        squashed = build_squashed(True)
-        assert len(non_squashed['RootFS']['Layers']) == 4
-        assert len(squashed['RootFS']['Layers']) == 2
-
     def test_build_stderr_data(self):
         control_chars = ['\x1b[91m', '\x1b[0m']
         snippet = 'Ancient Temple (Mystic Oriental Dream ~ Ancient Temple)'


### PR DESCRIPTION
Remove tests for dropped features on Docker v29

- Remove test_build_squash as the squash flag is no longer supported with BuildKit.
- Remove test_create_with_links https://docs.docker.com/reference/cli/docker/build-legacy/
- Also catch NotFound exception for test_run_with_image_that_does_not_exist