### PR TITLE
tests: Make stream assertions robust to chunk splitting

### DIFF
--- a/tests/integration/api_exec_test.py
+++ b/tests/integration/api_exec_test.py
@@ -286,13 +286,9 @@ class ExecDemuxTest(BaseAPIIntegrationTest):
         # tty=True, stream=True, demux=False
         res = self.client.exec_create(self.container, self.cmd, tty=True)
         exec_log = list(self.client.exec_start(res, stream=True))
-        assert b'hello out\r\n' in exec_log
-        if len(exec_log) == 2:
-            assert b'hello err\r\n' in exec_log
-        else:
-            assert len(exec_log) == 3
-            assert b'hello err' in exec_log
-            assert b'\r\n' in exec_log
+        merged = b''.join(chunk for chunk in exec_log)
+        assert b'hello out\r\n' in merged
+        assert b'hello err\r\n' in merged
 
     def test_exec_command_tty_no_stream_demux(self):
         # tty=True, stream=False, demux=True
@@ -304,10 +300,6 @@ class ExecDemuxTest(BaseAPIIntegrationTest):
         # tty=True, stream=True, demux=True
         res = self.client.exec_create(self.container, self.cmd, tty=True)
         exec_log = list(self.client.exec_start(res, demux=True, stream=True))
-        assert (b'hello out\r\n', None) in exec_log
-        if len(exec_log) == 2:
-            assert (b'hello err\r\n', None) in exec_log
-        else:
-            assert len(exec_log) == 3
-            assert (b'hello err', None) in exec_log
-            assert (b'\r\n', None) in exec_log
+        merged = b''.join(chunk for chunk, _ in exec_log)
+        assert b'hello out\r\n' in merged
+        assert b'hello err\r\n' in merged


### PR DESCRIPTION
When `tty=True` the output can be split across multiple stream chunks instead of aligning on line boundaries, making exact chunk membership checks unreliable.

Verify that the expected messages are present in the combined stream output rather than at specific chunk boundaries.

Otherwise tests may fail like this:

```
# test_exec_command_tty_stream_no_demux
# failure: 

AssertionError: assert b'hello out\r\n' in [b'hello out', b'\r\n', b'hello err\r\n']
tests/integration/api_exec_test.py:289: in test_exec_command_tty_stream_no_demux
    assert b'hello out\r\n' in exec_log
E   AssertionError: assert b'hello out\r\n' in [b'hello out', b'\r\n', b'hello err\r\n']
[ricardo@fedora /tmp]$ cat aja 
E   AssertionError: assert (b'hello out\r\n', None) in [(b'hello out', None), (b'\r\n', None), (b'hello err\r\n', None)]
E   AssertionError: assert (b'hello out\r\n', None) in [(b'hello out', None), (b'\r\n', None), (b'hello err\r\n', None)]
```

```
# Test messages # test_exec_command_tty_stream_no_demux
# failure: 

AssertionError: assert b'hello out\r\n' in [b'hello out', b'\r\n', b'hello err\r\n']
tests/integration/api_exec_test.py:289: in test_exec_command_tty_stream_no_demux
    assert b'hello out\r\n' in exec_log
E   AssertionError: assert b'hello out\r\n' in [b'hello out', b'\r\n', b'hello err\r\n']
```
