### PR TITLE
WIP: Use the active context if "base_url" is not provided (#3146)

### DIFF
--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -18,6 +18,7 @@ from ..constants import (
     MINIMUM_DOCKER_API_VERSION,
     STREAM_HEADER_SIZE_BYTES,
 )
+from .. import context
 from ..errors import (
     DockerException,
     InvalidVersion,
@@ -123,6 +124,11 @@ class APIClient(
             raise TLSParameterError(
                 'If using TLS, the base_url argument must be provided.'
             )
+
+        if base_url is None:
+            current_ctx = context.ContextAPI.get_current_context()
+            if current_ctx is not None:
+                base_url = current_ctx.Host
 
         self.base_url = base_url
         self.timeout = timeout

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -128,6 +128,7 @@ class APIClient(
             current_ctx = context.ContextAPI.get_current_context()
             if current_ctx is not None:
                 base_url = current_ctx.Host
+                tls = current_ctx.TLSConfig
 
         self.base_url = base_url
         self.timeout = timeout

--- a/docker/api/client.py
+++ b/docker/api/client.py
@@ -7,7 +7,7 @@ import requests
 import requests.adapters
 import requests.exceptions
 
-from .. import auth
+from .. import auth, context
 from ..constants import (
     DEFAULT_MAX_POOL_SIZE,
     DEFAULT_NUM_POOLS,
@@ -18,7 +18,6 @@ from ..constants import (
     MINIMUM_DOCKER_API_VERSION,
     STREAM_HEADER_SIZE_BYTES,
 )
-from .. import context
 from ..errors import (
     DockerException,
     InvalidVersion,


### PR DESCRIPTION
Hi!
This PR proposes a fix for [Issue #3146](https://github.com/docker/docker-py/issues/3146).

As this is my first time contributing to this codebase, I’d love some feedback on a couple of things:

- I'd appreciate your thoughts on whether this is the correct place in the codebase to handle this logic regarding the Docker context.

- I noted in CONTRIBUTING.md that tests are highly encouraged. However, I’m a bit unsure how to effectively test this specific behavior. Could you point me in the right direction or suggest an approach?

Thanks in advance for your time and feedback!