### PR TITLE
integration/swarm: Preserve rotated unlock key

### DIFF
--- a/tests/integration/api_swarm_test.py
+++ b/tests/integration/api_swarm_test.py
@@ -249,6 +249,7 @@ class SwarmTest(BaseAPIIntegrationTest):
             rotate_manager_unlock_key=True
         )
         key_2 = self.client.get_unlock_key()
+        self._unlock_key = key_2
         assert key_1['UnlockKey'] != key_2['UnlockKey']
 
     @requires_api_version('1.30')


### PR DESCRIPTION
Fixes flaky SwarmTest.test_update_node erroring out with "Swarm is encrypted and needs to be unlocked before it can be used. Please use "docker swarm unlock" to unlock it."

`test_rotate_manager_unlock_key` enables autolock and then rotates the manager unlock key, but teardown still holds the original key.

If the swarm needs to be unlocked during cleanup, the stale key cannot unlock it and the daemon can remain in locked swarm state for the next test.

Store the rotated unlock key so teardown can unlock and leave the swarm cleanly.