### PR TITLE
Fix test_connect_with_mac_address for Docker v29.3

### DIFF
--- a/tests/integration/api_network_test.py
+++ b/tests/integration/api_network_test.py
@@ -415,6 +415,7 @@ class TestNetworks(BaseAPIIntegrationTest):
 
         container = self.client.create_container(TEST_IMG, 'top')
         self.tmp_containers.append(container)
+        self.client.start(container)
 
         self.client.connect_container_to_network(
             container, net_name, mac_address='02:42:ac:11:00:02'


### PR DESCRIPTION
With (moby/moby#52040), Docker v29.3.0 now correctly applies the MacAddress field in EndpointSettings when connecting a container to a network.
    
The test connected a stopped container to immediately inspect it.
    
Start the container before connecting to the network so the MAC is correctly applied and reflected in inspect on both old and new Docker versions.

Fixes: https://github.com/docker/docker-py/issues/3389