### PR TITLE
harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 10
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,85 +1,130 @@
-name: Python package
+name: ci
 
-on: [push, pull_request]
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
 
 env:
-  DOCKER_BUILDKIT: '1'
+  DOCKER_BUILDKIT: 1
   FORCE_COLOR: 1
 
 jobs:
-    lint:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-            - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-              with:
-                  python-version: '3.x'
-            - run: pip install -U ruff==0.1.8
-            - name: Run ruff
-              run: ruff docker tests
-
-    build:
-      runs-on: ubuntu-22.04
-      steps:
-        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-          with:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      -
+        name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
             python-version: '3.x'
-        - run: pip3 install build && python -m build .
-        - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-          with:
-            name: dist
-            path: dist
+      -
+        name: Install ruff
+        run: pip install -U ruff==0.1.8
+      -
+        name: Run ruff
+        run: ruff docker tests
 
-    unit-tests:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      -
+        name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.x'
+      -
+        name: Build
+        run: pip3 install build && python -m build .
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist
 
-        steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-              with:
-                python-version: ${{ matrix.python-version }}
-                allow-prereleases: true
-            - name: Install dependencies
-              run: |
-                  python3 -m pip install --upgrade pip
-                  pip3 install '.[ssh,dev]'
-            - name: Run unit tests
-              run: |
-                  docker logout
-                  rm -rf ~/.docker
-                  py.test -v --cov=docker tests/unit
+  unit-tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      -
+        name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      -
+        name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install '.[ssh,dev]'
+      -
+        name: Run unit tests
+        run: |
+          docker logout
+          rm -rf ~/.docker
+          py.test -v --cov=docker tests/unit
 
-    integration-tests:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                variant: [ "integration-dind", "integration-dind-ssl", "integration-dind-ssh" ]
+  integration-tests:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        variant:
+          - integration-dind
+          - integration-dind-ssl
+          - integration-dind-ssh
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      -
+        name: Run ${{ matrix.variant }}
+        run: |
+          docker logout
+          rm -rf ~/.docker
+          make ${{ matrix.variant }}
 
-        steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-              with:
-                fetch-depth: 0
-                fetch-tags: true
-            - name: make ${{ matrix.variant }}
-              run: |
-                  docker logout
-                  rm -rf ~/.docker
-                  make ${{ matrix.variant }}
-
-    arm64-integration-tests:
-        runs-on: ubuntu-24.04-arm
-        steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-              with:
-                fetch-depth: 0
-                fetch-tags: true
-            - name: make integration-dind
-              run: |
-                  docker logout
-                  rm -rf ~/.docker
-                  make integration-dind
+  arm64-integration-tests:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      -
+        name: Run integration-dind
+        run: |
+          docker logout
+          rm -rf ~/.docker
+          make integration-dind

--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -1,9 +1,4 @@
 name: PR Review - Trigger
-on:
-  pull_request:
-    types: [ready_for_review, opened, review_requested]
-  pull_request_review_comment:
-    types: [created]
 
 permissions: {}
 
@@ -15,12 +10,19 @@ concurrency:
   group: pr-review-trigger-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+on:
+  pull_request:
+    types: [ready_for_review, opened, review_requested]
+  pull_request_review_comment:
+    types: [created]
+
 jobs:
   save-context:
     if: github.event.pull_request.head.repo.fork
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - name: Save event context
+      -
+        name: Save event context
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -33,8 +35,8 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
             printf '%s' "$COMMENT_JSON" > context/comment.json
           fi
-
-      - name: Upload context
+      -
+        name: Upload context
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-review-context

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,13 +1,17 @@
 name: PR Review
-on:
-  issue_comment:
-    types: [created]
-  workflow_run:
-    workflows: ["PR Review - Trigger"]
-    types: [completed]
 
 permissions:
-  contents: read
+  contents: read # Required at top-level to give `issue_comment` events access to the secrets below.
+
+# workflow_run is used deliberately here: the unprivileged "PR Review - Trigger"
+# workflow runs on the fork PR and this privileged one only consumes its
+# artifacts, never checks out or executes fork code.
+on: # zizmor: ignore[dangerous-triggers]
+  issue_comment:
+    types: [ created ]
+  workflow_run:
+    workflows: [ "PR Review - Trigger" ]
+    types: [ completed ]
 
 jobs:
   review:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
-name: Release
+name: release
+
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -19,14 +22,19 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # to create GitHub release
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      -
+        name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      -
+        name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
-
-      - name: Generate Package
+      -
+        name: Generate Package
         run: |
           pip3 install build
           python -m build .
@@ -34,20 +42,20 @@ jobs:
           # This is also supported by Hatch; see
           # https://github.com/ofek/hatch-vcs#version-source-environment-variables
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ inputs.tag }}
-
-      - name: Publish to PyPI
+      -
+        name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         if: '! inputs.dry-run'
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Create GitHub release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+      -
+        name: Create GitHub release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         if: '! inputs.dry-run'
         with:
-          artifacts: "dist/*"
-          generateReleaseNotes: true
+          files: dist/*
+          generate_release_notes: true
           draft: true
-          commit: ${{ github.sha }}
+          target_commitish: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ inputs.tag }}
+          tag_name: ${{ inputs.tag }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: zizmor
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  zizmor:
+    uses: crazy-max/.github/.github/workflows/zizmor.yml@46267a6e61cd56aac2fc79943df180152f4c89d6 # v1.10.1
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      min-severity: medium
+      min-confidence: medium
+      persona: pedantic


### PR DESCRIPTION
similar to https://github.com/moby/buildkit/pull/6623

This adds zizmor coverage for GitHub Actions workflows and tightens the workflows so the reported findings are either fixed directly or documented where the current trust model is intentional.

Dependabot is also configured to keep GitHub Actions updates moving.

Also the release workflow now uses the better maintained `softprops/action-gh-release` to be consistent with other repos in the org.