### PR TITLE
tests: isolate FromContextTest from ambient TLS env vars

### DIFF
--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -269,9 +269,13 @@ class FromContextTest(unittest.TestCase):
 
     def setUp(self):
         self.os_environ = os.environ.copy()
-        # Make sure DOCKER_HOST does not short-circuit the context path
+        # Make sure DOCKER_HOST does not short-circuit the context path,
+        # and that ambient DOCKER_TLS_VERIFY/DOCKER_CERT_PATH from the host
+        # running the tests don't leak into kwargs_from_env.
         os.environ.pop('DOCKER_HOST', None)
         os.environ.pop('DOCKER_CONTEXT', None)
+        os.environ.pop('DOCKER_CERT_PATH', None)
+        os.environ.pop('DOCKER_TLS_VERIFY', None)
 
     def tearDown(self):
         os.environ.clear()


### PR DESCRIPTION
DOCKER_TLS_VERIFY/DOCKER_CERT_PATH leaking from the host running the tests (e.g. openQA) broke from_env()'s base_url scheme and caused TLSParameterError. Pop both in setUp alongside DOCKER_HOST, etc.

Otherwise tests fail on openQA:
https://openqa.opensuse.org/tests/6180415

```
# Test messages # test_from_env_docker_host_overrides_context
# failure: 

AssertionError: assert 'https://192.168.59.103:2375' == 'http://192.168.59.103:2375'
  
  - http://192.168.59.103:2375
  + https://192.168.59.103:2375
  ?     +
tests/unit/client_test.py:302: in test_from_env_docker_host_overrides_context
    assert client.api.base_url == 'http://192.168.59.103:2375'
E   AssertionError: assert 'https://192.168.59.103:2375' == 'http://192.168.59.103:2375'
E     
E     - http://192.168.59.103:2375
E     + https://192.168.59.103:2375
E     ?     +
```

```
# Test messages # test_from_env_use_context_false_skips_context
# failure: 

docker.errors.TLSParameterError: If using TLS, the base_url argument must be provided.. TLS configurations should map the Docker CLI client configurations. See https://docs.docker.com/engine/articles/https/ for API details.
tests/unit/client_test.py:308: in test_from_env_use_context_false_skips_context
    client = docker.from_env(
docker/client.py:110: in from_env
    return cls(
docker/client.py:48: in __init__
    self.api = APIClient(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
docker/api/client.py:123: in __init__
    raise TLSParameterError(
E   docker.errors.TLSParameterError: If using TLS, the base_url argument must be provided.. TLS configurations should map the Docker CLI client configurations. See https://docs.docker.com/engine/articles/https/ for API details.
```