### PR TITLE
docs: add reference documentation for docker.utils module

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -351,6 +351,25 @@ def parse_devices(devices):
 
 
 def kwargs_from_env(environment=None):
+    """
+    Configure client arguments based on the environment variables.
+
+    Reads environment variables like ``DOCKER_HOST``, ``DOCKER_CERT_PATH``, and
+    ``DOCKER_TLS_VERIFY`` to configure communication with the Docker daemon.
+
+    Args:
+        environment (dict, optional): A dictionary representing the environment
+            variables to use. Defaults to ``os.environ``.
+
+    Returns:
+        dict: A dictionary of configuration options (e.g., ``base_url``,
+        ``tls``) that can be passed as keyword arguments to instantiate
+        a :py:class:`~docker.client.DockerClient` or :py:class:`~docker.api.client.APIClient`.
+
+    Example:
+        >>> kwargs = docker.utils.kwargs_from_env()
+        >>> client = docker.DockerClient(**kwargs)
+    """
     if not environment:
         environment = os.environ
     host = environment.get('DOCKER_HOST')
@@ -457,8 +476,25 @@ def normalize_links(links):
 
 def parse_env_file(env_file):
     """
-    Reads a line-separated environment file.
-    The format of each line should be "key=value".
+    Parse a line-separated environment file.
+
+    Reads a file containing ``KEY=VALUE`` environment variable pairs, ignoring
+    comments (lines starting with ``#``) and empty lines, and returns them as a
+    dictionary.
+
+    Args:
+        env_file (str): Path to the environment file.
+
+    Returns:
+        dict: A dictionary mapping environment variable names to their values.
+
+    Raises:
+        docker.errors.DockerException: If a line in the environment file
+            is malformed (does not contain a ``=`` character).
+
+    Example:
+        >>> env_vars = docker.utils.parse_env_file('path/to/.env')
+        >>> client.containers.run('ubuntu', environment=env_vars)
     """
     environment = {}
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,5 +92,6 @@ That's just a taste of what you can do with the Docker SDK for Python. For more,
   volumes
   api
   tls
+  utils
   user_guides/index
   change-log

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,0 +1,8 @@
+Utilities
+=========
+
+.. py:module:: docker.utils
+
+.. autofunction:: kwargs_from_env
+
+.. autofunction:: parse_env_file


### PR DESCRIPTION
Fixes #3386

### Context
The `docker.utils.parse_env_file` utility function was added in version 1.4.0, but it was never documented in the Sphinx reference files. As a result, the changelog link to the docs has been pointing to an empty location, leaving users unaware of how to officially parse `.env` files using `docker-py`. 

Furthermore, `kwargs_from_env` (the backbone of `docker.from_env()`) was completely missing a docstring.

### Changes Made
- Added detailed Google-style Python docstrings with usage examples to both `kwargs_from_env` and `parse_env_file` in `docker/utils/utils.py`.
- Created a new `docs/utils.rst` page using the `.. autofunction::` directive to automatically pull the documentation.
- Registered the new `utils` reference page in the `docs/index.rst` toctree.

### Verification
- Built the Sphinx documentation locally (`make docs`) successfully. 
- HTML renders cleanly without any warnings related to the newly added docstrings.
