### PR TITLE
Add pull option for container create and run

### DIFF
--- a/docker/api/container.py
+++ b/docker/api/container.py
@@ -226,7 +226,7 @@ class ContainerApiMixin:
                          mac_address=None, labels=None, stop_signal=None,
                          networking_config=None, healthcheck=None,
                          stop_timeout=None, runtime=None,
-                         use_config_proxy=True, platform=None):
+                         use_config_proxy=True, platform=None, pull=None):
         """
         Creates a container. Parameters are similar to those for the ``docker
         run`` command except it doesn't support the attach options (``-a``).
@@ -408,6 +408,7 @@ class ContainerApiMixin:
                 contains a proxy configuration, the corresponding environment
                 variables will be set in the container being created.
             platform (str): Platform in the format ``os[/arch[/variant]]``.
+            pull (str): Pull image before creating the container.
 
         Returns:
             A dictionary with an image 'Id' key and a 'Warnings' key.
@@ -437,12 +438,14 @@ class ContainerApiMixin:
             stop_signal, networking_config, healthcheck,
             stop_timeout, runtime
         )
-        return self.create_container_from_config(config, name, platform)
+        return self.create_container_from_config(config, name, platform, pull)
 
     def create_container_config(self, *args, **kwargs):
         return ContainerConfig(self._version, *args, **kwargs)
 
-    def create_container_from_config(self, config, name=None, platform=None):
+    def create_container_from_config(
+        self, config, name=None, platform=None, pull=None
+    ):
         u = self._url("/containers/create")
         params = {
             'name': name
@@ -451,8 +454,10 @@ class ContainerApiMixin:
             if utils.version_lt(self._version, '1.41'):
                 raise errors.InvalidVersion(
                     'platform is not supported for API version < 1.41'
-                )
+            )
             params['platform'] = platform
+        if pull is not None:
+            params['pull'] = pull
         res = self._post_json(u, data=config, params=params)
         return self._result(res, True)
 

--- a/docker/models/containers.py
+++ b/docker/models/containers.py
@@ -853,6 +853,7 @@ class ContainerCollection(Collection):
         stream = kwargs.pop('stream', False)
         detach = kwargs.pop('detach', False)
         platform = kwargs.get('platform', None)
+        pull = kwargs.get('pull', None)
 
         if detach and remove:
             if version_gte(self.client.api._version, '1.25'):
@@ -877,6 +878,8 @@ class ContainerCollection(Collection):
             container = self.create(image=image, command=command,
                                     detach=detach, **kwargs)
         except ImageNotFound:
+            if pull == 'never':
+                raise
             self.client.images.pull(image, platform=platform)
             container = self.create(image=image, command=command,
                                     detach=detach, **kwargs)
@@ -1044,6 +1047,7 @@ RUN_CREATE_KWARGS = [
     'name',
     'network_disabled',
     'platform',
+    'pull',
     'stdin_open',
     'stop_signal',
     'tty',

--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -369,6 +369,22 @@ class CreateContainerTest(BaseAPIClientTest):
         assert args[1]['headers'] == {'Content-Type': 'application/json'}
         assert args[1]['params'] == {'name': None, 'platform': 'linux'}
 
+    def test_create_container_with_pull(self):
+        self.client.create_container('busybox', 'true',
+                                     pull='always')
+
+        args = fake_request.call_args
+        assert args[0][1] == url_prefix + 'containers/create'
+        assert json.loads(args[1]['data']) == json.loads('''
+            {"Tty": false, "Image": "busybox", "Cmd": ["true"],
+             "AttachStdin": false,
+             "AttachStderr": true, "AttachStdout": true,
+             "StdinOnce": false,
+             "OpenStdin": false, "NetworkDisabled": false}
+        ''')
+        assert args[1]['headers'] == {'Content-Type': 'application/json'}
+        assert args[1]['params'] == {'name': None, 'pull': 'always'}
+
     def test_create_container_with_mem_limit_as_int(self):
         self.client.create_container(
             'busybox', 'true', host_config=self.client.create_host_config(

--- a/tests/unit/models_containers_test.py
+++ b/tests/unit/models_containers_test.py
@@ -92,6 +92,7 @@ class ContainerCollectionTest(unittest.TestCase):
             'platform': 'linux',
             'ports': {1111: 4567, 2222: None},
             'privileged': True,
+            'pull': 'always',
             'publish_all_ports': True,
             'read_only': True,
             'restart_policy': {'Name': 'always'},
@@ -211,6 +212,7 @@ class ContainerCollectionTest(unittest.TestCase):
             },
             'platform': 'linux',
             'ports': [('1111', 'tcp'), ('2222', 'tcp')],
+            'pull': 'always',
             'stdin_open': True,
             'stop_signal': 9,
             'tty': True,
@@ -244,6 +246,19 @@ class ContainerCollectionTest(unittest.TestCase):
         client.api.inspect_container.assert_called_with(FAKE_CONTAINER_ID)
         client.api.start.assert_called_with(FAKE_CONTAINER_ID)
 
+    def test_run_with_pull(self):
+        client = make_fake_client()
+        client.containers.run('alpine', pull='always')
+        client.api.create_container.assert_called_with(
+            image='alpine',
+            command=None,
+            detach=False,
+            pull='always',
+            host_config={
+                'NetworkMode': 'default',
+            }
+        )
+
     def test_run_pull(self):
         client = make_fake_client()
 
@@ -258,6 +273,24 @@ class ContainerCollectionTest(unittest.TestCase):
         assert container.id == FAKE_CONTAINER_ID
         client.api.pull.assert_called_with(
             'alpine', platform=None, tag='latest', all_tags=False, stream=True
+        )
+
+    def test_run_pull_never_does_not_fallback(self):
+        client = make_fake_client()
+        client.api.create_container.side_effect = docker.errors.ImageNotFound("")
+
+        with pytest.raises(docker.errors.ImageNotFound):
+            client.containers.run('alpine', pull='never')
+
+        client.api.pull.assert_not_called()
+        client.api.create_container.assert_called_once_with(
+            image='alpine',
+            command=None,
+            detach=False,
+            pull='never',
+            host_config={
+                'NetworkMode': 'default',
+            }
         )
 
     def test_run_with_error(self):
@@ -483,6 +516,18 @@ class ContainerCollectionTest(unittest.TestCase):
             host_config={'NetworkMode': 'default'}
         )
         client.api.inspect_container.assert_called_with(FAKE_CONTAINER_ID)
+
+    def test_create_with_pull(self):
+        client = make_fake_client()
+        container = client.containers.create('alpine', pull='always')
+        assert isinstance(container, Container)
+        assert container.id == FAKE_CONTAINER_ID
+        client.api.create_container.assert_called_with(
+            image='alpine',
+            command=None,
+            pull='always',
+            host_config={'NetworkMode': 'default'}
+        )
 
     def test_create_with_image_object(self):
         client = make_fake_client()


### PR DESCRIPTION
## Summary

Adds support for passing the `pull` option when creating or running containers.

This change:

* Adds `pull` as a create-level kwarg
* Passes `pull` through to the container create API query params
* Preserves existing automatic image pull fallback behavior
* Avoids fallback pulling when `pull="never"` is used

Fixes #3369

## Tests

Passed:

* tests/unit/api_container_test.py::CreateContainerTest::test_create_container_with_pull
* Relevant new pull-related tests

Broader local test runs had unrelated environment-sensitive failures involving timezone offsets, Docker context/configuration, and local TLS settings.
