### PR TITLE
Raise DockerException for invalid ports in parse_host()

### DIFF
--- a/docker/utils/utils.py
+++ b/docker/utils/utils.py
@@ -290,14 +290,23 @@ def parse_host(addr, is_win32=False, tls=False):
 
     netloc = parsed_url.netloc
     if proto in ('tcp', 'ssh'):
-        port = parsed_url.port or 0
-        if port <= 0:
+        try:
+            port = parsed_url.port
+        except ValueError as e:
+            raise errors.DockerException(
+                f'Invalid bind address format: {addr}'
+            ) from e
+        if port is None:
             if proto != 'ssh':
                 raise errors.DockerException(
                     f'Invalid bind address format: port is required: {addr}'
                 )
             port = 22
             netloc = f'{parsed_url.netloc}:{port}'
+        elif port <= 0:
+            raise errors.DockerException(
+                f'Invalid bind address format: port is required: {addr}'
+            )
 
         if not parsed_url.hostname:
             netloc = f'{DEFAULT_HTTP_HOST}:{port}'

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -285,6 +285,10 @@ class ParseHostTest(unittest.TestCase):
             'unix:///sock/path#fragment',
             'https://netloc:3333/path;params',
             'ssh://:clearpassword@host:22',
+            'tcp://host:0',
+            'ssh://host:0',
+            'tcp://host:99999',
+            'tcp://host:notaport',
         ]
 
         valid_hosts = {


### PR DESCRIPTION
## Problem

`parse_host()` mishandles invalid ports in the `tcp`/`ssh` branch.

**1. A raw `ValueError` escapes instead of `DockerException`.**
The port is read via `parsed_url.port`, and urllib's `.port` property *raises* `ValueError` for an out-of-range or non-numeric port. That error propagates unwrapped, even though the rest of `parse_host()` — and the `invalid_hosts` test contract in `tests/unit/utils_test.py` — guarantees invalid input raises `DockerException`. A user with a malformed `DOCKER_HOST` gets an opaque `ValueError` that `except DockerException` won't catch.

```python
>>> from docker.utils import parse_host
>>> parse_host('tcp://host:99999')
ValueError: Port out of range 0-65535
>>> parse_host('tcp://host:notaport')
ValueError: Port could not be cast to integer value as 'notaport'
```

**2. `ssh://host:0` silently produces a malformed result.**
`parsed_url.port or 0` collapses an explicit `:0` into the "no port given" case. For `ssh` the code then rebuilds `netloc = f'{parsed_url.netloc}:{port}'`, but `parsed_url.netloc` still ends in `:0`, so `:22` is appended to it:

```python
>>> parse_host('ssh://host:0')
'ssh://host:0:22'
```

`tcp://host:0` is already rejected with `DockerException`, so the two protocols were inconsistent.

## Fix

Wrap the `parsed_url.port` access, distinguish a missing port (`None`) from an explicitly invalid one, and reject port `0` for both protocols:

```python
try:
    port = parsed_url.port
except ValueError as e:
    raise errors.DockerException(f'Invalid bind address format: {addr}') from e
if port is None:
    if proto != 'ssh':
        raise errors.DockerException(f'Invalid bind address format: port is required: {addr}')
    port = 22
    netloc = f'{parsed_url.netloc}:{port}'
elif port <= 0:
    raise errors.DockerException(f'Invalid bind address format: port is required: {addr}')
```

After the change:

```
tcp://host:99999     -> DockerException: Invalid bind address format
tcp://host:notaport  -> DockerException: Invalid bind address format
ssh://host:0         -> DockerException: Invalid bind address format: port is required
```

Valid hosts are unaffected (`ssh://host` → `ssh://host:22`, `tcp://host:2375` → `http://host:2375`, empty host → `127.0.0.1`, IPv6, etc.).

## Tests

Added `tcp://host:0`, `ssh://host:0`, `tcp://host:99999` and `tcp://host:notaport` to the `invalid_hosts` list in `tests/unit/utils_test.py`. The full `utils_test.py` suite (73 tests) passes.
